### PR TITLE
Add VS code settings.json file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "python.linting.pylintEnabled": true,
     "python.linting.flake8Enabled": true,
     "python.linting.mypyEnabled": true,
     "python.linting.enabled": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,24 @@
 {
-    "python.testing.pytestArgs": [
-        "."
+    "python.linting.pylintEnabled": true,
+    "python.linting.flake8Enabled": true,
+    "python.linting.mypyEnabled": true,
+    "python.linting.enabled": true,
+    "python.formatting.provider": "black",
+    "editor.formatOnSave": true,
+    "workbench.tree.indent": 24,
+    "editor.rulers": [
+        88
     ],
+    "files.autoSave": "afterDelay",
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "python.testing.pytestArgs": [
+        "-s",
+        "tests"
+    ],
+    "workbench.editorAssociations": {
+        "*.ipynb": "jupyter-notebook"
+    },
+    "rewrap.autoWrap.enabled": true,
+    "editor.wordWrapColumn": 88
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,20 +5,16 @@
     "python.linting.enabled": true,
     "python.formatting.provider": "black",
     "editor.formatOnSave": true,
-    "workbench.tree.indent": 24,
     "editor.rulers": [
         88
     ],
-    "files.autoSave": "afterDelay",
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
+    // --no-cov needed so that breakpoints work: https://github.com/microsoft/vscode-python/issues/693
     "python.testing.pytestArgs": [
-        "-s",
-        "tests"
+        "--no-cov"
     ],
     "workbench.editorAssociations": {
         "*.ipynb": "jupyter-notebook"
     },
-    "rewrap.autoWrap.enabled": true,
-    "editor.wordWrapColumn": 88
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,8 +10,10 @@
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
-    // --no-cov needed so that breakpoints work: https://github.com/microsoft/vscode-python/issues/693
     "python.testing.pytestArgs": [
+        "-s",
+        "tests",
+        // --no-cov needed so that breakpoints work: https://github.com/microsoft/vscode-python/issues/693
         "--no-cov"
     ],
     "workbench.editorAssociations": {


### PR DESCRIPTION
So I started out by adding the settings.json file suggested by @dalonsoa, but I've made
a few changes:
* Removed ``workbench.tree.ident`` and ``files.autosave`` settings as I think those
  aren't specific to this repo (users might want different settings)
* Remove options relating to line rewrapping (``black`` does this already)
* Remove ``pytest`` settings: this should be done in a project-wide config file (e.g.
  setup.cfg)
* Add ``--no-cov`` to ``pytest`` args otherwise breakpoints won't work (see https://github.com/microsoft/vscode-python/issues/693)

Closes #27.