### PR TITLE
Fix coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+reports
 
 # Translations
 *.mo

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,8 +4,8 @@ test = pytest
 [tool:pytest]
 addopts =
 	-v --flake8 --mypy -p no:warnings
-	--cov=myproject  --cov-report=html:htmlcov/coverage
-	--doctest-modules --ignore=myproject/__main__.py
+	--cov=virtual_rainforest  --cov-report=html:htmlcov/coverage
+	--doctest-modules --ignore=virtual_rainforest/__main__.py
 testpaths = tests
 
 [pycodestyle]

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ test = pytest
 [tool:pytest]
 addopts =
 	-v --flake8 --mypy -p no:warnings
-	--cov=virtual_rainforest  --cov-report=html:htmlcov/coverage
+	--cov=virtual_rainforest  --cov-report=html:reports/coverage
 	--doctest-modules --ignore=virtual_rainforest/__main__.py
 testpaths = tests
 


### PR DESCRIPTION
# Description

When `pytest` is run, a coverage report should be generated in `reports/coverage` but the path indicating which folder should be observed to calculate the coverage was wrongly set.

To be reviewed and merged after #52 

Fixes # None

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

N/A

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
