### PR TITLE
Feature/extend ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.9" , "3.10" ]
+        python-version: [ "3.9" , "3.10.6" ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.9" , "3.10", "3.11-dev" ]
+        python-version: [ "3.9" , "3.10" ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
-        python-version: [ 3.9 ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: [ "3.9" , "3.10", "3.11-dev" ]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
# Description

This PR just extends the CI workflow to include Windows (since #69 removed the requirement for`fiona`) and adds Python 3.10 into the matrix. This is pinned at 3.10.6 because of a `mypy` issue - but a release of `mypy` to allow us to unpin to 3.10 is expected soon.

Fixes #75 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
