### PR TITLE
Fixed mutable default argument problem

### DIFF
--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -76,7 +76,7 @@ COMPLETE_CONFIG: dict = {}
 
 
 def check_dict_leaves(
-    d1: dict, d2: dict, conflicts: list = [], path: list = []
+    d1: dict, d2: dict, conflicts: list = None, path: list = None
 ) -> list:
     """Recursively checks if leaves are repeated between two nested dictionaries.
 
@@ -89,6 +89,12 @@ def check_dict_leaves(
     Returns:
         conflicts: List of variables that are defined in multiple places
     """
+
+    if conflicts is None:
+        conflicts = []
+
+    if path is None:
+        path = []
 
     for key in d2:
         if key in d1:


### PR DESCRIPTION
# Description

This fixes the problem pointed out by Alex where I had used a mutable default argument, which is apparently a common python gotcha. I fixed it using the approach laid out [here](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments). I've fixed this bug in the place Alex pointed out, and checked to see if I had made the same mistake elsewhere (I luckily hadn't).

Fixes #85

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
