### PR TITLE
Improved module docstrings

### DIFF
--- a/docs/source/api/core.md
+++ b/docs/source/api/core.md
@@ -45,3 +45,12 @@ This page contains the detailed documentation of the functions and classes in th
     :members:
     :special-members: __init__
 ```
+
+## The `virtual_rainforest.core.logger` module
+
+```{eval-rst}
+.. automodule:: virtual_rainforest.core.logger
+    :autosummary:
+    :members:
+    :special-members: __init__
+```

--- a/docs/source/api/soil.md
+++ b/docs/source/api/soil.md
@@ -1,0 +1,29 @@
+---
+jupytext:
+  cell_metadata_filter: -all
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.8
+kernelspec:
+  display_name: vr_python3
+  language: python
+  name: vr_python3
+---
+
+# API reference for `soil` modules
+
+This page contains the detailed documentation of the functions and classes in the
+`virtual_rainforest.soil` modules.
+
+## The `virtual_rainforest.soil.model` module
+
+```{eval-rst}
+.. automodule:: virtual_rainforest.soil.model
+    :autosummary:
+    :members:
+    :special-members: __init__
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,6 +40,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.mathjax",
     "sphinx.ext.autosummary",
+    "sphinx.ext.autosectionlabel",
     "sphinxcontrib.bibtex",
     "myst_nb",
     # "sphinx_astrorefs",  # Gives author year references
@@ -47,6 +48,10 @@ extensions = [
 ]
 autodoc_default_flags = ["members"]
 autosummary_generate = True
+
+# Set auto labelling to section level
+autosectionlabel_prefix_document = True
+autosectionlabel_maxdepth = 2
 
 myst_enable_extensions = ["dollarmath", "deflist"]
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -77,6 +77,7 @@ team.
   :hidden:
 
   api/core.md
+  api/soil.md
 ```
 
 ```{eval-rst}

--- a/docs/source/virtual_rainforest/core/config.md
+++ b/docs/source/virtual_rainforest/core/config.md
@@ -36,10 +36,10 @@ information cannot be repeated between files as there is no way to establish whi
 two values (of e.g. `core.grid.nx`) the user intended to provide. In this case, the
 module will throw critical error and the `virtual_rainforest` model will not configure.
 The user supplies a list of config files and/or folders to look for config files, within
-the supplied folders every `toml` file will be read in. An output folder and file name
-should also be provided, if a file already exists in the output folder that has the same
-name as the user provided output file name the configuration will critically fail. This
-happens in order to minimise the chance of significant confusion downstream.
+the supplied folders every `toml` file will be read in. Once the complete configuration
+is validated, it is saved as a single file using a user provided name and location. If a
+file already exists with this name at this location, the configuration process will
+critically fail. This minimises the chance of significant confusion downstream.
 
 ## Optional module loading
 

--- a/docs/source/virtual_rainforest/core/config.md
+++ b/docs/source/virtual_rainforest/core/config.md
@@ -1,4 +1,4 @@
-# The `core.config` module
+# The configuration module
 
 This module is used to configure a `virtual_rainforest` simulation run. This module
 reads in a set of configuration files written using `toml`. It is setup in such a way as

--- a/docs/source/virtual_rainforest/core/config.md
+++ b/docs/source/virtual_rainforest/core/config.md
@@ -35,11 +35,11 @@ input can be spread across an arbitrarily large number of config files. However,
 information cannot be repeated between files as there is no way to establish which of
 two values (of e.g. `core.grid.nx`) the user intended to provide. In this case, the
 module will throw critical error and the `virtual_rainforest` model will not configure.
-Config files are read from a folder that the user specifies, this can either be every
-`toml` file in the folder, or a user provided list of files. If a file exists in this
-folder that has the same name as the user provided output file name the configuration
-will critically fail, in order to minimise the chance of significant confusion
-downstream.
+The user supplies a list of config files and/or folders to look for config files, within
+the supplied folders every `toml` file will be read in. An output folder and file name
+should also be provided, if a file already exists in the output folder that has the same
+name as the user provided output file name the configuration will critically fail. This
+happens in order to minimise the chance of significant confusion downstream.
 
 ## Optional module loading
 

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -55,7 +55,10 @@ else:
     import tomli as tomllib
 
 SCHEMA_REGISTRY: dict = {}
-"""A registry for different module schema."""
+"""A registry for different module schema.
+
+:meta hide-value:
+"""
 
 
 class ConfigurationError(Exception):

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -2,10 +2,10 @@
 
 The `core.config` module is used to read in the various configuration files, validate
 their contents, and then configure a ready to run instance of the virtual rainforest
-model.
+model. The basic details of how this system functions can be found
+:ref:`here<virtual_rainforest/core/config:the configuration module>`.
 """
-# TODO - Think about how to expand the above docstring
-# Maybe just link the user to the already written config docs?
+# OKAY DECORATOR USAGE SHOULD BE DEMONSTRATED
 
 import sys
 from collections import ChainMap

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -2,10 +2,40 @@
 
 The `core.config` module is used to read in the various configuration files, validate
 their contents, and then configure a ready to run instance of the virtual rainforest
-model. The basic details of how this system functions can be found
+model. The basic details of how this system is used can be found
 :ref:`here<virtual_rainforest/core/config:the configuration module>`.
+
+When a new module is defined a `JSON` file should be written, which includes the
+expected configuration tags, their expected types, any value constraints, and where
+appropriate default values. This schema should be saved in the folder of the module that
+it relates to. In order to make this schema generally accessible to the `vr` package, it
+should then be added to the schema registry.  The
+:func:`~virtual_rainforest.core.config.register_schema` decorator is used for this
+purpose.
+
+Schema registration for each module takes place in the module's `__init__.py`. Here, a
+function is written that reads in the `JSON` file describing the schema. This function
+is then decorated using :func:`~virtual_rainforest.core.config.register_schema`, which
+results in the schema being added to the registry. The user provides a schema name to
+the decorator to register the schema under, this should be unique, and generally should
+just be the module name. An example of decorator usage is shown below:
+
+.. code-block:: python
+
+    @register_schema("example_module")
+    def schema() -> dict:
+        schema_file = Path(__file__).parent.resolve() / "example_module_schema.json"
+
+        with schema_file.open() as f:
+            config_schema = json.load(f)
+
+        return config_schema
+
+It's important to note that the schema will only be added to the registry if the module
+`__init__` is run. This means that somewhere in your path the module must be imported.
+Currently this is tackled by importing all active modules in the top level `__init__`,
+i.e. `virtual_rainforest.__init__.py`.
 """
-# OKAY DECORATOR USAGE SHOULD BE DEMONSTRATED
 
 import sys
 from collections import ChainMap
@@ -129,7 +159,7 @@ def check_dict_leaves(
         d1: First nested dictionary to compare
         d2: Second nested dictionary to compare
         path: List describing recursive path through the nested dictionary
-            conflicts: List of variables that are defined in multiple places
+        conflicts: List of variables that are defined in multiple places
 
     Returns:
         conflicts: List of variables that are defined in multiple places

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -1,21 +1,21 @@
 """API documentation for the :mod:`core.config` module.
 ************************************************** # noqa: D205
 
-The `core.config` module is used to read in the various configuration files, validate
-their contents, and then configure a ready to run instance of the virtual rainforest
-model. The basic details of how this system is used can be found
+The :mod:`core.config` module is used to read in the various configuration files,
+validate their contents, and then configure a ready to run instance of the virtual
+rainforest model. The basic details of how this system is used can be found
 :ref:`here<virtual_rainforest/core/config:the configuration module>`.
 
-When a new module is defined a `JSON` file should be written, which includes the
+When a new module is defined a ``JSON`` file should be written, which includes the
 expected configuration tags, their expected types, any value constraints, and where
 appropriate default values. This schema should be saved in the folder of the module that
-it relates to. In order to make this schema generally accessible to the `vr` package, it
-should then be added to the schema registry.  The
+it relates to. In order to make this schema generally accessible to the ``vr`` package,
+it should then be added to the schema registry.  The
 :func:`~virtual_rainforest.core.config.register_schema` decorator is used for this
 purpose.
 
-Schema registration for each module takes place in the module's `__init__.py`. Here, a
-function is written that reads in the `JSON` file describing the schema. This function
+Schema registration for each module takes place in the module's ``__init__.py``. Here, a
+function is written that reads in the ``JSON`` file describing the schema. This function
 is then decorated using :func:`~virtual_rainforest.core.config.register_schema`, which
 results in the schema being added to the registry. The user provides a schema name to
 the decorator to register the schema under, this should be unique, and generally should
@@ -33,9 +33,9 @@ just be the module name. An example of decorator usage is shown below:
         return config_schema
 
 It's important to note that the schema will only be added to the registry if the module
-`__init__` is run. This means that somewhere in your path the module must be imported.
-Currently this is tackled by importing all active modules in the top level `__init__`,
-i.e. `virtual_rainforest.__init__.py`.
+``__init__`` is run. This means that somewhere in your path the module must be imported.
+Currently this is tackled by importing all active modules in the top level ``__init__``,
+i.e. :mod:`virtual_rainforest.__init__.py`.
 """
 
 import sys

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -1,4 +1,5 @@
-"""The `core.config` module.
+"""API documentation for the :mod:`core.config` module.
+************************************************** # noqa: D205
 
 The `core.config` module is used to read in the various configuration files, validate
 their contents, and then configure a ready to run instance of the virtual rainforest

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -4,7 +4,8 @@ The `core.config` module is used to read in the various configuration files, val
 their contents, and then configure a ready to run instance of the virtual rainforest
 model.
 """
-# TODO - find config folder based on command line argument
+# TODO - Think about how to expand the above docstring
+# Maybe just link the user to the already written config docs?
 
 import sys
 from collections import ChainMap

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -7,10 +7,12 @@ rainforest model. The basic details of how this system is used can be found
 :ref:`here<virtual_rainforest/core/config:the configuration module>`.
 
 When a new module is defined a ``JSON`` file should be written, which includes the
-expected configuration tags, their expected types, any value constraints, and where
-appropriate default values. This schema should be saved in the folder of the module that
-it relates to. In order to make this schema generally accessible to the ``vr`` package,
-it should then be added to the schema registry.  The
+expected configuration tags, their expected types, and any constraints on their values
+(e.g. the number of soil layers being strictly positive). Additionally, where sensible
+default values exist (e.g. 1 week for the model time step) they should also be included
+in the schema. This schema should be saved in the folder of the module that it relates
+to. In order to make this schema generally accessible to the ``vr`` package, it should
+then be added to the schema registry. The
 :func:`~virtual_rainforest.core.config.register_schema` decorator is used for this
 purpose.
 
@@ -33,9 +35,12 @@ just be the module name. An example of decorator usage is shown below:
         return config_schema
 
 It's important to note that the schema will only be added to the registry if the module
-``__init__`` is run. This means that somewhere in your path the module must be imported.
-Currently this is tackled by importing all active modules in the top level ``__init__``,
-i.e. :mod:`virtual_rainforest.__init__.py`.
+``__init__`` is run. This means that somewhere in your chain of imports the module must
+be imported. Currently this is tackled by importing all active modules in the top level
+``__init__``, i.e. :mod:`virtual_rainforest.__init__.py`. This ensures that any script
+that imports :mod:`virtual_rainforest` will have implicitly imported all modules which
+define schema, in turn ensuring that
+:attr:`~virtual_rainforest.core.config.SCHEMA_REGISTRY` contains all necessary schema.
 """
 
 import sys

--- a/virtual_rainforest/core/grid.py
+++ b/virtual_rainforest/core/grid.py
@@ -1,8 +1,8 @@
 """API documentation for the :mod:`core.grid` module.
 ************************************************** # noqa: D205
 
-The `core.grid` module is used to create the grid of cells underlying the simulation and
-to identify the neighbourhood connections of cells.
+The :mod:`core.grid` module is used to create the grid of cells underlying the
+simulation and to identify the neighbourhood connections of cells.
 
 - set up neighbourhoods. ? store as graph (networkx - might only need a really
   lightweight graph description).

--- a/virtual_rainforest/core/grid.py
+++ b/virtual_rainforest/core/grid.py
@@ -1,4 +1,5 @@
-"""The `core.grid` module.
+"""API documentation for the :mod:`core.grid` module.
+************************************************** # noqa: D205
 
 The `core.grid` module is used to create the grid of cells underlying the simulation and
 to identify the neighbourhood connections of cells.

--- a/virtual_rainforest/core/logger.py
+++ b/virtual_rainforest/core/logger.py
@@ -1,4 +1,5 @@
-"""The `core.logging` module.
+"""API documentation for the :mod:`core.logger` module.
+************************************************** # noqa: D205
 
 The `core.logging` module is used to setup the extend the standard logging setup to
 provide additional functionality relevant to the virtual rainforest model.

--- a/virtual_rainforest/core/logger.py
+++ b/virtual_rainforest/core/logger.py
@@ -5,8 +5,53 @@ provide additional functionality relevant to the virtual rainforest model.
 
 At the moment the module simply sets up the logger so that other modules can access it.
 It is very likely to be further extended in future.
+
+All logging messages are emitted with a specified logging level, which essentially
+indicates the importance of the logging message. At the moment we use the 5 standard
+logging levels, though we might extend this by using custom logging levels at some
+point. The five logging levels we use are as follows:
+
+.. csv-table::
+    :header: Logging level, Use case
+
+    CRITICAL, "Something has gone so wrong that the model run has to stop immediately."
+    ERROR, "| Something has definitely gone wrong, but there is still a value in
+      continuing the execution
+    | of the model. This is mainly to check if other errors crop up, so that all
+    | relevant errors can be reported at once."
+    WARNING, "| Something seems a bit off, so the user should be warned, but the model
+      might actually be
+    | fine."
+
+
+=============  =========================================================================
+Logging level  Use case
+=============  =========================================================================
+CRITICAL       Something has gone so wrong that the model run has to stop immediately.
+ERROR          | Something has definitely gone wrong, but there is still a value in
+                 continuing the execution
+               | of the model. This is mainly to check if other errors crop
+                 up, so that all
+               | relevant errors can be reported at once.
+WARNING        | Something seems a bit off, so the user should be warned, but the model
+                 might actually be
+               | fine.
+INFO           | Something expected has happened, and it's useful to give the user
+                 information about it,
+               | e.g. configuration has been validated, or an output
+                 file is being saved to a specific
+               | location.
+DEBUG          | Something has happened that is generally of minimal interest, but might
+                 be relevant when
+               | attempting to debug issues.
+=============  =========================================================================
 """
-# TODO - EXPLAIN LOGGING LEVELS, HOW THEY SHOULD BE USED, HOW LOG AND RAISE IS USED
+# MAJOR PROBLEM WITH THE ABOVE IS THAT LINE BLOCKS CREATE AUTOMATIC NEWLINES, WHICH
+# CAUSES WEIRD TABLE FORMATTING. NEED TO FIGURE OUT HOW TO STOP THIS
+# https://stackoverflow.com/questions/54001054/force-a-new-line-in-sphinx-text
+# TODO - HOW THEY SHOULD BE USED, HOW LOG AND RAISE IS USED
+# So probably should mention that our main use case is probably turning off debug logs,
+# other use cases are a bit more advanced
 
 import logging
 from typing import Optional, Type

--- a/virtual_rainforest/core/logger.py
+++ b/virtual_rainforest/core/logger.py
@@ -1,7 +1,7 @@
 """API documentation for the :mod:`core.logger` module.
 ************************************************** # noqa: D205
 
-The `core.logging` module is used to setup the extend the standard logging setup to
+The :mod:`core.logging` module is used to setup the extend the standard logging setup to
 provide additional functionality relevant to the virtual rainforest model.
 
 At the moment the module simply sets up the logger so that other modules can access it.
@@ -15,37 +15,38 @@ point. The five logging levels we use are as follows:
 =============  =========================================================================
 Logging level  Use case
 =============  =========================================================================
-CRITICAL       Something has gone so wrong that the model run has to stop immediately.
-ERROR          | Something has definitely gone wrong, but there is still a value in
+``CRITICAL``   Something has gone so wrong that the model run has to stop immediately.
+``ERROR``      | Something has definitely gone wrong, but there is still a value in
                  continuing the execution
                | of the model. This is mainly to check if other errors crop
                  up, so that all relevant errors
                | can be reported at once.
-WARNING        | Something seems a bit off, so the user should be warned, but the model
+``WARNING``    | Something seems a bit off, so the user should be warned, but the model
                  might actually be
                | fine.
-INFO           | Something expected has happened, and it's useful to give the user
+``INFO``       | Something expected has happened, and it's useful to give the user
                  information about it,
                | e.g. configuration has been validated, or an output
                  file is being saved to a specific
                | location.
-DEBUG          | Something has happened that is generally of minimal interest, but might
+``DEBUG``      | Something has happened that is generally of minimal interest, but might
                  be relevant when
                | attempting to debug issues.
 =============  =========================================================================
 
 These logging levels can then be used to filter the messages the user receives, by
 setting the logging level such that only messages above a certain level (of importance)
-are displayed. In practice, we are likely to generally set the logging level to INFO so
-that DEBUG messages are suppressed, except when we are actively trying to debug the
-model.
+are displayed. In practice, we are likely to generally set the logging level to ``INFO``
+so that ``DEBUG`` messages are suppressed, except when we are actively trying to debug
+the model.
 
 The logging module also defines a function that we should generally make use of to kill
-the simulation when something goes wrong. This function `log_and_raise()` raises an
-exception (of the developers choice) and adds a developer specified CRITICAL message to
-the log. This function is useful as it ensures that CRITICAL logging events are
-accompanied by a simulation ending exception. As such, this is probably the only means
-by which you should log a CRITICAL message.
+the simulation when something goes wrong. This function
+:func:`~virtual_rainforest.core.logger.log_and_raise` raises an exception (of the
+developers choice) and adds a developer specified ``CRITICAL`` message to the log. This
+function is useful as it ensures that ``CRITICAL`` logging events are accompanied by a
+simulation ending exception. As such, this is probably the only means by which you
+should log a ``CRITICAL`` message.
 """
 
 import logging

--- a/virtual_rainforest/core/logger.py
+++ b/virtual_rainforest/core/logger.py
@@ -11,19 +11,6 @@ indicates the importance of the logging message. At the moment we use the 5 stan
 logging levels, though we might extend this by using custom logging levels at some
 point. The five logging levels we use are as follows:
 
-.. csv-table::
-    :header: Logging level, Use case
-
-    CRITICAL, "Something has gone so wrong that the model run has to stop immediately."
-    ERROR, "| Something has definitely gone wrong, but there is still a value in
-      continuing the execution
-    | of the model. This is mainly to check if other errors crop up, so that all
-    | relevant errors can be reported at once."
-    WARNING, "| Something seems a bit off, so the user should be warned, but the model
-      might actually be
-    | fine."
-
-
 =============  =========================================================================
 Logging level  Use case
 =============  =========================================================================
@@ -31,8 +18,8 @@ CRITICAL       Something has gone so wrong that the model run has to stop immedi
 ERROR          | Something has definitely gone wrong, but there is still a value in
                  continuing the execution
                | of the model. This is mainly to check if other errors crop
-                 up, so that all
-               | relevant errors can be reported at once.
+                 up, so that all relevant errors
+               | can be reported at once.
 WARNING        | Something seems a bit off, so the user should be warned, but the model
                  might actually be
                | fine.

--- a/virtual_rainforest/core/logger.py
+++ b/virtual_rainforest/core/logger.py
@@ -32,13 +32,20 @@ DEBUG          | Something has happened that is generally of minimal interest, b
                  be relevant when
                | attempting to debug issues.
 =============  =========================================================================
+
+These logging levels can then be used to filter the messages the user receives, by
+setting the logging level such that only messages above a certain level (of importance)
+are displayed. In practice, we are likely to generally set the logging level to INFO so
+that DEBUG messages are suppressed, except when we are actively trying to debug the
+model.
+
+The logging module also defines a function that we should generally make use of to kill
+the simulation when something goes wrong. This function `log_and_raise()` raises an
+exception (of the developers choice) and adds a developer specified CRITICAL message to
+the log. This function is useful as it ensures that CRITICAL logging events are
+accompanied by a simulation ending exception. As such, this is probably the only means
+by which you should log a CRITICAL message.
 """
-# MAJOR PROBLEM WITH THE ABOVE IS THAT LINE BLOCKS CREATE AUTOMATIC NEWLINES, WHICH
-# CAUSES WEIRD TABLE FORMATTING. NEED TO FIGURE OUT HOW TO STOP THIS
-# https://stackoverflow.com/questions/54001054/force-a-new-line-in-sphinx-text
-# TODO - HOW THEY SHOULD BE USED, HOW LOG AND RAISE IS USED
-# So probably should mention that our main use case is probably turning off debug logs,
-# other use cases are a bit more advanced
 
 import logging
 from typing import Optional, Type

--- a/virtual_rainforest/core/logger.py
+++ b/virtual_rainforest/core/logger.py
@@ -6,6 +6,7 @@ provide additional functionality relevant to the virtual rainforest model.
 At the moment the module simply sets up the logger so that other modules can access it.
 It is very likely to be further extended in future.
 """
+# TODO - EXPLAIN LOGGING LEVELS, HOW THEY SHOULD BE USED, HOW LOG AND RAISE IS USED
 
 import logging
 from typing import Optional, Type

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -8,6 +8,8 @@ functions defined in the base class, which are defined mainly to force a consist
 between models. It also establishes a model registry that allows models to become
 accessible across scripts without individual loading in.
 """
+# TODO - EXPLAIN USAGE OF THIS, AND IDEA BEHIND IT
+# PROBABLY LINK TO SOIL MODULE EXAMPLE AS THIS IS AN EASIER EXAMPLE TO FOLLOW
 
 from __future__ import annotations
 

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -1,15 +1,42 @@
 """The `core.model` module.
 
-The `core.model` module defines the api that all individual models (e.g. the soil
-model) should conform to. This consists of a class (`Model`), which defines the expected
-functions. The relevant modules will create classes to represent specific models, which
-will inherit from the `Model` base class. These subclasses will generally overwrite the
-functions defined in the base class, which are defined mainly to force a consistent api
-between models. It also establishes a model registry that allows models to become
-accessible across scripts without individual loading in.
+The `core.model` module defines the api that all individual models (e.g. the soil model)
+should conform to. This consists of a class (`BaseModel`), which defines the expected
+functions. This class is an abstract base class, which is a class that is never intended
+to be instantiated itself but instead serves as a blueprint for inheriting classes. Some
+of its functions will be inherited and used by its child classes (e.g. `__repr__` and
+`__str__`), unless they are explicitly overwritten in the child class. However, it also
+possesses abstract methods (denoted by `@abstractmethod`), which are merely
+placeholders. For these abstract methods child classes have to overwrite the methods
+with new functions, otherwise class inheritance fails. This ensures that a consistent
+api (set of functions) is used across models, while also ensuring that functions don't
+default to an inappropriate generic behaviour due to a function not being defined for a
+particular model. Abstract classes should thus be used for functions that are always
+required, and are near certain to follow a different process for each model. At the
+moment we expect every model should have a setup, spinup, solve and cleanup process,
+though this might well change in the future.
+
+We also define an abstract class method to perform model initialisation. This method
+(`from_config`) is a factory method which unpacks the configuration dictionary, extracts
+the relevant tags and attempts to convert them into the form needed to initialise a
+class instance. As this method is a class method it must be defined for every child
+class of `BaseModel`. This is because unpacking of our complex configuration dictionary
+is a necessary before a class instance can be initialised, so this function is vital.
+
+As in the case of configuration schema, we make `Model` classes generally accessible by
+adding them to a registry. However, in this case the function to add to the registry
+isn't a decorator but rather a member function of `BaseModel`. The existence of this
+`__init_subclass__` function means that every child class is automatically added to the
+model registry (called `MODEL_REGISTRY`), but that in every case a `model_name` has to
+be provided to register it under. This model name should be unique. Although
+registration is automatic, it only happens when class definition happens, which requires
+the module which defines the child class to be imported somewhere. At the moment, we
+import all child models in the top level `__init__.py` to ensure that they are added to
+the registry.
+
+An example of `Model` inheritance from `BaseModel` can been seen in the `soil.model`
+module.
 """
-# TODO - EXPLAIN USAGE OF THIS, AND IDEA BEHIND IT
-# PROBABLY LINK TO SOIL MODULE EXAMPLE AS THIS IS AN EASIER EXAMPLE TO FOLLOW
 
 from __future__ import annotations
 

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -9,29 +9,30 @@ to be instantiated itself but instead serves as a blueprint for inheriting class
 of its functions will be inherited and used by its child classes (e.g.
 :func:`~virtual_rainforest.core.model.BaseModel.__repr__` and
 :func:`~virtual_rainforest.core.model.BaseModel.__str__`), unless they are explicitly
-overwritten in the child class. However, it also possesses abstract methods (denoted by
-``@abstractmethod``), which are merely placeholders. For these abstract methods child
-classes have to overwrite the methods with new functions, otherwise class inheritance
-fails. This ensures that a consistent api (set of functions) is used across models,
-while also ensuring that functions don't default to an inappropriate generic behaviour
-due to a function not being defined for a particular model. Abstract classes should thus
-be used for functions that are always required, and are near certain to follow a
-different process for each model. At the moment we expect every model should have a
-setup, spinup, solve and cleanup process, though this might well change in the future.
+overwritten in the child class (which is generally necessary for ``__init__``). However,
+it also possesses abstract methods (denoted by ``@abstractmethod``), which are merely
+placeholders. For these abstract methods, child classes have to overwrite the methods
+with new functions, otherwise class inheritance fails. This ensures that a consistent
+api (set of functions) is used across models, while also ensuring that functions don't
+default to an inappropriate generic behaviour due to a function not being defined for a
+particular model. Therefore, abstract methods should be used for functions that are
+always required, and are near certain to follow a different process for each model. At
+the moment, we expect every model to have a setup, spinup, solve and cleanup process,
+though this might change in the future.
 
 We also define an abstract class method to perform model initialisation. This method
 (:func:`~virtual_rainforest.core.model.BaseModel.from_config`) is a factory method which
 unpacks the configuration dictionary, extracts the relevant tags and attempts to convert
-them into the form needed to initialise a class instance. As this method is a class
-method it must be defined for every child class of
-:class:`~virtual_rainforest.core.model.BaseModel`. This is because unpacking of our
-complex configuration dictionary is a necessary before a class instance can be
-initialised, so this function is vital.
+them into the form needed to initialise a class instance. This method must be defined
+for every child class of :class:`~virtual_rainforest.core.model.BaseModel`, as unpacking
+our complex configuration dictionary is a necessary before a class instance can be
+initialised.
 
-As in the case of configuration schema, we make `Model` classes generally accessible by
-adding them to a registry. However, in this case the function to add to the registry
-isn't a decorator but rather a member function of `BaseModel`. The existence of this
-:func`~virtual_rainforest.core.model.BaseModel.__init_subclass__` function means that
+As in the case of configuration schema, we make ``Model`` classes generally accessible
+by adding them to a registry. However, in this case the function to add to the registry
+isn't a decorator but rather a member function of
+:class:`~virtual_rainforest.core.model.BaseModel`. The existence of this
+:func:`~virtual_rainforest.core.model.BaseModel.__init_subclass__` function means that
 every child class is automatically added to the model registry (called
 :attr:`~virtual_rainforest.core.model.MODEL_REGISTRY`), but that in every case a
 ``model_name`` has to be provided to register it under. This model name should be

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -1,24 +1,38 @@
 """API documentation for the :mod:`core.model` module.
 ************************************************** # noqa: D205
 
+The Virtual Rainforest model requires a consistent api across models. That is a common
+set of functions which work the same across all modules. This cannot exist at a low
+level, as the basic classes and functions will differ massively between modules (e.g.
+:mod:`~virtual_rainforest.abiotic` will not have functions to handle consumption). So,
+this common api has to be high level and define a basic set of functions to set up and
+run each model. These functions effectively convert a general instruction (i.e. "setup
+the model") into the steps needed to carry out that instruction for a specific model.
+
 The :mod:`core.model` module defines the api that all individual models (e.g. the soil
 model) should conform to. This consists of a class
 (:class:`~virtual_rainforest.core.model.BaseModel`), which defines the expected
-functions. This class is an abstract base class, which is a class that is never intended
-to be instantiated itself but instead serves as a blueprint for inheriting classes. Some
-of its functions will be inherited and used by its child classes (e.g.
-:func:`~virtual_rainforest.core.model.BaseModel.__repr__` and
+functions. Some functions of this class will be inherited and used by its child classes
+(e.g. :func:`~virtual_rainforest.core.model.BaseModel.__repr__` and
 :func:`~virtual_rainforest.core.model.BaseModel.__str__`), unless they are explicitly
-overwritten in the child class (which is generally necessary for ``__init__``). However,
-it also possesses abstract methods (denoted by ``@abstractmethod``), which are merely
-placeholders. For these abstract methods, child classes have to overwrite the methods
-with new functions, otherwise class inheritance fails. This ensures that a consistent
-api (set of functions) is used across models, while also ensuring that functions don't
-default to an inappropriate generic behaviour due to a function not being defined for a
-particular model. Therefore, abstract methods should be used for functions that are
-always required, and are near certain to follow a different process for each model. At
-the moment, we expect every model to have a setup, spinup, solve and cleanup process,
-though this might change in the future.
+overwritten in the child class (which is generally necessary for ``__init__``). This is
+standard python class inheritance, which will be used in many places throughout the
+``virtual_rainforest`` model.
+
+However, a more complex form of inheritance is required for functions that define the
+shared api. These should take the same input and perform an equivalent set of steps
+across models, but because they interact with radically different modules their internal
+workings will have little in common. Thus,
+:class:`~virtual_rainforest.core.model.BaseModel` is defined as an abstract base class,
+which is a class that is never intended to be instantiated itself but instead serves as
+a blueprint for inheriting classes. This type of class can define abstract methods
+(denoted by ``@abstractmethod``), which are merely placeholders. For these abstract
+methods, child classes have to overwrite the methods with new functions, otherwise class
+inheritance fails. This ensures that a consistent api (set of functions) is used across
+models, while also ensuring that functions don't default to an inappropriate generic
+behaviour due to a function not being defined for a particular model. At the moment, we
+expect every model to have a setup, spinup, solve and cleanup process, though this might
+change in the future.
 
 We also define an abstract class method to perform model initialisation. This method
 (:func:`~virtual_rainforest.core.model.BaseModel.from_config`) is a factory method which

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -1,4 +1,5 @@
-"""The `core.model` module.
+"""API documentation for the :mod:`core.model` module.
+************************************************** # noqa: D205
 
 The `core.model` module defines the api that all individual models (e.g. the soil model)
 should conform to. This consists of a class (`BaseModel`), which defines the expected

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -1,41 +1,47 @@
 """API documentation for the :mod:`core.model` module.
 ************************************************** # noqa: D205
 
-The `core.model` module defines the api that all individual models (e.g. the soil model)
-should conform to. This consists of a class (`BaseModel`), which defines the expected
+The :mod:`core.model` module defines the api that all individual models (e.g. the soil
+model) should conform to. This consists of a class
+(:class:`~virtual_rainforest.core.model.BaseModel`), which defines the expected
 functions. This class is an abstract base class, which is a class that is never intended
 to be instantiated itself but instead serves as a blueprint for inheriting classes. Some
-of its functions will be inherited and used by its child classes (e.g. `__repr__` and
-`__str__`), unless they are explicitly overwritten in the child class. However, it also
-possesses abstract methods (denoted by `@abstractmethod`), which are merely
-placeholders. For these abstract methods child classes have to overwrite the methods
-with new functions, otherwise class inheritance fails. This ensures that a consistent
-api (set of functions) is used across models, while also ensuring that functions don't
-default to an inappropriate generic behaviour due to a function not being defined for a
-particular model. Abstract classes should thus be used for functions that are always
-required, and are near certain to follow a different process for each model. At the
-moment we expect every model should have a setup, spinup, solve and cleanup process,
-though this might well change in the future.
+of its functions will be inherited and used by its child classes (e.g.
+:func:`~virtual_rainforest.core.model.BaseModel.__repr__` and
+:func:`~virtual_rainforest.core.model.BaseModel.__str__`), unless they are explicitly
+overwritten in the child class. However, it also possesses abstract methods (denoted by
+``@abstractmethod``), which are merely placeholders. For these abstract methods child
+classes have to overwrite the methods with new functions, otherwise class inheritance
+fails. This ensures that a consistent api (set of functions) is used across models,
+while also ensuring that functions don't default to an inappropriate generic behaviour
+due to a function not being defined for a particular model. Abstract classes should thus
+be used for functions that are always required, and are near certain to follow a
+different process for each model. At the moment we expect every model should have a
+setup, spinup, solve and cleanup process, though this might well change in the future.
 
 We also define an abstract class method to perform model initialisation. This method
-(`from_config`) is a factory method which unpacks the configuration dictionary, extracts
-the relevant tags and attempts to convert them into the form needed to initialise a
-class instance. As this method is a class method it must be defined for every child
-class of `BaseModel`. This is because unpacking of our complex configuration dictionary
-is a necessary before a class instance can be initialised, so this function is vital.
+(:func:`~virtual_rainforest.core.model.BaseModel.from_config`) is a factory method which
+unpacks the configuration dictionary, extracts the relevant tags and attempts to convert
+them into the form needed to initialise a class instance. As this method is a class
+method it must be defined for every child class of
+:class:`~virtual_rainforest.core.model.BaseModel`. This is because unpacking of our
+complex configuration dictionary is a necessary before a class instance can be
+initialised, so this function is vital.
 
 As in the case of configuration schema, we make `Model` classes generally accessible by
 adding them to a registry. However, in this case the function to add to the registry
 isn't a decorator but rather a member function of `BaseModel`. The existence of this
-`__init_subclass__` function means that every child class is automatically added to the
-model registry (called `MODEL_REGISTRY`), but that in every case a `model_name` has to
-be provided to register it under. This model name should be unique. Although
-registration is automatic, it only happens when class definition happens, which requires
-the module which defines the child class to be imported somewhere. At the moment, we
-import all child models in the top level `__init__.py` to ensure that they are added to
-the registry.
+:func`~virtual_rainforest.core.model.BaseModel.__init_subclass__` function means that
+every child class is automatically added to the model registry (called
+:attr:`~virtual_rainforest.core.model.MODEL_REGISTRY`), but that in every case a
+``model_name`` has to be provided to register it under. This model name should be
+unique. Although registration is automatic, it only happens when class definition
+happens, which requires the module which defines the child class to be imported
+somewhere. At the moment, we import all child models in the top level ``__init__.py`` to
+ensure that they are added to the registry.
 
-An example of `Model` inheritance from `BaseModel` can been seen in the `soil.model`
+An example of ``Model`` inheritance from
+:class:`~virtual_rainforest.core.model.BaseModel` can been seen in the :mod:`soil.model`
 module.
 """
 

--- a/virtual_rainforest/soil/model.py
+++ b/virtual_rainforest/soil/model.py
@@ -1,10 +1,16 @@
 """The `soil.model` module.
 
-The `soil.model` module creates a `SoilModel` class, which extended the base `Model`
-class to be usable to simulate the soil.
+The `soil.model` module creates a `SoilModel` class as a child of the `BaseModel` class.
+At present a lot of the abstract methods of the parent class (e.g. `setup` and `spinup`)
+are overwritten using placeholder functions that don't do anything. This will change as
+the `virtual_rainforest` model develops. The factory method `from_config` exists in a
+more complete state, and unpacks a small number of parameters from our currently pretty
+minimal configuration dictionary. These parameters are then used to generate a class
+instance. If errors crop here when converting the information from the config dictionary
+to the required types (e.g. `timedelat64`)  they are caught and then logged, and at the
+end of the unpacking an error is thrown. This error should be caught and handled by
+downstream functions so that all model configuration failures can be reported as one.
 """
-# TODO - Extend this docstring to explain the module properly
-# Should give this a fair deal of detail, as others will have to copy this over
 
 from __future__ import annotations
 

--- a/virtual_rainforest/soil/model.py
+++ b/virtual_rainforest/soil/model.py
@@ -1,4 +1,5 @@
-"""The `soil.model` module.
+"""API documentation for the :mod:`soil.model` module.
+************************************************** # noqa: D205
 
 The `soil.model` module creates a `SoilModel` class as a child of the `BaseModel` class.
 At present a lot of the abstract methods of the parent class (e.g. `setup` and `spinup`)

--- a/virtual_rainforest/soil/model.py
+++ b/virtual_rainforest/soil/model.py
@@ -3,6 +3,8 @@
 The `soil.model` module creates a `SoilModel` class, which extended the base `Model`
 class to be usable to simulate the soil.
 """
+# TODO - Extend this docstring to explain the module properly
+# Should give this a fair deal of detail, as others will have to copy this over
 
 from __future__ import annotations
 

--- a/virtual_rainforest/soil/model.py
+++ b/virtual_rainforest/soil/model.py
@@ -1,16 +1,20 @@
 """API documentation for the :mod:`soil.model` module.
 ************************************************** # noqa: D205
 
-The `soil.model` module creates a `SoilModel` class as a child of the `BaseModel` class.
-At present a lot of the abstract methods of the parent class (e.g. `setup` and `spinup`)
-are overwritten using placeholder functions that don't do anything. This will change as
-the `virtual_rainforest` model develops. The factory method `from_config` exists in a
-more complete state, and unpacks a small number of parameters from our currently pretty
-minimal configuration dictionary. These parameters are then used to generate a class
-instance. If errors crop here when converting the information from the config dictionary
-to the required types (e.g. `timedelat64`)  they are caught and then logged, and at the
-end of the unpacking an error is thrown. This error should be caught and handled by
-downstream functions so that all model configuration failures can be reported as one.
+The :mod:`soil.model` module creates a :class:`~virtual_rainforest.soil.model.SoilModel`
+class as a child of the :class:`~virtual_rainforest.core.model.BaseModel` class. At
+present a lot of the abstract methods of the parent class (e.g.
+:func:`~virtual_rainforest.core.model.BaseModel.setup` and
+:func:`~virtual_rainforest.core.model.BaseModel.spinup`) are overwritten using
+placeholder functions that don't do anything. This will change as the
+:mod:`virtual_rainforest` model develops. The factory method
+:func:`~virtual_rainforest.soil.model.SoilModel.from_config` exists in a more complete
+state, and unpacks a small number of parameters from our currently pretty minimal
+configuration dictionary. These parameters are then used to generate a class instance.
+If errors crop here when converting the information from the config dictionary to the
+required types (e.g. :class:`~numpy.timedelta64`) they are caught and then logged, and
+at the end of the unpacking an error is thrown. This error should be caught and handled
+by downstream functions so that all model configuration failures can be reported as one.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
# Description

I've extended the module docstrings for the `core.logger`, `core.config`, `core.model` and  `soil.model` modules. The aim is that they give enough information that people weren't involved in building these systems (i.e. Vivienne and Taran) can understand how they are supposed to be used. So let me know if anything is unclear, or if you feel like anything needs further expansion.

I'm also far from an expert in using reStructuredText, so David let me know if any of my usage seems suspect.

In terms of viewing the docstrings it is probably best to make the docs and then view them in browser. This can be done by running `cd docs` followed by `make html`. If this doesn't work you might have to make sure that `Jupyter` is properly set up (see [here](https://github.com/ImperialCollegeLondon/virtual_rainforest/blob/develop/docs/source/development/jupyter_notebooks.md#jupyter-lab)).

Fixes #105
Also addresses #107, but doesn't completely resolve it.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation improvement 

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
