### PR TITLE
Main timing loop

### DIFF
--- a/tests/fixtures/all_config.toml
+++ b/tests/fixtures/all_config.toml
@@ -7,7 +7,7 @@ ny = 10
 
 [core.timing]
 start_date = "2020-01-01"
-end_date = "2120-01-01"
+run_length = "50 years"
 main_time_step = "0.5 days"
 
 [plants]

--- a/tests/fixtures/all_config.toml
+++ b/tests/fixtures/all_config.toml
@@ -8,7 +8,7 @@ ny = 10
 [core.timing]
 start_date = "2020-01-01"
 end_date = "2120-01-01"
-min_time_step = "0.5 days"
+main_time_step = "0.5 days"
 
 [plants]
 a_plant_integer = 12

--- a/tests/fixtures/all_config.toml
+++ b/tests/fixtures/all_config.toml
@@ -8,7 +8,6 @@ ny = 10
 [core.timing]
 start_date = "2020-01-01"
 run_length = "50 years"
-main_time_step = "0.5 days"
 
 [plants]
 a_plant_integer = 12

--- a/tests/fixtures/all_config.toml
+++ b/tests/fixtures/all_config.toml
@@ -23,3 +23,4 @@ maxh = 50.0
 
 [soil]
 no_layers = 1
+model_time_step = "5 days"

--- a/tests/fixtures/all_config.toml
+++ b/tests/fixtures/all_config.toml
@@ -7,6 +7,7 @@ ny = 10
 
 [core.timing]
 start_date = "2020-01-01"
+update_interval = "10 minutes"
 run_length = "50 years"
 
 [plants]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -244,14 +244,12 @@ def test_vr_run_bad_model(mocker, caplog):
                     "timing": {
                         "start_date": "2020-01-01",
                         "run_length": "30 years",
-                        "main_time_step": "1 month",
                     }
                 }
             },
             {
                 "start_time": datetime64("2020-01-01"),
                 "end_time": datetime64("2049-12-31T12:00"),
-                "update_interval": timedelta64(43830, "m"),
             },
             does_not_raise(),
             (
@@ -268,8 +266,7 @@ def test_vr_run_bad_model(mocker, caplog):
                 "core": {
                     "timing": {
                         "start_date": "2020-01-01",
-                        "run_length": "1 year",
-                        "main_time_step": "2 years",
+                        "run_length": "1 minute",
                     }
                 }
             },
@@ -278,8 +275,8 @@ def test_vr_run_bad_model(mocker, caplog):
             (
                 (
                     CRITICAL,
-                    "Models will never update as the update interval (1051920 minutes) "
-                    "is larger than the run length (525960 minutes)",
+                    "Models will never update as the update interval (10 minutes) is "
+                    "larger than the run length (1 minutes)",
                 ),
             ),
         ),
@@ -288,8 +285,7 @@ def test_vr_run_bad_model(mocker, caplog):
                 "core": {
                     "timing": {
                         "start_date": "2020-01-01",
-                        "run_length": "30 years",
-                        "main_time_step": "7 short days",
+                        "run_length": "7 short days",
                     }
                 }
             },
@@ -298,8 +294,8 @@ def test_vr_run_bad_model(mocker, caplog):
             (
                 (
                     CRITICAL,
-                    "Units for core.timing.main_time_step are not valid time units: 7 "
-                    "short days",
+                    "Units for core.timing.run_length are not valid time units: 7 short"
+                    " days",
                 ),
             ),
         ),
@@ -309,12 +305,8 @@ def test_extract_timing_details(caplog, config, output, raises, expected_log_ent
     """Test that function to extract main loop timing works as intended."""
 
     with raises:
-        start_time, end_time, update_interval, current_time = extract_timing_details(
-            config
-        )
-        assert start_time == output["start_time"]
+        current_time, end_time = extract_timing_details(config, timedelta64(10, "m"))
         assert end_time == output["end_time"]
-        assert update_interval == output["update_interval"]
         assert current_time == output["start_time"]
 
     log_check(caplog, expected_log_entries)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -76,7 +76,7 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
         (
             {  # valid config
                 "soil": {"no_layers": 1},
-                "core": {"timing": {"min_time_step": "7 days"}},
+                "core": {"timing": {"main_time_step": "7 days"}},
             },
             "SoilModel(update_interval = 10080 minutes, no_layers = 1)",
             does_not_raise(),
@@ -92,7 +92,7 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
         (
             {  # invalid soil config tag
                 "soil": {"no_layers": -1},
-                "core": {"timing": {"min_time_step": "7 days"}},
+                "core": {"timing": {"main_time_step": "7 days"}},
             },
             None,
             pytest.raises(InitialisationError),
@@ -117,7 +117,7 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
         (
             {  # min_time_step missing units
                 "soil": {"no_layers": 1},
-                "core": {"timing": {"min_time_step": "7"}},
+                "core": {"timing": {"main_time_step": "7"}},
             },
             None,
             pytest.raises(InitialisationError),
@@ -186,7 +186,7 @@ def test_vr_run_bad_model(mocker, caplog):
             "timing": {
                 "start_date": "2020-01-01",
                 "end_date": "2120-01-01",
-                "min_time_step": "0.5 martian days",
+                "main_time_step": "0.5 martian days",
             },
         },
         "soil": {},

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -84,10 +84,8 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
     [
         (
             {  # valid config
-                "soil": {"no_layers": 1},
-                "core": {
-                    "timing": {"start_time": "2020-01-01", "main_time_step": "7 days"}
-                },
+                "soil": {"no_layers": 1, "model_time_step": "7 days"},
+                "core": {"timing": {"start_time": "2020-01-01"}},
             },
             "SoilModel(update_interval = 10080 minutes, next_update = 2020-01-08T00:00,"
             " no_layers = 1)",
@@ -103,10 +101,8 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
         ),
         (
             {  # invalid soil config tag
-                "soil": {"no_layers": -1},
-                "core": {
-                    "timing": {"start_time": "2020-01-01", "main_time_step": "7 days"}
-                },
+                "soil": {"no_layers": -1, "model_time_step": "7 days"},
+                "core": {"timing": {"start_time": "2020-01-01"}},
             },
             None,
             pytest.raises(InitialisationError),
@@ -129,9 +125,9 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
             ),
         ),
         (
-            {  # min_time_step missing units
-                "soil": {"no_layers": 1},
-                "core": {"timing": {"main_time_step": "7"}},
+            {  # model_time_step missing units
+                "soil": {"no_layers": 1, "model_time_step": "7"},
+                "core": {"timing": {}},
             },
             None,
             pytest.raises(InitialisationError),
@@ -202,10 +198,11 @@ def test_vr_run_bad_model(mocker, caplog):
             "timing": {
                 "start_date": "2020-01-01",
                 "end_date": "2120-01-01",
-                "main_time_step": "0.5 martian days",
             },
         },
-        "soil": {},
+        "soil": {
+            "model_time_step": "0.5 martian days",
+        },
     }
 
     with pytest.raises(InitialisationError):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -319,10 +319,13 @@ def test_extract_timing_details(caplog, config, output, raises, expected_log_ent
     """Test that function to extract main loop timing works as intended."""
 
     with raises:
-        start_time, end_time, update_interval = extract_timing_details(config)
+        start_time, end_time, update_interval, current_time = extract_timing_details(
+            config
+        )
         assert start_time == output["start_time"]
         assert end_time == output["end_time"]
         assert update_interval == output["update_interval"]
+        assert current_time == output["start_time"]
 
     log_check(caplog, expected_log_entries)
 
@@ -387,9 +390,7 @@ def test_setup_timing_loop(caplog, update_interval, expected_log_entries):
 
     start_time = datetime64("2020-03-01")
     end_time = datetime64("2050-03-01")
-    current_time = setup_timing_loop(start_time, end_time, update_interval)
-
-    assert start_time == current_time
+    setup_timing_loop(start_time, end_time, update_interval)
 
     log_check(caplog, expected_log_entries)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -112,32 +112,10 @@ def test_register_model_errors(caplog):
         ),
         (
             {
-                "core": {
-                    "timing": {"main_time_step": "0.5 days", "start_time": "2020-01-01"}
-                },
-                "soil": {"no_layers": 2},
+                "core": {"timing": {"start_time": "2020-01-01"}},
+                "soil": {"no_layers": 2, "model_time_step": "12 hours"},
             },
             timedelta64(12, "h"),
-            does_not_raise(),
-            (
-                (
-                    INFO,
-                    "Information required to initialise the soil model successfully "
-                    "extracted.",
-                ),
-            ),
-        ),
-        (
-            {
-                "core": {
-                    "timing": {
-                        "main_time_step": "0.5 days",
-                        "start_time": "2020-01-01",
-                    }
-                },
-                "soil": {"no_layers": 2, "model_time_step": "5 days"},
-            },
-            timedelta64(5, "D"),
             does_not_raise(),
             (
                 (

--- a/virtual_rainforest/core/core_schema.json
+++ b/virtual_rainforest/core/core_schema.json
@@ -42,18 +42,12 @@
                      "description": "How long the simulation should be run for",
                      "type": "string",
                      "default": "30 years"
-                  },
-                  "main_time_step": {
-                     "description": "Main model time step, units must be provided!",
-                     "type": "string",
-                     "default": "7.0 days"
                   }
                },
                "default": {},
                "required": [
                   "start_date",
-                  "run_length",
-                  "main_time_step"
+                  "run_length"
                ]
             },
             "modules": {

--- a/virtual_rainforest/core/core_schema.json
+++ b/virtual_rainforest/core/core_schema.json
@@ -38,6 +38,13 @@
                      "format": "date",
                      "default": "2015-01-01"
                   },
+                  "update_interval": {
+                     "description": "Model update interval. This should either be significantly",
+                     "desc_cont": "shorter than the model time steps, or all model time steps",
+                     "desc_cont2": "should be directly divisible by it.",
+                     "type": "string",
+                     "default": "10 minutes"
+                  },
                   "run_length": {
                      "description": "How long the simulation should be run for",
                      "type": "string",
@@ -47,6 +54,7 @@
                "default": {},
                "required": [
                   "start_date",
+                  "update_interval",
                   "run_length"
                ]
             },

--- a/virtual_rainforest/core/core_schema.json
+++ b/virtual_rainforest/core/core_schema.json
@@ -38,11 +38,10 @@
                      "format": "date",
                      "default": "2015-01-01"
                   },
-                  "end_date": {
-                     "description": "Simulation end date",
+                  "run_length": {
+                     "description": "How long the simulation should be run for",
                      "type": "string",
-                     "format": "date",
-                     "default": "2065-01-01"
+                     "default": "30 years"
                   },
                   "main_time_step": {
                      "description": "Main model time step, units must be provided!",
@@ -53,7 +52,7 @@
                "default": {},
                "required": [
                   "start_date",
-                  "end_date",
+                  "run_length",
                   "main_time_step"
                ]
             },

--- a/virtual_rainforest/core/core_schema.json
+++ b/virtual_rainforest/core/core_schema.json
@@ -44,7 +44,7 @@
                      "format": "date",
                      "default": "2065-01-01"
                   },
-                  "min_time_step": {
+                  "main_time_step": {
                      "description": "Minimum time step, units must be provided!",
                      "type": "string",
                      "default": "7.0 days"
@@ -54,7 +54,7 @@
                "required": [
                   "start_date",
                   "end_date",
-                  "min_time_step"
+                  "main_time_step"
                ]
             },
             "modules": {

--- a/virtual_rainforest/core/core_schema.json
+++ b/virtual_rainforest/core/core_schema.json
@@ -45,7 +45,7 @@
                      "default": "2065-01-01"
                   },
                   "main_time_step": {
-                     "description": "Minimum time step, units must be provided!",
+                     "description": "Main model time step, units must be provided!",
                      "type": "string",
                      "default": "7.0 days"
                   }

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -100,7 +100,7 @@ class BaseModel(ABC):
     def should_update(self, current_time: datetime64) -> bool:
         """Determines whether a model should be updated for a specific time step."""
 
-        if current_time > self.last_update + self.update_interval:
+        if current_time >= self.last_update + self.update_interval:
             self.last_update = current_time
             return True
         return False

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -45,8 +45,7 @@ class BaseModel(ABC):
     """
 
     name = "base"
-    # TODO - Once higher level timing function is written use it to set this
-    last_update = datetime64("2000-01-01")
+    last_update = None
 
     def __init__(self, update_interval: timedelta64, **kwargs: Any):
         self.update_interval = update_interval
@@ -87,7 +86,10 @@ class BaseModel(ABC):
     def should_update(self, current_time: datetime64) -> bool:
         """Determines whether a model should be updated for a specific time step."""
 
-        if current_time > self.last_update + self.update_interval:
+        if (
+            not self.last_update
+            or current_time > self.last_update + self.update_interval
+        ):
             self.last_update = current_time
             return True
         return False

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -31,8 +31,8 @@ methods, child classes have to overwrite the methods with new functions, otherwi
 inheritance fails. This ensures that a consistent api (set of functions) is used across
 models, while also ensuring that functions don't default to an inappropriate generic
 behaviour due to a function not being defined for a particular model. At the moment, we
-expect every model to have a setup, spinup, solve and cleanup process, though this might
-change in the future.
+expect every model to have a setup, spinup, update and cleanup process, though this
+might change in the future.
 
 We also define an abstract class method to perform model initialisation. This method
 (:func:`~virtual_rainforest.core.model.BaseModel.from_config`) is a factory method which
@@ -67,14 +67,10 @@ from typing import Any, Type
 
 from numpy import datetime64, timedelta64
 
-from virtual_rainforest.core.logger import LOGGER, log_and_raise
+from virtual_rainforest.core.logger import LOGGER
 
 MODEL_REGISTRY: dict[str, Type[BaseModel]] = {}
 """A registry for different models."""
-
-
-class ImproperFunctionCall(Exception):
-    """Custom exception class for cases where functions should not have been called."""
 
 
 class InitialisationError(Exception):
@@ -85,7 +81,7 @@ class BaseModel(ABC):
     """A superclass for all `vr` models.
 
     Describes the common functions and attributes that all `vr` models should have. This
-    includes functions to setup, spin up and solve the specific model, as well as a
+    includes functions to setup, spin up and update the specific model, as well as a
     function to cleanup redundant model data. At this level these functions are not
     define and are mere placeholders to be overwritten (where appropriate) by the
     inheriting classes.
@@ -101,18 +97,21 @@ class BaseModel(ABC):
 
     name = "base"
 
-    def __init__(self, update_interval: timedelta64, **kwargs: Any):
+    def __init__(
+        self, update_interval: timedelta64, start_time: datetime64, **kwargs: Any
+    ):
         self.update_interval = update_interval
+        self.next_update = start_time + update_interval
         # Save variables names to be used by the __repr__
-        self._repr = ["update_interval"]
+        self._repr = ["update_interval", "next_update"]
 
     @abstractmethod
     def spinup(self) -> None:
         """Function to spin up the model."""
 
     @abstractmethod
-    def solve(self) -> None:
-        """Function to solve the model."""
+    def update(self) -> None:
+        """Function to update the model."""
 
     @abstractmethod
     def cleanup(self) -> None:
@@ -136,25 +135,6 @@ class BaseModel(ABC):
 
     def setup(self) -> None:
         """Function to use input data to set up the model."""
-
-    def start_model_timing(self, start_time: datetime64) -> None:
-        """Set of model timing by setting up initial last update time."""
-
-        if hasattr(self, "last_update"):
-            log_and_raise(
-                "Model timing was already set up, it should not be setup again!",
-                ImproperFunctionCall,
-            )
-        else:
-            self.last_update = start_time
-
-    def should_update(self, current_time: datetime64) -> bool:
-        """Determines whether a model should be updated for a specific time step."""
-
-        if current_time >= self.last_update + self.update_interval:
-            self.last_update = current_time
-            return True
-        return False
 
     def __repr__(self) -> str:
         """Represent a Model as a string."""

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -182,7 +182,6 @@ def setup_timing_loop(
     return start_time
 
 
-# TODO - TEST THIS
 def get_models_to_update(
     current_time: datetime64, models: list[BaseModel]
 ) -> tuple[list[BaseModel], list[BaseModel]]:
@@ -258,6 +257,9 @@ def vr_run(
         to_refresh, fixed = get_models_to_update(current_time, models_cfd)
 
         # TODO - Solve models to steady state
+
+        models_cfd = to_refresh + fixed
+
         # TODO - Save model state
 
     LOGGER.info("Virtual rainforest model run completed!")

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -133,6 +133,21 @@ def extract_timing_details(
     return start_time, end_time, update_interval
 
 
+# TODO - TEST THIS
+def check_for_fast_models(
+    models_cfd: list[BaseModel], update_interval: timedelta64
+) -> None:
+    """Warn user of any models using a faster time step than update interval."""
+    fast_models = [
+        model.name for model in models_cfd if model.update_interval < update_interval
+    ]
+    if fast_models:
+        LOGGER.warning(
+            "The following models have shorter time steps than the main model: %s"
+            % fast_models
+        )
+
+
 def vr_run(
     cfg_paths: Union[str, list[str]], output_folder: str, out_file_name: str
 ) -> None:
@@ -155,21 +170,17 @@ def vr_run(
 
     LOGGER.info("All models found in the registry, now attempting to configure them.")
 
-    # TODO - Need to decide how to handle model update intervals
     models_cfd = configure_models(config, model_list)
 
     LOGGER.info(
         "All models successfully configured, now attempting to initialise them."
     )
 
-    # This is just a step to pass flake8 checks (DELETE LATER)
-    print(models_cfd)
-
     # Extract all the relevant timing details
     start_time, end_time, update_interval = extract_timing_details(config)
 
-    # TODO - SOMEWHERE THERE NEEDS TO BE A CHECK THAT MODEL TIME STEPS ARE NOT SHORTER
-    # THAN THE MAIN TIME STEP, IF SO THERE PROBABLY SHOULD BE A WARNING EMITTED
+    # Identify models with shorter time steps than main loop and warn user about them
+    check_for_fast_models(models_cfd, update_interval)
 
     # TODO - Extract input data required to initialise the models
 

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -6,6 +6,8 @@ this script also defines the command line entry points for the model.
 
 from typing import Any, Type, Union
 
+from numpy import datetime64, timedelta64
+
 from virtual_rainforest.core.config import validate_config
 from virtual_rainforest.core.logger import LOGGER, log_and_raise
 from virtual_rainforest.core.model import MODEL_REGISTRY, BaseModel, InitialisationError
@@ -80,6 +82,26 @@ def configure_models(
     return models_cfd
 
 
+# TODO TEST THIS
+def extract_timing_details(
+    config: dict[str, Any]
+) -> tuple[datetime64, datetime64, timedelta64]:
+    """TODO- PROPER DOCSTRING."""
+
+    # TODO - SOMEWHERE THERE NEEDS TO BE A CHECK THAT MODEL TIME STEPS ARE NOT SHORTER
+    # THAN THE MAIN TIME STEP, IF SO THERE PROBABLY SHOULD BE A WARNING EMITTED
+
+    # First extract start and end times
+    start_time = datetime64(config["core"]["timing"]["start_date"])
+    end_time = datetime64(config["core"]["timing"]["end_date"])
+    # CHECK UNITS ETC HERE, DO THE CONVERSION FROM PINT
+    timedelta = timedelta64(config["core"]["timing"]["main_time_step"])
+    # TYPE CHECKING IS ALREADY HANDLED, CHECK THAT SIMULATION DOESN'T END BEFORE IT
+    # STARTS THOUGH, ALSO CHECK THAT UPDATE INTERVAL DOESN'T MEAN NO UPDATE EVER OCCURS
+
+    return start_time, end_time, timedelta
+
+
 def vr_run(
     cfg_paths: Union[str, list[str]], output_folder: str, out_file_name: str
 ) -> None:
@@ -102,6 +124,7 @@ def vr_run(
 
     LOGGER.info("All models found in the registry, now attempting to configure them.")
 
+    # TODO - Need to decide how to handle model update intervals
     models_cfd = configure_models(config, model_list)
 
     LOGGER.info(
@@ -111,9 +134,16 @@ def vr_run(
     # This is just a step to pass flake8 checks (DELETE LATER)
     print(models_cfd)
 
+    # Extract all the relevant timing details
+    current_time, end_time, timedelta = extract_timing_details(config)
+
     # TODO - Extract input data required to initialise the models
 
     # TODO - Initialise the set of configured models
+
+    # TODO - Spin up the models
+
+    # Set initial model times here!!!
 
     # TODO - Save model state
 

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -87,7 +87,7 @@ def configure_models(
 
 def extract_timing_details(
     config: dict[str, Any]
-) -> tuple[datetime64, datetime64, timedelta64]:
+) -> tuple[datetime64, datetime64, timedelta64, datetime64]:
     """Extract timing details for main loop from the model configuration.
 
     Args:
@@ -132,7 +132,7 @@ def extract_timing_details(
             InitialisationError,
         )
 
-    return start_time, end_time, update_interval
+    return start_time, end_time, update_interval, start_time
 
 
 def check_for_fast_models(
@@ -156,10 +156,10 @@ def check_for_fast_models(
 
 def setup_timing_loop(
     start_time: datetime64, end_time: datetime64, update_interval: timedelta64
-) -> datetime64:
-    """Setup timing loop by returning the current time.
+) -> None:
+    """Check whether time interval covers the time window well.
 
-    Also check if the time interval chosen means that more than 10% of the time window
+    Check if the time interval chosen means that more than 10% of the time window
     is not covered. If this is the case the user is warned.
 
     Args:
@@ -179,8 +179,6 @@ def setup_timing_loop(
             "Due to a (relatively) large model time step, %.4s%% of the desired time "
             "span is not covered!" % p
         )
-
-    return start_time
 
 
 def get_models_to_update(
@@ -232,7 +230,7 @@ def vr_run(
     )
 
     # Extract all the relevant timing details
-    start_time, end_time, update_interval = extract_timing_details(config)
+    start_time, end_time, update_interval, current_time = extract_timing_details(config)
 
     # Identify models with shorter time steps than main loop and warn user about them
     check_for_fast_models(models_cfd, update_interval)
@@ -250,7 +248,7 @@ def vr_run(
     # TODO - Save model state
 
     # Setup the timing loop
-    current_time = setup_timing_loop(start_time, end_time, update_interval)
+    setup_timing_loop(start_time, end_time, update_interval)
     while current_time < end_time:
 
         current_time += update_interval

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -4,6 +4,7 @@ As well as setting up the function to run the overall virtual rainforest simulat
 this script also defines the command line entry points for the model.
 """
 
+from itertools import compress
 from typing import Any, Type, Union
 
 import pint
@@ -181,6 +182,27 @@ def setup_timing_loop(
     return start_time
 
 
+# TODO - TEST THIS
+def get_models_to_update(
+    current_time: datetime64, models: list[BaseModel]
+) -> tuple[list[BaseModel], list[BaseModel]]:
+    """Split set of models based on whether they should be updated.
+
+    Args:
+        current_time: Main timing loop time step
+        models: Full set of models
+    """
+
+    # Find models to update
+    to_update = [model.should_update(current_time) for model in models]
+
+    # Separate models into lists based on whether they should update or not
+    to_refresh = list(compress([mod for mod in models], to_update))
+    fixed = list(compress([mod for mod in models], [not elem for elem in to_update]))
+
+    return (to_refresh, fixed)
+
+
 def vr_run(
     cfg_paths: Union[str, list[str]], output_folder: str, out_file_name: str
 ) -> None:
@@ -227,16 +249,16 @@ def vr_run(
 
     # TODO - Save model state
 
-    # TODO - Add timing loop
+    # Setup the timing loop
     current_time = setup_timing_loop(start_time, end_time, update_interval)
     while current_time < end_time:
 
-        # TODO - ACTUALLY DO SOMETHING HERE
         current_time += update_interval
 
-    # TODO - Find models to update
-    # TODO - Solve models to steady state
-    # TODO - Save model state
+        to_refresh, fixed = get_models_to_update(current_time, models_cfd)
+
+        # TODO - Solve models to steady state
+        # TODO - Save model state
 
     LOGGER.info("Virtual rainforest model run completed!")
 

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -86,8 +86,8 @@ def configure_models(
 
 
 def extract_timing_details(
-    config: dict[str, Any]
-) -> tuple[datetime64, datetime64, timedelta64, datetime64]:
+    config: dict[str, Any], update_interval: timedelta64
+) -> tuple[datetime64, datetime64]:
     """Extract timing details for main loop from the model configuration.
 
     The start time, run length and update interval are all extracted from the
@@ -99,6 +99,7 @@ def extract_timing_details(
 
     Args:
         config: The full virtual rainforest configuration
+        update_interval: Update interval for the main timing loop
 
     Raises:
         InitialisationError: If the run length is too short for the model to update, or
@@ -121,21 +122,6 @@ def extract_timing_details(
         # Round raw time interval to nearest minute
         run_length = timedelta64(int(round(raw_length.magnitude)), "m")
 
-    # Catch bad time dimensions
-    try:
-        raw_interval = pint.Quantity(config["core"]["timing"]["main_time_step"]).to(
-            "minutes"
-        )
-    except (pint.errors.DimensionalityError, pint.errors.UndefinedUnitError):
-        log_and_raise(
-            "Units for core.timing.main_time_step are not valid time units: %s"
-            % config["core"]["timing"]["main_time_step"],
-            InitialisationError,
-        )
-    else:
-        # Round raw time interval to nearest minute
-        update_interval = timedelta64(int(round(raw_interval.magnitude)), "m")
-
     if run_length < update_interval:
         log_and_raise(
             f"Models will never update as the update interval ({update_interval}) is "
@@ -154,8 +140,7 @@ def extract_timing_details(
         % (start_time, end_time, end_time - start_time, run_length)
     )
 
-    # TODO - WORK OUT WHICH OF THESE SHOULD ACTUALLY BE RETURNED
-    return start_time, end_time, update_interval, start_time
+    return start_time, end_time
 
 
 def check_for_fast_models(
@@ -207,8 +192,11 @@ def vr_run(
         "All models successfully configured, now attempting to initialise them."
     )
 
+    # Define the basic model time grain (set to 10 minutes for now)
+    update_interval = timedelta64(10, "m")
+
     # Extract all the relevant timing details
-    start_time, end_time, update_interval, current_time = extract_timing_details(config)
+    current_time, end_time = extract_timing_details(config, update_interval)
 
     # Identify models with shorter time steps than main loop and warn user about them
     check_for_fast_models(models_cfd, update_interval)

--- a/virtual_rainforest/soil/model.py
+++ b/virtual_rainforest/soil/model.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from typing import Any
 
 import pint
-from numpy import timedelta64
+from numpy import datetime64, timedelta64
 
 from virtual_rainforest.core.logger import LOGGER, log_and_raise
 from virtual_rainforest.core.model import BaseModel, InitialisationError
@@ -46,7 +46,13 @@ class SoilModel(BaseModel, model_name="soil"):
 
     name = "soil"
 
-    def __init__(self, update_interval: timedelta64, no_layers: int, **kwargs: Any):
+    def __init__(
+        self,
+        update_interval: timedelta64,
+        start_time: datetime64,
+        no_layers: int,
+        **kwargs: Any,
+    ):
 
         if no_layers < 1:
             log_and_raise(
@@ -58,7 +64,7 @@ class SoilModel(BaseModel, model_name="soil"):
                 "The number of soil layers must be an integer!", InitialisationError
             )
 
-        super(SoilModel, self).__init__(update_interval, **kwargs)
+        super().__init__(update_interval, start_time, **kwargs)
         self.no_layers = int(no_layers)
         # Save variables names to be used by the __repr__
         self._repr.append("no_layers")
@@ -91,7 +97,8 @@ class SoilModel(BaseModel, model_name="soil"):
                     config["core"]["timing"]["main_time_step"]
                 ).to("minutes")
             # Round raw time interval to nearest minute
-            update_interval = timedelta64(int(raw_interval.magnitude), "m")
+            update_interval = timedelta64(int(round(raw_interval.magnitude)), "m")
+            start_time = datetime64(config["core"]["timing"]["start_time"])
             no_layers = config["soil"]["no_layers"]
         except (
             ValueError,
@@ -110,7 +117,7 @@ class SoilModel(BaseModel, model_name="soil"):
                 "Information required to initialise the soil model successfully "
                 "extracted."
             )
-            return cls(update_interval, no_layers)
+            return cls(update_interval, start_time, no_layers)
         else:
             raise InitialisationError()
 
@@ -126,8 +133,11 @@ class SoilModel(BaseModel, model_name="soil"):
     def spinup(self) -> None:
         """Placeholder function to spin up the soil model."""
 
-    def solve(self) -> None:
-        """Placeholder function to solve the soil model."""
+    def update(self) -> None:
+        """Placeholder function to update the soil model."""
+
+        # Finally increment timing
+        self.next_update += self.update_interval
 
     def cleanup(self) -> None:
         """Placeholder function for soil model cleanup."""

--- a/virtual_rainforest/soil/model.py
+++ b/virtual_rainforest/soil/model.py
@@ -68,9 +68,15 @@ class SoilModel(BaseModel, model_name="soil"):
         # Assume input is valid until we learn otherwise
         valid_input = True
         try:
-            raw_interval = pint.Quantity(config["core"]["timing"]["min_time_step"]).to(
-                "minutes"
-            )
+            # If model specific time step found use it, if not use
+            try:
+                raw_interval = pint.Quantity(config["soil"]["model_time_step"]).to(
+                    "minutes"
+                )
+            except KeyError:
+                raw_interval = pint.Quantity(
+                    config["core"]["timing"]["main_time_step"]
+                ).to("minutes")
             # Round raw time interval to nearest minute
             update_interval = timedelta64(int(raw_interval.magnitude), "m")
             no_layers = config["soil"]["no_layers"]

--- a/virtual_rainforest/soil/model.py
+++ b/virtual_rainforest/soil/model.py
@@ -87,7 +87,7 @@ class SoilModel(BaseModel, model_name="soil"):
         # Assume input is valid until we learn otherwise
         valid_input = True
         try:
-            raw_interval = pint.Quantity(config["core"]["timing"]["main_time_step"]).to(
+            raw_interval = pint.Quantity(config["soil"]["model_time_step"]).to(
                 "minutes"
             )
             # Round raw time interval to nearest minute

--- a/virtual_rainforest/soil/model.py
+++ b/virtual_rainforest/soil/model.py
@@ -87,15 +87,9 @@ class SoilModel(BaseModel, model_name="soil"):
         # Assume input is valid until we learn otherwise
         valid_input = True
         try:
-            # If model specific time step found use it, if not use main time step
-            try:
-                raw_interval = pint.Quantity(config["soil"]["model_time_step"]).to(
-                    "minutes"
-                )
-            except KeyError:
-                raw_interval = pint.Quantity(
-                    config["core"]["timing"]["main_time_step"]
-                ).to("minutes")
+            raw_interval = pint.Quantity(config["core"]["timing"]["main_time_step"]).to(
+                "minutes"
+            )
             # Round raw time interval to nearest minute
             update_interval = timedelta64(int(round(raw_interval.magnitude)), "m")
             start_time = datetime64(config["core"]["timing"]["start_time"])

--- a/virtual_rainforest/soil/model.py
+++ b/virtual_rainforest/soil/model.py
@@ -68,7 +68,7 @@ class SoilModel(BaseModel, model_name="soil"):
         # Assume input is valid until we learn otherwise
         valid_input = True
         try:
-            # If model specific time step found use it, if not use
+            # If model specific time step found use it, if not use main time step
             try:
                 raw_interval = pint.Quantity(config["soil"]["model_time_step"]).to(
                     "minutes"

--- a/virtual_rainforest/soil/soil_schema.json
+++ b/virtual_rainforest/soil/soil_schema.json
@@ -13,12 +13,16 @@
             },
             "model_time_step": {
                "description": "Time step for soil module, units must be provided!",
-               "type": "string"
+               "desc_cont": "The time grain of the model is 10 minutes, so your choice",
+               "desc_cont2": "here should be divisible by 10 minutes.",
+               "type": "string",
+               "default": "7 days"
             }
          },
          "default": {},
          "required": [
-            "no_layers"
+            "no_layers",
+            "model_time_step"
          ]
       }
    },

--- a/virtual_rainforest/soil/soil_schema.json
+++ b/virtual_rainforest/soil/soil_schema.json
@@ -10,6 +10,10 @@
                "type": "integer",
                "exclusiveMinimum": 0,
                "default": 2
+            },
+            "model_time_step": {
+               "description": "Time step for soil module, units must be provided!",
+               "type": "string"
             }
          },
          "default": {},


### PR DESCRIPTION
# Description

I've added a timing loop to the main function which runs the Virtual Rainforest model. This loop controls which models should be updated on a given time step. I've also added a few functions which check that timing options work sensibly together, and warn the user when they probably don't. To facilitate all this the time check function defined in `BaseModel` was modified, and a new function was added which starts the timing.

One thing it would be useful to get feedback on is whether the way I divide models between `to_refresh` and `fixed` in `get_models_to_update` is efficient. Because at some point these are presumably going to be fairly large objects, so if I'm copying them in an inefficient manner the performance overhead might be quite large.

Anyway, let me know your thoughts. 

Fixes #103 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
