### PR TITLE
Added xarray dataset accessor to record axis validation

### DIFF
--- a/docs/source/api/core/logger.md
+++ b/docs/source/api/core/logger.md
@@ -1,0 +1,24 @@
+---
+jupytext:
+  cell_metadata_filter: -all
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.8
+kernelspec:
+  display_name: vr_python3
+  language: python
+  name: vr_python3
+---
+
+<!-- markdownlint-disable MD041 -->
+
+```{eval-rst}
+.. automodule:: virtual_rainforest.core.logger
+    :autosummary:
+    :members:
+    :special-members: __init__
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,7 +40,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.mathjax",
     "sphinx.ext.autosummary",
-    "sphinx.ext.autosectionlabel",
+    # "sphinx.ext.autosectionlabel",
     "sphinxcontrib.bibtex",
     "myst_nb",
     # "sphinx_astrorefs",  # Gives author year references

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -68,6 +68,7 @@ team.
   virtual_rainforest/usage.md
   virtual_rainforest/soil/soil_details.md
   virtual_rainforest/core/grid.md
+  virtual_rainforest/core/data.md
   virtual_rainforest/core/config.md
 ```
 

--- a/docs/source/virtual_rainforest/core/data.md
+++ b/docs/source/virtual_rainforest/core/data.md
@@ -148,9 +148,9 @@ loaded_temp = data["temperature"]
 print(loaded_temp)
 ```
 
-The returned data array has a `core_axes` property, which can be used to check that data
-has been validated on a particular core axis:
+You can check whether a particular variable has been validated on a given core axis
+using the {meth}`~virtual_rainforest.core.data.Data.on_core_axis` method:
 
 ```{code-cell} ipython3
-loaded_temp.core_axes('spatial')
+data.on_core_axis("temperature", "spatial")
 ```

--- a/docs/source/virtual_rainforest/core/data.md
+++ b/docs/source/virtual_rainforest/core/data.md
@@ -26,11 +26,10 @@ to provide support for different file formats and axis validation (see the [modu
 docs](../../api/core/data.md)) but that is beyond the scope of this document.
 
 A Virtual Rainforest simulation will have one instance of the
-{class}`~virtual_rainforest.core.data.Data` class and this instance behaves as a
-dictionary to provide access to the different forcing and internal variables used in the
-simulation. All of the variables are stored as {class}`~xarray.DataArray` objects from
-the {mod}`xarray` package, which provides a consistent indexing and data manipulation
-for the underlying arrays of data.
+{class}`~virtual_rainforest.core.data.Data` class to provide access to the different
+forcing and internal variables used in the simulation. As they are loaded, all variables
+are validated and then  added to an {class}`xarray.Dataset` object, which provides a
+consistent indexing and data manipulation for the underlying arrays of data.
 
 In many cases, a user will simply provide a configuration file to set up the data that
 will be validated and loaded when a simulation runs, but the main functionality for
@@ -39,11 +38,31 @@ working with data using Python are shown below.
 ## Validation
 
 One of the main functions of the {mod}`~virtual_rainforest.core.data` module is to
-automatically validate data before it is added to the `Data` instance. This works by
-looking for particular dimensions on the data that map onto core axes in the simulation
-and checking that the dimensions in the input data are congruent with the model
-configuration. For example, a data array with `x` and `y` dimensions should have the
-same number of rows and columns as square grid.
+automatically validate data before it is added to the `Data` instance. Validation is
+applied along a set of **core axes** used in the simulation. Each core axis has a set of
+validators: each validator in the set detects a possible data configuration and then
+runs code to validate data in that configuration. The validation process is primarily
+intended to check that provided data is congruent with the configuration of a particular
+simulation.
+
+The validators use the dimension names of input data to detect if that data should be
+validated on a particular axis. For example, the `x` and `y` dimension names are used to
+trigger validation on the `spatial` core axis.
+
+### Core axes
+
+The table below show the dimension names that are used to trigger validation on core
+axes in a simulation. If an input data set uses **any** of the dimension names
+associated with a given core axes, then that data must past validation on the axis.
+
+```{list-table}
+:header-rows: 1
+
+* - Axis name
+  - Dimension names
+* - `spatial`
+  - `x`, `y`, `cell_id`
+```
 
 ## Creating a `Data` instance
 
@@ -54,6 +73,7 @@ is just the spatial grid being used.
 ```{code-cell} ipython3
 from virtual_rainforest.core.grid import Grid
 from virtual_rainforest.core.data import Data
+from virtual_rainforest.core.axes import *
 from xarray import DataArray
 import numpy as np
 
@@ -118,6 +138,19 @@ the loaded variables:
 data
 ```
 
+A variable can be accessed from the `data` object using the variable name as a key, and
+the data is returned as an :class:`xarray.DataArray` object.
+
 ```{code-cell} ipython3
-print(data["temperature"])
+# Get the temperature data
+loaded_temp = data["temperature"]
+
+print(loaded_temp)
+```
+
+The returned data array has a `core_axes` property, which can be used to check that data
+has been validated on a particular core axis:
+
+```{code-cell} ipython3
+loaded_temp.core_axes('spatial')
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Collection of fixtures to assist the testing scripts."""
+from typing import Any
 
 import pytest
 from xarray import DataArray
@@ -84,3 +85,38 @@ def fixture_data(fixture_square_grid_simple):
     data["existing_var"] = DataArray([1, 2, 3, 4], dims=("cell_id",))
 
     return data
+
+
+@pytest.fixture
+def new_axis_validators():
+    """Create new axis validators to test methods and registration."""
+    from virtual_rainforest.core.axes import AxisValidator
+    from virtual_rainforest.core.grid import Grid
+
+    # Create a new subclass.
+    class TestAxis(AxisValidator):
+
+        core_axis = "testing"
+        dim_names = {"test"}
+
+        def can_validate(self, value: DataArray, grid: Grid, **kwargs: Any) -> bool:
+            return True if value.sum() > 10 else False
+
+        def run_validation(
+            self, value: DataArray, grid: Grid, **kwargs: Any
+        ) -> DataArray:
+            return value * 2
+
+    # Create a new duplicate subclass to check mutual exclusivity test
+    class TestAxis2(AxisValidator):
+
+        core_axis = "testing"
+        dim_names = {"test"}
+
+        def can_validate(self, value: DataArray, grid: Grid, **kwargs: Any) -> bool:
+            return True if value.sum() > 10 else False
+
+        def run_validation(
+            self, value: DataArray, grid: Grid, **kwargs: Any
+        ) -> DataArray:
+            return value * 2

--- a/tests/test_axes.py
+++ b/tests/test_axes.py
@@ -118,16 +118,18 @@ def test_AxisValidator_methods(new_axis_validators, fixture_data):
 
 
 @pytest.mark.parametrize(
-    argnames=["value", "exp_err", "exp_msg"],
+    argnames=["value", "exp_val_dict", "exp_err", "exp_msg"],
     argvalues=[
         pytest.param(
             DataArray(data=np.arange(4), dims=("cell_id")),
+            {"spatial": "Spat_CellId_Dim_Any", "testing": None},
             does_not_raise(),
             None,
             id="Match found",
         ),
         pytest.param(
             DataArray(data=np.arange(4), dims=("x")),
+            {},
             pytest.raises(ValueError),
             "DataArray uses 'spatial' axis dimension names but "
             "does not match a validator: x",
@@ -135,19 +137,23 @@ def test_AxisValidator_methods(new_axis_validators, fixture_data):
         ),
         pytest.param(
             DataArray(data=np.arange(50), dims=("test")),
+            {},
             pytest.raises(RuntimeError),
             "Validators on 'testing' axis not mutually exclusive",
             id="Bad validator setup",
         ),
         pytest.param(
             DataArray(data=np.arange(4), dims=("cell_identities")),
+            {"spatial": None, "testing": None},
             does_not_raise(),
             None,
             id="No match found",
         ),
     ],
 )
-def test_validate_dataarray(new_axis_validators, fixture_data, value, exp_err, exp_msg):
+def test_validate_dataarray(
+    new_axis_validators, fixture_data, value, exp_val_dict, exp_err, exp_msg
+):
     """Test the validate_dataarray function.
 
     This just checks the pass through and failure modes - the individual AxisValidator
@@ -158,26 +164,10 @@ def test_validate_dataarray(new_axis_validators, fixture_data, value, exp_err, e
 
     # Decorate a mock function to test the failure modes
     with exp_err as err:
-        value = validate_dataarray(value, grid=fixture_data.grid)
-
+        value, val_dict = validate_dataarray(value, grid=fixture_data.grid)
+        assert exp_val_dict == val_dict
     if err is not None:
         assert str(err.value) == exp_msg
-
-
-def test_validate_CoreAxesAccessor(new_axis_validators, fixture_data):
-    """Test the core_axis property functions correctly."""
-
-    from virtual_rainforest.core.axes import validate_dataarray
-
-    value = DataArray(data=np.arange(4), dims=("cell_id"))
-
-    value = validate_dataarray(value, grid=fixture_data.grid)
-
-    assert value.core_axes["spatial"] == "Spat_CellId_Dim_Any"
-    assert value.core_axes["testing"] is None
-
-    assert value.core_axes("spatial")
-    assert not value.core_axes("testing")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_axes.py
+++ b/tests/test_axes.py
@@ -8,41 +8,6 @@ import pytest
 from xarray import DataArray
 
 
-@pytest.fixture
-def new_axis_validators():
-    """Create new axis validators to test methods and registration."""
-    from virtual_rainforest.core.axes import AxisValidator
-    from virtual_rainforest.core.grid import Grid
-
-    # Create a new subclass.
-    class TestAxis(AxisValidator):
-
-        core_axis = "testing"
-        dim_names = {"test"}
-
-        def can_validate(self, value: DataArray, grid: Grid, **kwargs: Any) -> bool:
-            return True if value.sum() > 10 else False
-
-        def run_validation(
-            self, value: DataArray, grid: Grid, **kwargs: Any
-        ) -> DataArray:
-            return value * 2
-
-    # Create a new duplicate subclass to check mutual exclusivity test
-    class TestAxis2(AxisValidator):
-
-        core_axis = "testing"
-        dim_names = {"test"}
-
-        def can_validate(self, value: DataArray, grid: Grid, **kwargs: Any) -> bool:
-            return True if value.sum() > 10 else False
-
-        def run_validation(
-            self, value: DataArray, grid: Grid, **kwargs: Any
-        ) -> DataArray:
-            return value * 2
-
-
 def test_AxisValidator_registration_bad_core_axis():
     """Simple test of AxisValidator registration."""
     from virtual_rainforest.core.axes import AxisValidator

--- a/tests/test_axes.py
+++ b/tests/test_axes.py
@@ -164,7 +164,7 @@ def test_validate_dataarray(new_axis_validators, fixture_data, value, exp_err, e
         assert str(err.value) == exp_msg
 
 
-def test_validate_CoreAxisAccessor(new_axis_validators, fixture_data):
+def test_validate_CoreAxesAccessor(new_axis_validators, fixture_data):
     """Test the core_axis property functions correctly."""
 
     from virtual_rainforest.core.axes import validate_dataarray

--- a/tests/test_axes.py
+++ b/tests/test_axes.py
@@ -164,6 +164,22 @@ def test_validate_dataarray(new_axis_validators, fixture_data, value, exp_err, e
         assert str(err.value) == exp_msg
 
 
+def test_validate_CoreAxisAccessor(new_axis_validators, fixture_data):
+    """Test the core_axis property functions correctly."""
+
+    from virtual_rainforest.core.axes import validate_dataarray
+
+    value = DataArray(data=np.arange(4), dims=("cell_id"))
+
+    value = validate_dataarray(value, grid=fixture_data.grid)
+
+    assert value.core_axes["spatial"] == "Spat_CellId_Dim_Any"
+    assert value.core_axes["testing"] is None
+
+    assert value.core_axes("spatial")
+    assert not value.core_axes("testing")
+
+
 @pytest.mark.parametrize(
     argnames=["grid_args", "darray", "exp_err", "exp_message", "exp_vals"],
     argvalues=[

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -619,3 +619,50 @@ def test_Data_load_from_config(
         assert str(err.value) == exp_msg
 
     log_check(caplog, exp_log)
+
+
+@pytest.mark.parametrize(
+    argnames="vname, axname, result, err_ctxt, err_message",
+    argvalues=[
+        ("temp", "spatial", True, does_not_raise(), None),
+        ("temp", "testing", False, does_not_raise(), None),
+        (
+            "missing",
+            "spatial",
+            False,
+            pytest.raises(ValueError),
+            "Unknown variable name: missing",
+        ),
+        (
+            "incorrect",
+            "spatial",
+            False,
+            pytest.raises(RuntimeError),
+            "Missing variable validation data: incorrect",
+        ),
+        (
+            "temp",
+            "missing",
+            False,
+            pytest.raises(ValueError),
+            "Unknown core axis name: missing",
+        ),
+    ],
+)
+def test_on_core_axis(
+    new_axis_validators, fixture_data, vname, axname, result, err_ctxt, err_message
+):
+    """Test the on_core_axis method."""
+
+    # Add a data array properly
+    da = DataArray([1, 2, 3, 4], dims=("cell_id",), name="temp")
+    fixture_data["temp"] = da
+
+    # Add a data array _incorrectly_
+    fixture_data.data["incorrect"] = da
+
+    with err_ctxt as err:
+        assert result == fixture_data.on_core_axis(vname, axname)
+
+    if err_message:
+        assert str(err.value) == err_message

--- a/virtual_rainforest/core/axes.py
+++ b/virtual_rainforest/core/axes.py
@@ -162,13 +162,14 @@ def validate_dataarray(
     used to validate the input array and the validated array is passed on to the next
     axis for further validation.
 
-    The function returns the validated data array and a dictionary recording which
-    AxisValidator classes were applied to each of the core axes.
-
     Args:
         value: An input DataArray for validation
         grid: A Grid object giving the spatial configuration.
         kwargs: Further configuration details to be passed to AxisValidators
+
+    Returns:
+        The function returns the validated data array and a dictionary recording which
+        AxisValidator classes were applied to each of the core axes.
 
     Raises:
         ValueError: If the input data array uses dimension names required for an axis

--- a/virtual_rainforest/core/axes.py
+++ b/virtual_rainforest/core/axes.py
@@ -214,23 +214,23 @@ def validate_dataarray(value: DataArray, grid: Grid, **kwargs: Any) -> DataArray
         if matching_dims:
 
             # There should be one and only validator that can validate for this axis.
-            validator_found = [v().can_validate(value, grid) for v in validators]
+            validator_found = [v for v in validators if v().can_validate(value, grid)]
 
-            if not any(validator_found):
+            if len(validator_found) == 0:
                 log_and_raise(
                     f"DataArray uses '{axis}' axis dimension names but does "
                     f"not match a validator: {','.join(matching_dims)}",
                     ValueError,
                 )
 
-            if sum(validator_found) > 1:
+            if len(validator_found) > 1:
                 log_and_raise(
                     f"Validators on '{axis}' axis not mutually exclusive", RuntimeError
                 )
 
             # Get the appropriate Validator class and then use it to update the data
             # array
-            this_validator = validators[validator_found.index(True)]
+            this_validator = validator_found[0]
             try:
                 value = this_validator().run_validation(value, grid, **kwargs)
                 value.core_axes[axis] = this_validator.__name__

--- a/virtual_rainforest/core/axes.py
+++ b/virtual_rainforest/core/axes.py
@@ -24,6 +24,16 @@ the validators define for each core axis.
 Note that the set of validators defined for a specific core axis should be mutually
 exclusive: only one should be applicable to any given dataset being tested on that axis.
 
+DataArray validation records
+============================
+
+The :mod:`~virtual_rainforest.core.axes` module uses the custom `DataArray.core_axes`
+property to record the validation applied to input Data Arrays. This property is set
+using the :func:`xarray.register_dataarray_accessor` framework and the
+:class:`~virtual_rainforest.core.axes.CoreAxesAccessor` class. The `core_axes` property
+provides a dictionary of the validators applied to each core axis on a DataArray and a
+callable to check if validation has been applied on a particular axis.
+
 Core axes
 =========
 
@@ -139,7 +149,7 @@ the `__subclass_init__` method.
 
 
 @register_dataarray_accessor("core_axes")  # type:ignore
-class CoreAxisAccessor(dict):
+class CoreAxesAccessor(dict):
     """An xarray DataArray accessor providing a core_axes dictionary.
 
     This class extends xarray DataArrays to provide a property containing a dictionary

--- a/virtual_rainforest/core/core_schema.json
+++ b/virtual_rainforest/core/core_schema.json
@@ -91,7 +91,7 @@
                         },
                         "required": [
                            "file",
-                           "file_var"
+                           "file_var_name"
                         ]
                      }
                   }

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -200,13 +200,13 @@ class Data:
         """
 
         if var_name not in self.data:
-            raise KeyError(f"Unknown variable name: {var_name}")
-
-        if axis_name not in AXIS_VALIDATORS:
-            raise KeyError(f"Unknown core axis name: {var_name}")
+            raise ValueError(f"Unknown variable name: {var_name}")
 
         if var_name not in self._variable_validation:
             raise RuntimeError(f"Missing variable validation data: {var_name}")
+
+        if axis_name not in AXIS_VALIDATORS:
+            raise ValueError(f"Unknown core axis name: {axis_name}")
 
         return False if self._variable_validation[var_name][axis_name] is None else True
 

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -197,6 +197,13 @@ class Data:
         Args:
             var_name: The name of a variable
             axis_name: The core axis name
+
+        Returns:
+            A boolean indicating if the variable was validated on the named axis.
+
+        Raises:
+            ValueError: Unknown variable or core axis name
+            RuntimeError: Incomplete variable validation data in Data instance.
         """
 
         if var_name not in self.data:

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -300,7 +300,7 @@ class Data:
                 # processed
                 try:
                     self.load_from_file(
-                        file=each_var["file"],
+                        file=Path(each_var["file"]),
                         file_var_name=each_var["file_var_name"],
                         data_var_name=each_var.get("data_var_name"),
                     )

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -84,7 +84,7 @@ from typing import Any, Optional
 
 from xarray import DataArray, Dataset
 
-from virtual_rainforest.core.axes import validate_dataarray
+from virtual_rainforest.core.axes import AXIS_VALIDATORS, validate_dataarray
 from virtual_rainforest.core.config import ConfigurationError
 from virtual_rainforest.core.grid import Grid
 from virtual_rainforest.core.logger import LOGGER, log_and_raise
@@ -114,6 +114,7 @@ class Data:
 
         self.grid = grid
         self.data = Dataset()
+        self._variable_validation: dict[str, dict[str, Optional[str]]] = {}
 
     def __repr__(self) -> str:
         """Returns a representation of a Data instance."""
@@ -154,7 +155,9 @@ class Data:
             LOGGER.info(f"Replacing data array for '{key}'")
 
         # Validate and store the data array
-        self.data[key] = validate_dataarray(value=value, grid=self.grid)
+        value, valid_dict = validate_dataarray(value=value, grid=self.grid)
+        self.data[key] = value
+        self._variable_validation[key] = valid_dict
 
     def __getitem__(self, key: str) -> DataArray:
         """Get a given data variable from a Data instance.
@@ -184,6 +187,28 @@ class Data:
         """
 
         return key in self.data
+
+    def on_core_axis(self, var_name: str, axis_name: str) -> bool:
+        """Check core axis validation.
+
+        This function checks if a given variable loaded into a Data instance has been
+        validated on one of the core axes.
+
+        Args:
+            var_name: The name of a variable
+            axis_name: The core axis name
+        """
+
+        if var_name not in self.data:
+            raise KeyError(f"Unknown variable name: {var_name}")
+
+        if axis_name not in AXIS_VALIDATORS:
+            raise KeyError(f"Unknown core axis name: {var_name}")
+
+        if var_name not in self._variable_validation:
+            raise RuntimeError(f"Missing variable validation data: {var_name}")
+
+        return False if self._variable_validation[var_name][axis_name] is None else True
 
     def load_from_file(
         self,


### PR DESCRIPTION
# Description

This PR extends `xarray.DataArray` to add a `core_axes` property that is used to record the axis validation applied to that data array. It uses  the `xarray` Accessor framework.

The `core_axis` property is basically a dictionary of which AxisValidator was applied to each core axis (or `None` if no validator was applied. The property is also made callable as a simple shorthand boolean test of whether a named axis has been validated. For example, a model `__init__` might confirm:

```python
if not elevation.core_axis('spatial'):
    raise ValueError("Elevation data not validated on spatial axis")
```

I worry a little that making the `dict` callable is a bit too clever. The main reason is to keep a short API - it would otherwise have to be something like `elevation.core_axis.has_axis('spatial')`, which admittedly isn't exactly verbose.


## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
