### PR TITLE
Solve issue with documentation not rendering properly

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,7 @@ build:
       - pip install poetry
       # Tell poetry to not use a virtual environment
       - poetry config virtualenvs.create false
+    post_install:
       # Install dependencies with 'docs' dependency group
       # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
       - poetry install --with docs


### PR DESCRIPTION
# Description

I think that Read The Docs install step is installing older version of some packages where the bug described [this link](https://github.com/readthedocs/sphinx_rtd_theme/issues/1115) - which is what we observe - is still present. 

The solution should be as straight forward as to install the dependencies in the `post_install` step rather than when setting up the environment. This blog post describes de solution:

https://browniebroke.com/blog/specify-docs-dependency-groups-with-poetry-and-read-the-docs/

Fixes #143 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
