### PR TITLE
Unpinning CI python versions as no longer needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         # Pinned to fix problem with macosx and older python versions (change when fixed)
-        python-version: [ "3.9.16" , "3.10.9", "3.11" ]
+        python-version: [ "3.9" , "3.10", "3.11" ]
 
     steps:
     - uses: actions/checkout@v3
@@ -41,7 +41,7 @@ jobs:
       run: poetry run pytest
 
     - name: Run codecov
-      if: success() && (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9.16')
+      if: success() && (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9')
       run: |
         pip install codecov
         codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        # Pinned to fix problem with macosx and older python versions (change when fixed)
         python-version: [ "3.9" , "3.10", "3.11" ]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,6 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         # Pinned to fix problem with macosx and older python versions (change when fixed)
         python-version: [ "3.9.16" , "3.10.9", "3.11" ]
-        exclude:
-           - os: windows-latest
-             python-version: 3.9.16 # Not yet available
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
# Description

Github actions python versions for 3.9 and 3.10 now default to 3.9.16 and 3.10.9, respectively. This means there's no longer any reason to keep the versions pinned, so I have unpinned them. (They were originally pinned to fix a weird CI edge case where a specific test would fail on macOS for python versions <3.9.16 and <3.10.9)


## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
