### PR TITLE
Remove unnecessary critical messages in model.py scripts

### DIFF
--- a/docs/source/development/defining_new_models.md
+++ b/docs/source/development/defining_new_models.md
@@ -89,7 +89,7 @@ def __init__(
         to_raise = InitialisationError(
                 "There has to be at least one pond in the freshwater model!"
             )
-        LOGGER.critical(to_raise)
+        LOGGER.error(to_raise)
         raise to_raise
         
     # Provide general attributes to the __init__ of the base class

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -114,7 +114,7 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
                     "extracted.",
                 ),
                 (
-                    CRITICAL,
+                    ERROR,
                     "There has to be at least one soil layer in the soil model!",
                 ),
                 (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,7 @@ define models based on the class defined in model.py
 """
 
 from contextlib import nullcontext as does_not_raise
-from logging import CRITICAL, INFO, WARNING
+from logging import CRITICAL, ERROR, INFO, WARNING
 
 import pytest
 from numpy import datetime64, timedelta64
@@ -47,7 +47,7 @@ def test_base_model_initialization(caplog, mocker):
             pytest.raises(InitialisationError),
             (
                 (
-                    CRITICAL,
+                    ERROR,
                     "There has to be at least one soil layer in the soil model!",
                 ),
             ),
@@ -57,7 +57,7 @@ def test_base_model_initialization(caplog, mocker):
             pytest.raises(InitialisationError),
             (
                 (
-                    CRITICAL,
+                    ERROR,
                     "The number of soil layers must be an integer!",
                 ),
             ),
@@ -220,7 +220,7 @@ def test_generate_soil_model(
             pytest.raises(InitialisationError),
             (
                 (
-                    CRITICAL,
+                    ERROR,
                     "There has to be at least one soil layer in the abiotic model!",
                 ),
             ),
@@ -231,7 +231,7 @@ def test_generate_soil_model(
             pytest.raises(InitialisationError),
             (
                 (
-                    CRITICAL,
+                    ERROR,
                     "There has to be at least one canopy layer in the abiotic model!",
                 ),
             ),
@@ -242,7 +242,7 @@ def test_generate_soil_model(
             pytest.raises(InitialisationError),
             (
                 (
-                    CRITICAL,
+                    ERROR,
                     "The number of soil layers must be an integer!",
                 ),
             ),
@@ -253,7 +253,7 @@ def test_generate_soil_model(
             pytest.raises(InitialisationError),
             (
                 (
-                    CRITICAL,
+                    ERROR,
                     "The number of canopy layers must be an integer!",
                 ),
             ),

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -133,11 +133,11 @@ class BaseModel(ABC):
         # Check that model_name exists and is a string
         if not hasattr(cls, "model_name"):
             excep = ValueError("Models must have a model_name attribute!")
-            LOGGER.error(excep)
+            LOGGER.critical(excep)
             raise excep
         elif not isinstance(cls.model_name, str):
             excep = TypeError("Models should only be named using strings!")
-            LOGGER.error(excep)
+            LOGGER.critical(excep)
             raise excep
 
         # Add the new model to the registry

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -133,11 +133,11 @@ class BaseModel(ABC):
         # Check that model_name exists and is a string
         if not hasattr(cls, "model_name"):
             excep = ValueError("Models must have a model_name attribute!")
-            LOGGER.critical(excep)
+            LOGGER.error(excep)
             raise excep
         elif not isinstance(cls.model_name, str):
             excep = TypeError("Models should only be named using strings!")
-            LOGGER.critical(excep)
+            LOGGER.error(excep)
             raise excep
 
         # Add the new model to the registry

--- a/virtual_rainforest/models/abiotic/model.py
+++ b/virtual_rainforest/models/abiotic/model.py
@@ -42,28 +42,28 @@ class AbioticModel(BaseModel):
             to_raise = InitialisationError(
                 "There has to be at least one soil layer in the abiotic model!"
             )
-            LOGGER.critical(to_raise)
+            LOGGER.error(to_raise)
             raise to_raise
 
         if soil_layers != int(soil_layers):
             to_raise = InitialisationError(
                 "The number of soil layers must be an integer!"
             )
-            LOGGER.critical(to_raise)
+            LOGGER.error(to_raise)
             raise to_raise
 
         if canopy_layers < 1:
             to_raise = InitialisationError(
                 "There has to be at least one canopy layer in the abiotic model!"
             )
-            LOGGER.critical(to_raise)
+            LOGGER.error(to_raise)
             raise to_raise
 
         if canopy_layers != int(canopy_layers):
             to_raise = InitialisationError(
                 "The number of canopy layers must be an integer!"
             )
-            LOGGER.critical(to_raise)
+            LOGGER.error(to_raise)
             raise to_raise
 
         super().__init__(update_interval, start_time, **kwargs)

--- a/virtual_rainforest/models/soil/model.py
+++ b/virtual_rainforest/models/soil/model.py
@@ -53,14 +53,14 @@ class SoilModel(BaseModel):
             to_raise = InitialisationError(
                 "There has to be at least one soil layer in the soil model!"
             )
-            LOGGER.critical(to_raise)
+            LOGGER.error(to_raise)
             raise to_raise
 
         if no_layers != int(no_layers):
             to_raise = InitialisationError(
                 "The number of soil layers must be an integer!"
             )
-            LOGGER.critical(to_raise)
+            LOGGER.error(to_raise)
             raise to_raise
 
         super().__init__(update_interval, start_time, **kwargs)


### PR DESCRIPTION
# Description

Critical logging messages were being raised by `Model` `__init__`'s when the errors they were emitting were being handled by higher level functions in `main.py`. This is obviously not correct, as it led to multiple `CRITICAL` messages being logged. I thought it was worth fixing this immediately as the documentation informing people how to setup a model was basically instructing people to make this mistake.

This does not fix #113 or #160, which are much broader discussion. It does however remove an egregious example of the problem.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
