### PR TITLE
Make a `Data` object part of the `BaseModel.__init__` 

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,7 +27,7 @@ from .conftest import log_check
 @pytest.mark.parametrize(
     "model_list,no_models,raises,expected_log_entries",
     [
-        (
+        pytest.param(
             ["soil"],  # valid input
             1,
             does_not_raise(),
@@ -37,8 +37,9 @@ from .conftest import log_check
                     "Attempting to configure the following models: ['soil']",
                 ),
             ),
+            id="valid input",
         ),
-        (
+        pytest.param(
             ["soil", "core"],
             1,
             does_not_raise(),
@@ -48,8 +49,9 @@ from .conftest import log_check
                     "Attempting to configure the following models: ['soil']",
                 ),
             ),
+            id="ignores core",
         ),
-        (
+        pytest.param(
             ["soil", "freshwater"],  # Model that hasn't been defined
             0,
             pytest.raises(InitialisationError),
@@ -65,6 +67,7 @@ from .conftest import log_check
                     " the registry: ['freshwater']",
                 ),
             ),
+            id="undefined model",
         ),
     ],
 )
@@ -82,7 +85,7 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
 @pytest.mark.parametrize(
     "config,output,raises,expected_log_entries",
     [
-        (
+        pytest.param(
             {  # valid config
                 "soil": {"no_layers": 1, "model_time_step": "7 days"},
                 "core": {"timing": {"start_time": "2020-01-01"}},
@@ -98,8 +101,9 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
                     "extracted.",
                 ),
             ),
+            id="valid config",
         ),
-        (
+        pytest.param(
             {  # invalid soil config tag
                 "soil": {"no_layers": -1, "model_time_step": "7 days"},
                 "core": {"timing": {"start_time": "2020-01-01"}},
@@ -123,8 +127,9 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
                     "simulation.",
                 ),
             ),
+            id="invalid soil config tag",
         ),
-        (
+        pytest.param(
             {  # model_time_step missing units
                 "soil": {"no_layers": 1, "model_time_step": "7"},
                 "core": {"timing": {}},
@@ -146,6 +151,7 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
                     "simulation.",
                 ),
             ),
+            id="model_time_step missing units",
         ),
     ],
 )
@@ -235,7 +241,7 @@ def test_vr_run_bad_model(mocker, caplog):
 @pytest.mark.parametrize(
     "config,output,raises,expected_log_entries",
     [
-        (
+        pytest.param(
             {
                 "core": {
                     "timing": {
@@ -259,8 +265,9 @@ def test_vr_run_bad_model(mocker, caplog):
                     "requested 15778800 minutes",
                 ),
             ),
+            id="timing correct",
         ),
-        (
+        pytest.param(
             {
                 "core": {
                     "timing": {
@@ -279,8 +286,9 @@ def test_vr_run_bad_model(mocker, caplog):
                     "larger than the run length (1 minutes)",
                 ),
             ),
+            id="run length < update interval",
         ),
-        (
+        pytest.param(
             {
                 "core": {
                     "timing": {
@@ -299,8 +307,9 @@ def test_vr_run_bad_model(mocker, caplog):
                     " days",
                 ),
             ),
+            id="invalid run length units",
         ),
-        (
+        pytest.param(
             {
                 "core": {
                     "timing": {
@@ -319,6 +328,7 @@ def test_vr_run_bad_model(mocker, caplog):
                     " long minutes",
                 ),
             ),
+            id="invalid update_interval units",
         ),
     ],
 )
@@ -337,8 +347,8 @@ def test_extract_timing_details(caplog, config, output, raises, expected_log_ent
 @pytest.mark.parametrize(
     "update_interval,expected_log_entries",
     [
-        (timedelta64(2, "W"), ()),
-        (
+        pytest.param(timedelta64(2, "W"), (), id="valid"),
+        pytest.param(
             timedelta64(5, "W"),
             (
                 (
@@ -347,10 +357,11 @@ def test_extract_timing_details(caplog, config, output, raises, expected_log_ent
                     "['soil']",
                 ),
             ),
+            id="fast model",
         ),
     ],
 )
-def test_check_for_fast_models(caplog, mocker, update_interval, expected_log_entries):
+def test_check_for_fast_models(caplog, update_interval, expected_log_entries):
     """Test that function to warn user about short module time steps works."""
 
     # Create SoilModel instance and then populate the update_interval

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,7 +10,7 @@ from logging import CRITICAL, ERROR, INFO, WARNING
 import pytest
 from numpy import datetime64, timedelta64
 
-from virtual_rainforest.core.model import BaseModel, InitialisationError
+from virtual_rainforest.core.model import InitialisationError
 from virtual_rainforest.models.abiotic.model import AbioticModel
 from virtual_rainforest.models.soil.model import SoilModel
 
@@ -36,12 +36,24 @@ def data_instance():
 
 def test_base_model_initialization(data_instance, mocker):
     """Test `BaseModel` initialization."""
+    from virtual_rainforest.core.model import BaseModel
 
     # Patch abstract methods so that BaseModel can be instantiated for testing
     mocker.patch.object(BaseModel, "__abstractmethods__", new_callable=set)
 
-    # Patch attributes defined but not set in ABC
-    mocker.patch.object(BaseModel, "required_init_vars", [])
+    # Patch properties defined but not set in ABC
+    mocker.patch.object(
+        BaseModel,
+        "required_init_vars",
+        new_callable=mocker.PropertyMock,
+        return_value=[],
+    )
+    mocker.patch.object(
+        BaseModel,
+        "model_name",
+        new_callable=mocker.PropertyMock,
+        return_value="base",
+    )
 
     # Initialise model
     model = BaseModel(
@@ -146,6 +158,7 @@ def test_soil_model_initialization(caplog, no_layers, raises, expected_log_entri
 )
 def test_register_model_errors(caplog, name, raises, expected_log_entries):
     """Test that the function registering models generates correct errors/warnings."""
+    from virtual_rainforest.core.model import BaseModel
 
     with raises:
 
@@ -161,6 +174,7 @@ def test_register_model_errors(caplog, name, raises, expected_log_entries):
 
 def test_unnamed_model(caplog):
     """Test that the registering a model without a name fails correctly."""
+    from virtual_rainforest.core.model import BaseModel
 
     with pytest.raises(ValueError):
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,14 +5,10 @@ define models based on the class defined in model.py
 """
 
 from contextlib import nullcontext as does_not_raise
-from logging import CRITICAL, ERROR, INFO, WARNING
+from logging import CRITICAL, WARNING
 
 import pytest
 from numpy import datetime64, timedelta64
-
-from virtual_rainforest.core.model import InitialisationError
-from virtual_rainforest.models.abiotic.model import AbioticModel
-from virtual_rainforest.models.soil.model import SoilModel
 
 from .conftest import log_check
 
@@ -71,57 +67,6 @@ def test_base_model_initialization(data_instance, mocker):
 
 
 @pytest.mark.parametrize(
-    "no_layers,raises,expected_log_entries",
-    [
-        (
-            2,
-            does_not_raise(),
-            (),
-        ),
-        (
-            -2,
-            pytest.raises(InitialisationError),
-            (
-                (
-                    ERROR,
-                    "There has to be at least one soil layer in the soil model!",
-                ),
-            ),
-        ),
-        (
-            2.5,
-            pytest.raises(InitialisationError),
-            (
-                (
-                    ERROR,
-                    "The number of soil layers must be an integer!",
-                ),
-            ),
-        ),
-    ],
-)
-def test_soil_model_initialization(caplog, no_layers, raises, expected_log_entries):
-    """Test `SoilModel` initialization."""
-
-    with raises:
-        # Initialize model
-        model = SoilModel(timedelta64(1, "W"), datetime64("2022-11-01"), no_layers)
-
-        # In cases where it passes then checks that the object has the right properties
-        assert set(["setup", "spinup", "update", "cleanup"]).issubset(dir(model))
-        assert model.model_name == "soil"
-        assert str(model) == "A soil model instance"
-        assert (
-            repr(model)
-            == f"SoilModel(update_interval = 1 weeks, next_update = 2022-11-08, "
-            f"no_layers = {int(no_layers)})"
-        )
-
-    # Final check that expected logging entries are produced
-    log_check(caplog, expected_log_entries)
-
-
-@pytest.mark.parametrize(
     "name,raises,expected_log_entries",
     [
         (
@@ -165,8 +110,7 @@ def test_register_model_errors(caplog, name, raises, expected_log_entries):
         class NewSoilModel(BaseModel):
             """Test class for use in testing __init_subclass__."""
 
-            model_name = name
-            """The model name for use in registering the model and logging."""
+            pass
 
     # Then check that the correct (warning) log messages are emitted
     log_check(caplog, expected_log_entries)
@@ -176,206 +120,12 @@ def test_unnamed_model(caplog):
     """Test that the registering a model without a name fails correctly."""
     from virtual_rainforest.core.model import BaseModel
 
-    with pytest.raises(ValueError):
+    # with pytest.raises(ValueError):
 
-        class UnnamedModel(BaseModel):
-            """Model where a model_name hasn't been included."""
+    class UnnamedModel(BaseModel):
+        """Model where a model_name hasn't been included."""
 
     expected_log_entries = ((CRITICAL, "Models must have a model_name attribute!"),)
 
     # Then check that the correct (warning) log messages are emitted
-    log_check(caplog, expected_log_entries)
-
-
-@pytest.mark.parametrize(
-    "config,time_interval,raises,expected_log_entries",
-    [
-        (
-            {},
-            None,
-            pytest.raises(KeyError),
-            (),  # This error isn't handled so doesn't generate logging
-        ),
-        (
-            {
-                "core": {"timing": {"start_time": "2020-01-01"}},
-                "soil": {"no_layers": 2, "model_time_step": "12 hours"},
-            },
-            timedelta64(12, "h"),
-            does_not_raise(),
-            (
-                (
-                    INFO,
-                    "Information required to initialise the soil model successfully "
-                    "extracted.",
-                ),
-            ),
-        ),
-    ],
-)
-def test_generate_soil_model(
-    caplog, config, time_interval, raises, expected_log_entries
-):
-    """Test that the function to initialise the soil model behaves as expected."""
-
-    # Check whether model is initialised (or not) as expected
-    with raises:
-        model = SoilModel.from_config(config)
-        assert model.no_layers == config["soil"]["no_layers"]
-        assert model.update_interval == time_interval
-        assert (
-            model.next_update
-            == datetime64(config["core"]["timing"]["start_time"]) + time_interval
-        )
-        # Run the update step and check that next_update has incremented properly
-        model.update()
-        assert (
-            model.next_update
-            == datetime64(config["core"]["timing"]["start_time"]) + 2 * time_interval
-        )
-
-    # Final check that expected logging entries are produced
-    log_check(caplog, expected_log_entries)
-
-
-# -------------------------------------
-# abiotic model tests
-# -------------------------------------
-
-
-@pytest.mark.parametrize(
-    "soil_layers,canopy_layers,raises,expected_log_entries",
-    [
-        (
-            2,
-            3,
-            does_not_raise(),
-            (),
-        ),
-        (
-            -2,
-            3,
-            pytest.raises(InitialisationError),
-            (
-                (
-                    ERROR,
-                    "There has to be at least one soil layer in the abiotic model!",
-                ),
-            ),
-        ),
-        (
-            2,
-            -3,
-            pytest.raises(InitialisationError),
-            (
-                (
-                    ERROR,
-                    "There has to be at least one canopy layer in the abiotic model!",
-                ),
-            ),
-        ),
-        (
-            2.5,
-            3,
-            pytest.raises(InitialisationError),
-            (
-                (
-                    ERROR,
-                    "The number of soil layers must be an integer!",
-                ),
-            ),
-        ),
-        (
-            2,
-            3.4,
-            pytest.raises(InitialisationError),
-            (
-                (
-                    ERROR,
-                    "The number of canopy layers must be an integer!",
-                ),
-            ),
-        ),
-    ],
-)
-def test_abiotic_model_initialization(
-    caplog, soil_layers, canopy_layers, raises, expected_log_entries
-):
-    """Test `AbioticModel` initialization."""
-
-    with raises:
-        # Initialize model
-        model = AbioticModel(
-            timedelta64(1, "W"), datetime64("2022-11-01"), soil_layers, canopy_layers
-        )
-
-        # In cases where it passes then checks that the object has the right properties
-        assert set(["setup", "spinup", "update", "cleanup"]).issubset(dir(model))
-        assert model.model_name == "abiotic"
-        assert (
-            repr(model)
-            == f"AbioticModel(update_interval = 1 weeks, next_update = 2022-11-08, "
-            f"soil_layers = {int(soil_layers)}, "
-            f"canopy_layers = {int(canopy_layers)})"
-        )
-        assert model.soil_layers == soil_layers
-        assert model.canopy_layers == canopy_layers
-
-    # Final check that expected logging entries are produced
-    log_check(caplog, expected_log_entries)
-
-
-@pytest.mark.parametrize(
-    "config,time_interval,raises,expected_log_entries",
-    [
-        (
-            {},
-            None,
-            pytest.raises(KeyError),
-            (),  # This error isn't handled so doesn't generate logging
-        ),
-        (
-            {
-                "core": {"timing": {"start_time": "2020-01-01"}},
-                "abiotic": {
-                    "soil_layers": 2,
-                    "canopy_layers": 3,
-                    "model_time_step": "12 hours",
-                },
-            },
-            timedelta64(12, "h"),
-            does_not_raise(),
-            (
-                (
-                    INFO,
-                    "Information required to initialise the abiotic model successfully "
-                    "extracted.",
-                ),
-            ),
-        ),
-    ],
-)
-def test_generate_abiotic_model(
-    caplog, config, time_interval, raises, expected_log_entries
-):
-    """Test that the function to initialise the soil model behaves as expected."""
-
-    # Check whether model is initialised (or not) as expected
-    with raises:
-        model = AbioticModel.from_config(config)
-        assert model.soil_layers == config["abiotic"]["soil_layers"]
-        assert model.canopy_layers == config["abiotic"]["canopy_layers"]
-        assert model.update_interval == time_interval
-        assert (
-            model.next_update
-            == datetime64(config["core"]["timing"]["start_time"]) + time_interval
-        )
-        # Run the update step and check that next_update has incremented properly
-        model.update()
-        assert (
-            model.next_update
-            == datetime64(config["core"]["timing"]["start_time"]) + 2 * time_interval
-        )
-
-    # Final check that expected logging entries are produced
     log_check(caplog, expected_log_entries)

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -77,13 +77,15 @@ class InitialisationError(Exception):
 
 
 class BaseModel(ABC):
-    """A superclass for all `vr` models.
+    """A superclass for all Virtual Rainforest models.
 
-    Describes the common functions and attributes that all `vr` models should have. This
-    includes functions to setup, spin up and update the specific model, as well as a
-    function to cleanup redundant model data. At this level these functions are not
-    define and are mere placeholders to be overwritten (where appropriate) by the
-    inheriting classes.
+    This abstract base class defines the shared common methods and attributes used as an
+    API across all Virtual Rainforest models. This includes functions to setup, spin up
+    and update the specific model, as well as a function to cleanup redundant model
+    data.
+
+    The base class defines the core abstract methods that must be defined in subclasses
+    as well as shared helper functions.
 
     Args:
         data: A :class:`~virtual_rainforest.core.data.Data` instance containing

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -2,9 +2,10 @@
 different models within the Virtual Rainforest. The module creates the
 :class:`~virtual_rainforest.core.models.BaseModel` abstract base class (ABC) which
 defines a consistent API for subclasses defining an actual model. The API defines
-abstract methods for each of the key stages in the workflow of running a model;
-individual subclasses will then need to implement the specific model behaviour within
-each stage. The stages are:
+abstract methods for each of the key stages in the workflow of running a model:
+individual subclasses are **required** to provide model specific implementations for
+each stage, although the specific methods may simply do nothing if no action is needed
+at that stage. The stages are:
 
 * Creating a model instance (:class:`~virtual_rainforest.core.models.BaseModel`).
 * Setup a model instance (:meth:`~virtual_rainforest.core.models.BaseModel.setup`).
@@ -15,101 +16,54 @@ each stage. The stages are:
 * Cleanup any unneeded resources at the end of a simulation
   (:meth:`~virtual_rainforest.core.models.BaseModel.cleanup`).
 
-As well as those methods representing workflow stages, the
-:class:`~virtual_rainforest.core.models.BaseModel` also provides
+The :class:`~virtual_rainforest.core.models.BaseModel` class also provides default
+implementations for the :func:`~virtual_rainforest.core.model.BaseModel.__repr__` and
+:func:`~virtual_rainforest.core.model.BaseModel.__str__` special methods.
 
+The :class:`~virtual_rainforest.core.models.BaseModel` has two class attributes that
+must be defined in subclasses:
 
-Creating a new model subclass
------------------------------
+* The :attr:`~virtual_rainforest.core.models.BaseModel.model_name` atttribute and
+* The :attr:`~virtual_rainforest.core.models.BaseModel.required_init_vars` attribute.
 
-
-Model configuration
--------------------
-
-As in the case of configuration schema, we make ``Model`` classes generally accessible
-by adding them to a registry
+The usage of these two attributes is described in their docstrings.
 
 Model registration
 ------------------
 
-The :class:`~virtual_rainforest.core.models.BaseModel` abstract base class also defines
-the :func:`~virtual_rainforest.core.model.BaseModel.__init_subclass__` class method.
-This method is called automatically whenever a subclass of the ABC is defined: it
-validates the class attributes for the new class and then registers the model name and
-model class in the called :attr:`~virtual_rainforest.core.model.MODEL_REGISTRY`
-register. This registry allows the configuration of a Virtual Rainforest simulation to
-look up and configure the required model components.
+The :class:`~virtual_rainforest.core.models.BaseModel` abstract base class defines the
+:func:`~virtual_rainforest.core.model.BaseModel.__init_subclass__` class method. This
+method is called automatically whenever a subclass of the ABC is imported: it validates
+the class attributes for the new class and then registers the model name and model class
+in the called :attr:`~virtual_rainforest.core.model.MODEL_REGISTRY` register. This
+registry is used to identify requested model subclasses from the configuration details
+from  Virtual Rainforest simulation.
 
+The ``BaseModel.__init__`` method
+----------------------------------
 
-, but that in every case a ``model_name`` has to be provided to register it under. This
-model name should be unique. Although registration is automatic, it only happens when
-class definition happens, which requires the module which defines the child class to be
-imported somewhere. At the moment, we import all child models in the top level
-``__init__.py`` to ensure that they are added to the registry.
+All subclasses **must** call the
+:meth:`~virtual_rainforest.core.models.BaseModel.__init__` method. This method does two
+things:
 
+* It populates the shared instance attributes
+  :attr:`~virtual_rainforest.core.models.BaseModel.data`,
+  :attr:`~virtual_rainforest.core.models.BaseModel.start_time` and
+  :attr:`~virtual_rainforest.core.models.BaseModel.update_interval`.
+* It uses the :meth:`~virtual_rainforest.core.models.BaseModel.check_required_init_vars`
+  to confirm that the required variables for the model are present in the ``data``
+  attribute.
 
-The :func:`~virtual_rainforest.core.model.BaseModel.from_config` factory method
--------------------------------------------------------------------------------
+The ``from_config`` factory method
+----------------------------------
 
-
-
- model: that is, a common set of functions which work
-the same across all modules. This cannot exist at a low level, as the basic classes and
-functions will differ massively between modules (e.g. :mod:`~virtual_rainforest.abiotic`
-will not have functions to handle consumption). So, this common api has to be high level
-and define a basic set of functions to set up and run each model. These functions
-effectively convert a general instruction (i.e. "setup the model") into the steps needed
-to carry out that instruction for a specific model.
-
-The :mod:`core.model` module defines the api that all individual models (e.g. the soil
-model) should conform to. This consists of a class
-(:class:`~virtual_rainforest.core.model.BaseModel`), which defines the expected
-functions. Some functions of this class will be inherited and used by its child classes
-(e.g. :func:`~virtual_rainforest.core.model.BaseModel.__repr__` and
-:func:`~virtual_rainforest.core.model.BaseModel.__str__`), unless they are explicitly
-overwritten in the child class (which is generally necessary for ``__init__``). This is
-standard python class inheritance, which will be used in many places throughout the
-``virtual_rainforest`` model.
-
-However, a more complex form of inheritance is required for functions that define the
-shared api. These should take the same input and perform an equivalent set of steps
-across models, but because they interact with radically different modules their internal
-workings will have little in common. Thus,
-:class:`~virtual_rainforest.core.model.BaseModel` is defined as an abstract base class,
-which is a class that is never intended to be instantiated itself but instead serves as
-a blueprint for inheriting classes. This type of class can define abstract methods
-(denoted by ``@abstractmethod``), which are merely placeholders. For these abstract
-methods, child classes have to overwrite the methods with new functions, otherwise class
-inheritance fails. This ensures that a consistent api (set of functions) is used across
-models, while also ensuring that functions don't default to an inappropriate generic
-behaviour due to a function not being defined for a particular model. At the moment, we
-expect every model to have a setup, spinup, update and cleanup process, though this
-might change in the future.
-
-We also define an abstract class method to perform model initialisation. This method
-(:func:`~virtual_rainforest.core.model.BaseModel.from_config`) is a factory method which
-unpacks the configuration dictionary, extracts the relevant tags and attempts to convert
-them into the form needed to initialise a class instance. This method must be defined
-for every child class of :class:`~virtual_rainforest.core.model.BaseModel`, as unpacking
-our complex configuration dictionary is a necessary before a class instance can be
-initialised.
-
-As in the case of configuration schema, we make ``Model`` classes generally accessible
-by adding them to a registry. However, in this case the function to add to the registry
-isn't a decorator but rather a member function of
-:class:`~virtual_rainforest.core.model.BaseModel`. The existence of this
-:func:`~virtual_rainforest.core.model.BaseModel.__init_subclass__` function means that
-every child class is automatically added to the model registry (called
-:attr:`~virtual_rainforest.core.model.MODEL_REGISTRY`), but that in every case a
-``model_name`` has to be provided to register it under. This model name should be
-unique. Although registration is automatic, it only happens when class definition
-happens, which requires the module which defines the child class to be imported
-somewhere. At the moment, we import all child models in the top level ``__init__.py`` to
-ensure that they are added to the registry.
-
-An example of ``Model`` inheritance from
-:class:`~virtual_rainforest.core.model.BaseModel` can been seen in the :mod:`soil.model`
-module.
+The ABC also defines the abstract class method
+:func:`~virtual_rainforest.core.model.BaseModel.from_config`. This method must be
+defined by subclasses and must be a factory method that takes a
+:class:`~virtual_rainforest.core.data.Data` instance and  a model specific configuration
+dictionary and returns an instance of the subclass. For any given model, the method
+should provide any code to validate the configuration and then use the configuration to
+initialise and return a new instance of the class.
 """  # noqa: D205, D415
 
 from __future__ import annotations
@@ -145,7 +99,6 @@ class BaseModel(ABC):
         data: A :class:`~virtual_rainforest.core.data.Data` instance containing
             variables to be used in the model.
         start_time: Point in time that the model simulation should be started.
-        end_time: Time that the model simulation should end
         update_interval: Time to wait between updates of the model state.
     """
 
@@ -204,7 +157,7 @@ class BaseModel(ABC):
 
     @classmethod
     @abstractmethod
-    def from_config(cls, config: dict[str, Any]) -> Any:
+    def from_config(cls, data: Data, config: dict[str, Any]) -> Any:
         """Factory function to unpack config and initialise a model instance."""
 
     @classmethod

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -228,10 +228,7 @@ class BaseModel(ABC):
 
     def __str__(self) -> str:
         """Inform user what the model type is."""
-        if hasattr(self, "model_name"):
-            return f"A {self.model_name} model instance"
-        else:
-            return "A base model instance"
+        return f"A {self.model_name} model instance"
 
     def check_required_init_vars(self) -> None:
         """Check the required set of variables is present.

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -163,7 +163,7 @@ class BaseModel(ABC):
 
     @classmethod
     @abstractmethod
-    def from_config(cls, data: Data, config: dict[str, Any]) -> Any:
+    def from_config(cls, data: Data, config: dict[str, Any]) -> BaseModel:
         """Factory function to unpack config and initialise a model instance."""
 
     @classmethod

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -254,23 +254,26 @@ class BaseModel(ABC):
             # Record when a variable is missing
             if var not in self.data:
                 LOGGER.error(
-                    f"Required init variable '{var}' missing from data in "
-                    "{self.model_name} model."
+                    f"{self.model_name} model: init data missing required var '{var}'"
                 )
                 all_vars_found = False
                 continue
 
-            # Check for required axes
+            # Get a list of missing axes
+            bad_axes = []
             for axis in axes:
-                axis_ok = self.data.on_core_axis(var, axis)
+                if not self.data.on_core_axis(var, axis):
+                    bad_axes.append(axis)
 
-                if not axis_ok:
-                    LOGGER.error(
-                        f"Required init variable '{var}' not on core axis '{axis}' in "
-                        "{self.model_name} model."
-                    )
-
-                    all_axes_ok = False
+            # Log the outcome
+            if bad_axes:
+                LOGGER.error(
+                    f"{self.model_name} model: required var '{var}' "
+                    f"not on axes {','.join(bad_axes)}"
+                )
+                all_axes_ok = False
+            else:
+                LOGGER.debug(f"{self.model_name} model: required var '{var}' checked")
 
         # Raise if any problems found
         if not (all_axes_ok and all_vars_found):

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -181,20 +181,25 @@ class BaseModel(ABC):
 
         excep: Exception
 
-        # Check that model_name exists and is a string
-        if not hasattr(cls, "model_name"):
-            excep = ValueError("Models must have a model_name attribute!")
+        # Check that model_name exists and is a string - if it is not implemented in the
+        # subclass then the object will be of type property
+        if isinstance(cls.model_name, property):
+            excep = NotImplementedError(
+                f"Property model_name is not implemented in {cls.__name__}"
+            )
             LOGGER.error(excep)
             raise excep
 
         if not isinstance(cls.model_name, str):
-            excep = TypeError("Models should only be named using strings!")
+            excep = TypeError(f"Property model_name in {cls.__name__} is not a string")
             LOGGER.error(excep)
             raise excep
 
-        # Check that required_init_vars is set - not testing structure here
-        if not hasattr(cls, "required_init_vars"):
-            excep = ValueError("BaseModel subclasses must define required_init_vars")
+        # Check that required_init_vars is set - TODO - not testing structure here
+        if isinstance(cls.required_init_vars, property):
+            excep = NotImplementedError(
+                f"Property required_init_vars is not implemented in {cls.__name__}"
+            )
             LOGGER.error(excep)
             raise excep
 

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -94,6 +94,22 @@ class BaseModel(ABC):
     """
 
     model_name: str
+    """The model name.
+
+    This class attribute sets the name used to refer to identify the model class in the
+    :data:`~virtual_rainforest.core.model.MODEL_REGISTRY`, within the configuration
+    settings and in logging messages."""
+
+    required_init_vars: list[tuple[str, tuple[str]]]
+    """Required variables for model initialisation.
+
+    This class attribute defines a set of variable names that must be present in the
+    :class:`~virtual_rainforest.core.data.Data` instance used to initialise an instance
+    of this class. It is a list of variable names and then optionally the names of any
+    core axes which the variable must map onto.
+
+    For example: ``[('temperature', ('spatial', 'temporal'))]``
+    """
 
     def __init__(
         self,
@@ -105,8 +121,9 @@ class BaseModel(ABC):
         self.data = data
         """A Data instance providing access to the shared simulation data."""
         self.update_interval = update_interval
+        """The time interval between model updates."""
         self.next_update = start_time + update_interval
-        # Save variables names to be used by the __repr__
+        """The simulation time at which the model should next run the update method"""
         self._repr = ["update_interval", "next_update"]
 
     @abstractmethod
@@ -142,11 +159,18 @@ class BaseModel(ABC):
         # Check that model_name exists and is a string
         if not hasattr(cls, "model_name"):
             excep = ValueError("Models must have a model_name attribute!")
-            LOGGER.critical(excep)
+            LOGGER.error(excep)
             raise excep
-        elif not isinstance(cls.model_name, str):
+
+        if not isinstance(cls.model_name, str):
             excep = TypeError("Models should only be named using strings!")
-            LOGGER.critical(excep)
+            LOGGER.error(excep)
+            raise excep
+
+        # Check that required_init_vars is set - not testing structure here
+        if not hasattr(cls, "required_init_vars"):
+            excep = ValueError("BaseModel subclasses must define required_init_vars")
+            LOGGER.error(excep)
             raise excep
 
         # Add the new model to the registry

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -205,10 +205,15 @@ class BaseModel(ABC):
 
         # Add the new model to the registry
         if cls.model_name in MODEL_REGISTRY:
+            old_class_name = MODEL_REGISTRY[cls.model_name].__name__
             LOGGER.warning(
-                "Model with name %s already exists and is being replaced",
+                "%s already registered under name '%s', replaced with %s",
+                old_class_name,
                 cls.model_name,
+                cls.__name__,
             )
+        else:
+            LOGGER.info("%s registered under name '%s'", cls.__name__, cls.model_name)
 
         MODEL_REGISTRY[cls.model_name] = cls
 

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -1,5 +1,59 @@
-"""The :mod:`~virtual_rainforest.core.model` module provides a consistent API across
-models for the Virtual Rainforest model: that is, a common set of functions which work
+"""The :mod:`~virtual_rainforest.core.model` module defines the high level API for the
+different models within the Virtual Rainforest. The module creates the
+:class:`~virtual_rainforest.core.models.BaseModel` abstract base class (ABC) which
+defines a consistent API for subclasses defining an actual model. The API defines
+abstract methods for each of the key stages in the workflow of running a model;
+individual subclasses will then need to implement the specific model behaviour within
+each stage. The stages are:
+
+* Creating a model instance (:class:`~virtual_rainforest.core.models.BaseModel`).
+* Setup a model instance (:meth:`~virtual_rainforest.core.models.BaseModel.setup`).
+* Perform any spinup required to get a model state to equilibrate
+  (:meth:`~virtual_rainforest.core.models.BaseModel.spinup`).
+* Update the model from one time step to the next
+  :meth:`~virtual_rainforest.core.models.BaseModel.update`).
+* Cleanup any unneeded resources at the end of a simulation
+  (:meth:`~virtual_rainforest.core.models.BaseModel.cleanup`).
+
+As well as those methods representing workflow stages, the
+:class:`~virtual_rainforest.core.models.BaseModel` also provides
+
+
+Creating a new model subclass
+-----------------------------
+
+
+Model configuration
+-------------------
+
+As in the case of configuration schema, we make ``Model`` classes generally accessible
+by adding them to a registry
+
+Model registration
+------------------
+
+The :class:`~virtual_rainforest.core.models.BaseModel` abstract base class also defines
+the :func:`~virtual_rainforest.core.model.BaseModel.__init_subclass__` class method.
+This method is called automatically whenever a subclass of the ABC is defined: it
+validates the class attributes for the new class and then registers the model name and
+model class in the called :attr:`~virtual_rainforest.core.model.MODEL_REGISTRY`
+register. This registry allows the configuration of a Virtual Rainforest simulation to
+look up and configure the required model components.
+
+
+, but that in every case a ``model_name`` has to be provided to register it under. This
+model name should be unique. Although registration is automatic, it only happens when
+class definition happens, which requires the module which defines the child class to be
+imported somewhere. At the moment, we import all child models in the top level
+``__init__.py`` to ensure that they are added to the registry.
+
+
+The :func:`~virtual_rainforest.core.model.BaseModel.from_config` factory method
+-------------------------------------------------------------------------------
+
+
+
+ model: that is, a common set of functions which work
 the same across all modules. This cannot exist at a low level, as the basic classes and
 functions will differ massively between modules (e.g. :mod:`~virtual_rainforest.abiotic`
 will not have functions to handle consumption). So, this common api has to be high level

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -65,6 +65,7 @@ from typing import Any, Type
 
 from numpy import datetime64, timedelta64
 
+from virtual_rainforest.core.data import Data
 from virtual_rainforest.core.logger import LOGGER
 
 MODEL_REGISTRY: dict[str, Type[BaseModel]] = {}
@@ -85,6 +86,8 @@ class BaseModel(ABC):
     inheriting classes.
 
     Args:
+        data: A :class:`~virtual_rainforest.core.data.Data` instance containing
+            variables to be used in the model.
         start_time: Point in time that the model simulation should be started.
         end_time: Time that the model simulation should end
         update_interval: Time to wait between updates of the model state.
@@ -93,8 +96,14 @@ class BaseModel(ABC):
     model_name: str
 
     def __init__(
-        self, update_interval: timedelta64, start_time: datetime64, **kwargs: Any
+        self,
+        data: Data,
+        update_interval: timedelta64,
+        start_time: datetime64,
+        **kwargs: Any,
     ):
+        self.data = data
+        """A Data instance providing access to the shared simulation data."""
         self.update_interval = update_interval
         self.next_update = start_time + update_interval
         # Save variables names to be used by the __repr__

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -102,23 +102,28 @@ class BaseModel(ABC):
         update_interval: Time to wait between updates of the model state.
     """
 
-    model_name: str
-    """The model name.
+    @property
+    @abstractmethod
+    def model_name(cls) -> str:
+        """The model name.
 
-    This class attribute sets the name used to refer to identify the model class in the
-    :data:`~virtual_rainforest.core.model.MODEL_REGISTRY`, within the configuration
-    settings and in logging messages."""
+        This class property sets the name used to refer to identify the model class in
+        the :data:`~virtual_rainforest.core.model.MODEL_REGISTRY`, within the
+        configuration settings and in logging messages.
+        """
 
-    required_init_vars: list[tuple[str, tuple[str]]]
-    """Required variables for model initialisation.
+    @property
+    @abstractmethod
+    def required_init_vars(cls) -> list[tuple[str, tuple[str]]]:
+        """Required variables for model initialisation.
 
-    This class attribute defines a set of variable names that must be present in the
-    :class:`~virtual_rainforest.core.data.Data` instance used to initialise an instance
-    of this class. It is a list of variable names and then optionally the names of any
-    core axes which the variable must map onto.
+        This class property defines a set of variable names that must be present in the
+        :class:`~virtual_rainforest.core.data.Data` instance used to initialise an
+        instance of this class. It is a list of variable names and then optionally the
+        names of any core axes which the variable must map onto.
 
-    For example: ``[('temperature', ('spatial', 'temporal'))]``
-    """
+        For example: ``[('temperature', ('spatial', 'temporal'))]``
+        """
 
     def __init__(
         self,
@@ -168,6 +173,8 @@ class BaseModel(ABC):
             ValueError: If model_name attribute isn't defined
             TypeError: If model_name is not a string
         """
+
+        excep: Exception
 
         # Check that model_name exists and is a string
         if not hasattr(cls, "model_name"):

--- a/virtual_rainforest/core/model.py
+++ b/virtual_rainforest/core/model.py
@@ -167,10 +167,15 @@ class BaseModel(ABC):
 
     @classmethod
     def __init_subclass__(cls) -> None:
-        """Method that adds new model classes to the model registry.
+        """Initialise subclasses deriving from BaseModel.
+
+        This method runs when a new BaseModel subclass is imported. It adds the new
+        subclasses to the model registry and validates the values of the class
+        properties.
 
         Raises:
-            ValueError: If model_name attribute isn't defined
+            ValueError: If the model_name or required_init_vars properties are not
+                defined
             TypeError: If model_name is not a string
         """
 

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -11,6 +11,8 @@ import pint
 from numpy import datetime64, timedelta64
 
 from virtual_rainforest.core.config import validate_config
+from virtual_rainforest.core.data import Data
+from virtual_rainforest.core.grid import Grid
 from virtual_rainforest.core.logger import LOGGER
 from virtual_rainforest.core.model import MODEL_REGISTRY, BaseModel, InitialisationError
 
@@ -53,12 +55,13 @@ def select_models(model_list: list[str]) -> list[Type[BaseModel]]:
 
 
 def configure_models(
-    config: dict[str, Any], model_list: list[Type[BaseModel]]
+    config: dict[str, Any], data: Data, model_list: list[Type[BaseModel]]
 ) -> dict[str, BaseModel]:
     """Configure a set of models for use in a `virtual_rainforest` simulation.
 
     Args:
         config: The full virtual rainforest configuration
+        data: A Data instance.
         modules: A set of models to be configured
 
     Raises:
@@ -70,7 +73,8 @@ def configure_models(
     models_cfd = {}
     for model in model_list:
         try:
-            models_cfd[model.model_name] = model.from_config(config)
+            this_model = model.from_config(data, config)
+            models_cfd[this_model.model_name] = this_model
         except InitialisationError:
             failed_models.append(model.model_name)
 
@@ -201,11 +205,15 @@ def vr_run(
 
     config = validate_config(cfg_paths, merge_file_path)
 
+    grid = Grid()  # TODO - this needs a Grid.from_config factory function
+    data = Data(grid)
+    data.load_data_config(config["core"]["data"])
+
     model_list = select_models(config["core"]["modules"])
 
     LOGGER.info("All models found in the registry, now attempting to configure them.")
 
-    models_cfd = configure_models(config, model_list)
+    models_cfd = configure_models(config, data, model_list)
 
     LOGGER.info(
         "All models successfully configured, now attempting to initialise them."
@@ -241,7 +249,7 @@ def vr_run(
         # Run their update() method and update due dates for all expired models
         for mod_nm in update_needed:
             models_cfd[mod_nm].update()
-            update_due[mod_nm] = models_cfd[mod_nm].next_update()
+            update_due[mod_nm] = models_cfd[mod_nm].next_update
 
         # TODO - Save model state
 

--- a/virtual_rainforest/models/abiotic/model.py
+++ b/virtual_rainforest/models/abiotic/model.py
@@ -10,6 +10,7 @@ from typing import Any
 import pint
 from numpy import datetime64, timedelta64
 
+from virtual_rainforest.core.data import Data
 from virtual_rainforest.core.logger import LOGGER
 from virtual_rainforest.core.model import BaseModel, InitialisationError
 
@@ -29,9 +30,11 @@ class AbioticModel(BaseModel):
     """
 
     model_name = "abiotic"
+    required_init_vars = []
 
     def __init__(
         self,
+        data: Data,
         update_interval: timedelta64,
         start_time: datetime64,
         soil_layers: int,
@@ -66,7 +69,7 @@ class AbioticModel(BaseModel):
             LOGGER.error(to_raise)
             raise to_raise
 
-        super().__init__(update_interval, start_time, **kwargs)
+        super().__init__(data, update_interval, start_time, **kwargs)
         self.soil_layers = int(soil_layers)
         self.canopy_layers = int(canopy_layers)
         # Save variables names to be used by the __repr__
@@ -74,7 +77,7 @@ class AbioticModel(BaseModel):
         self._repr.append("canopy_layers")
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> AbioticModel:
+    def from_config(cls, data: Data, config: dict[str, Any]) -> AbioticModel:
         """Factory function to initialise the abiotic model from configuration.
 
         This function unpacks the relevant information from the configuration file, and
@@ -82,6 +85,7 @@ class AbioticModel(BaseModel):
         invalid rather than returning an initialised model instance None is returned.
 
         Args:
+            data: A :class:`~virtual_rainforest.core.data.Data` instance.
             config: The complete (and validated) virtual rainforest configuration.
 
         Raises:
@@ -116,7 +120,7 @@ class AbioticModel(BaseModel):
                 "Information required to initialise the abiotic model successfully "
                 "extracted."
             )
-            return cls(update_interval, start_time, soil_layers, canopy_layers)
+            return cls(data, update_interval, start_time, soil_layers, canopy_layers)
         else:
             raise InitialisationError()
 

--- a/virtual_rainforest/models/soil/model.py
+++ b/virtual_rainforest/models/soil/model.py
@@ -22,6 +22,7 @@ from typing import Any
 import pint
 from numpy import datetime64, timedelta64
 
+from virtual_rainforest.core.data import Data
 from virtual_rainforest.core.logger import LOGGER
 from virtual_rainforest.core.model import BaseModel, InitialisationError
 
@@ -41,9 +42,11 @@ class SoilModel(BaseModel):
 
     model_name = "soil"
     """The model name for use in registering the model and logging."""
+    required_init_vars = []
 
     def __init__(
         self,
+        data: Data,
         update_interval: timedelta64,
         start_time: datetime64,
         no_layers: int,
@@ -63,13 +66,13 @@ class SoilModel(BaseModel):
             LOGGER.error(to_raise)
             raise to_raise
 
-        super().__init__(update_interval, start_time, **kwargs)
+        super().__init__(data, update_interval, start_time, **kwargs)
         self.no_layers = int(no_layers)
         # Save variables names to be used by the __repr__
         self._repr.append("no_layers")
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> SoilModel:
+    def from_config(cls, data: Data, config: dict[str, Any]) -> SoilModel:
         """Factory function to initialise the soil model from configuration.
 
         This function unpacks the relevant information from the configuration file, and
@@ -77,6 +80,7 @@ class SoilModel(BaseModel):
         invalid rather than returning an initialised model instance an error is raised.
 
         Args:
+            data: A :class:`~virtual_rainforest.core.data.Data` instance.
             config: The complete (and validated) Virtual Rainforest configuration.
 
         Raises:
@@ -110,7 +114,7 @@ class SoilModel(BaseModel):
                 "Information required to initialise the soil model successfully "
                 "extracted."
             )
-            return cls(update_interval, start_time, no_layers)
+            return cls(data, update_interval, start_time, no_layers)
         else:
             raise InitialisationError()
 


### PR DESCRIPTION
# Description

This PR:

1. Makes a `Data` object a core part of model creation, by adding it to the `__init__` method for the `BaseModel` ABC. All subclasses now have a way to connect through to a shared `Data`instance.
2. Adds the `required_init_vars` property to `BaseModel` and adds running the new `check_required_init_vars` to the `BaseModel.__init__` method. Model subclasses can now define what variables (and on what axes) they need in Data to successfully `__init__` via that property. (Discussed #97)
3. Makes the two class properties (`model_name` and `required_init_vars`) part of the abstract BaseModel API, rather than just class attributes.
4. Updates `__init_subclass__`
5. Updates `test_model.py` to add new tests for.
6. Updates module docstring.
7. Updates `main.py`, `test_main.py` and existing models to match new signatures.

Fixes #97

Some notes:

* I wanted to use a parameterised test for `__init_subclass_` because there are multiple new subclass failure modes. That is awkward because the new class has to be defined within the test. I've used `exec()` to run the different subclass attempts within the model. That feels a bit clumsy but I can't see a better way and I don't think it is actively harmful.
* This PR has revealed that we need a new `Grid.from_config` function but I'll leave that for another PR.
* The `test_main.py` tests are using the `SoilModel` as a demo - that is a constantly moving target as that model develops so we should probably just define a new test BaseModel subclass in here for use in testing `main.py`.


## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
