### PR TITLE
API links updated to new model names

### DIFF
--- a/docs/source/api/abiotic.md
+++ b/docs/source/api/abiotic.md
@@ -16,13 +16,6 @@ kernelspec:
 
 # API reference for `abiotic` modules
 
-The {mod}`~virtual_rainforest.models.abiotic` module is one of the component models of
-the Virtual Rainforest. It is comprised of several submodules that calculate the
-radiation balance, the energy balance, the water balance and the atmospheric CO2
-balance.
-
-Each of the abiotic sub-modules has its own API reference page:
-
-* The {mod}`~virtual_rainforest.models.abiotic.abiotic_model` submodule instantiates the
-  AbioticModel class which consolidates the functionality of the abiotic module into a
-  single class, which the high level functions of the Virtual Rainforest can then use.
+```{eval-rst}
+.. automodule:: virtual_rainforest.models.abiotic
+```

--- a/docs/source/api/abiotic.md
+++ b/docs/source/api/abiotic.md
@@ -23,6 +23,6 @@ balance.
 
 Each of the abiotic sub-modules has its own API reference page:
 
-* The {mod}`~virtual_rainforest.models.abiotic.model` submodule instantiates the
+* The {mod}`~virtual_rainforest.models.abiotic.abiotic_model` submodule instantiates the
   AbioticModel class which consolidates the functionality of the abiotic module into a
   single class, which the high level functions of the Virtual Rainforest can then use.

--- a/docs/source/api/abiotic/abiotic_model.md
+++ b/docs/source/api/abiotic/abiotic_model.md
@@ -14,7 +14,7 @@ kernelspec:
   name: vr_python3
 ---
 
-# API documentation for the {mod}`~virtual_rainforest.models.abiotic.model` module
+# API documentation for the {mod}`~virtual_rainforest.models.abiotic.abiotic_model` module
 
 ```{eval-rst}
 .. automodule:: virtual_rainforest.models.abiotic.abiotic_model

--- a/docs/source/api/abiotic/abiotic_model.md
+++ b/docs/source/api/abiotic/abiotic_model.md
@@ -17,7 +17,7 @@ kernelspec:
 # API documentation for the {mod}`~virtual_rainforest.models.abiotic.model` module
 
 ```{eval-rst}
-.. automodule:: virtual_rainforest.models.abiotic.model
+.. automodule:: virtual_rainforest.models.abiotic.abiotic_model
     :autosummary:
     :members:
     :special-members: __init_subclass__, __repr__, __str__

--- a/docs/source/api/abiotic/abiotic_model.md
+++ b/docs/source/api/abiotic/abiotic_model.md
@@ -14,7 +14,7 @@ kernelspec:
   name: vr_python3
 ---
 
-# API documentation for the {mod}`~virtual_rainforest.models.abiotic.abiotic_model` module
+# API documentation for the {mod}`~virtual_rainforest.models.abiotic_model` module
 
 ```{eval-rst}
 .. automodule:: virtual_rainforest.models.abiotic.abiotic_model

--- a/docs/source/api/abiotic/abiotic_model.md
+++ b/docs/source/api/abiotic/abiotic_model.md
@@ -14,7 +14,7 @@ kernelspec:
   name: vr_python3
 ---
 
-# API documentation for the {mod}`~virtual_rainforest.models.abiotic_model` module
+# API documentation for the {mod}`~virtual_rainforest.models.abiotic.abiotic_model` module
 
 ```{eval-rst}
 .. automodule:: virtual_rainforest.models.abiotic.abiotic_model

--- a/docs/source/api/core.md
+++ b/docs/source/api/core.md
@@ -35,7 +35,7 @@ Each of the core sub-modules has its own API reference page:
   ensure that it is congruent with the model configuration.
 * The {mod}`~virtual_rainforest.core.readers` submodule provides functionality to read
   external data files into a standard internal format.
-* The {mod}`~virtual_rainforest.core.model` submodule provides an Abstract
+* The {mod}`~virtual_rainforest.core.base_model` submodule provides an Abstract
   Base Class describing the shared API to be used by science models within the Virtual
   Rainforest.
 * The {mod}`~virtual_rainforest.core.logger` configures the {class}`~logging.LOGGER`

--- a/docs/source/api/core.md
+++ b/docs/source/api/core.md
@@ -16,27 +16,6 @@ kernelspec:
 
 # API reference for `core` modules
 
-The {mod}`~virtual_rainforest.core` module contains the key shared resources and
-building blocks used to develop the different component models of the Virtual Rainforest
-and then to configure them, populate them with data and provide logging.
-
-Each of the core sub-modules has its own API reference page:
-
-* The {mod}`~virtual_rainforest.core.config` submodule covers the
-  definition of formal configuration schema for components and the parsing and
-  validation of TOML configuration documents against those schema.
-* The {mod}`~virtual_rainforest.core.grid` submodule covers the
-  definition of the spatial layout to be used in a simulation and provides an interface
-  to the spatial relationships between cells.
-* The {mod}`~virtual_rainforest.core.data` submodule provides the
-  central data object used to store data required by the simulation and methods to
-  populate that data object for use in simulations.
-* The {mod}`~virtual_rainforest.core.axes` submodule provides validation for data to
-  ensure that it is congruent with the model configuration.
-* The {mod}`~virtual_rainforest.core.readers` submodule provides functionality to read
-  external data files into a standard internal format.
-* The {mod}`~virtual_rainforest.core.base_model` submodule provides an Abstract
-  Base Class describing the shared API to be used by science models within the Virtual
-  Rainforest.
-* The {mod}`~virtual_rainforest.core.logger` configures the {class}`~logging.LOGGER`
-  instance used throughout the package.
+```{eval-rst}
+.. automodule:: virtual_rainforest.core
+```

--- a/docs/source/api/core/base_model.md
+++ b/docs/source/api/core/base_model.md
@@ -14,7 +14,7 @@ kernelspec:
   name: vr_python3
 ---
 
-# API documentation for the {mod}`~virtual_rainforest.core.model` module
+# API documentation for the {mod}`~virtual_rainforest.core.base_model` module
 
 ```{eval-rst}
 .. automodule:: virtual_rainforest.core.base_model

--- a/docs/source/api/core/base_model.md
+++ b/docs/source/api/core/base_model.md
@@ -17,7 +17,7 @@ kernelspec:
 # API documentation for the {mod}`~virtual_rainforest.core.model` module
 
 ```{eval-rst}
-.. automodule:: virtual_rainforest.core.model
+.. automodule:: virtual_rainforest.core.base_model
     :autosummary:
     :members:
     :special-members: __init_subclass__, __repr__, __str__

--- a/docs/source/api/core/data.md
+++ b/docs/source/api/core/data.md
@@ -20,5 +20,5 @@ kernelspec:
 .. automodule:: virtual_rainforest.core.data
     :autosummary:
     :members:
-    :special-members: __repr__, __set_item__, __get_item__, __contains__
+    :special-members: __repr__, __setitem__, __getitem__, __contains__
 ```

--- a/docs/source/api/soil.md
+++ b/docs/source/api/soil.md
@@ -21,7 +21,7 @@ Virtual Rainforest. It is comprised of a number of submodules.
 
 Each of the soil sub-modules has its own API reference page:
 
-* The {mod}`~virtual_rainforest.models.soil.model` submodule instantiates the SoilModel
+* The {mod}`~virtual_rainforest.models.soil.soil_model` submodule instantiates the SoilModel
   class which consolidates the functionality of the soil module into a single class,
   which the high level functions of the Virtual Rainforest can then make use of.
 * The {mod}`~virtual_rainforest.models.soil.carbon` provides a model for the soil carbon

--- a/docs/source/api/soil.md
+++ b/docs/source/api/soil.md
@@ -16,13 +16,6 @@ kernelspec:
 
 # API reference for `soil` modules
 
-The {mod}`~virtual_rainforest.models.soil` module is one of the component models of the
-Virtual Rainforest. It is comprised of a number of submodules.
-
-Each of the soil sub-modules has its own API reference page:
-
-* The {mod}`~virtual_rainforest.models.soil.soil_model` submodule instantiates the SoilModel
-  class which consolidates the functionality of the soil module into a single class,
-  which the high level functions of the Virtual Rainforest can then make use of.
-* The {mod}`~virtual_rainforest.models.soil.carbon` provides a model for the soil carbon
-  cycle.
+```{eval-rst}
+.. automodule:: virtual_rainforest.models.soil
+```

--- a/docs/source/api/soil/carbon.md
+++ b/docs/source/api/soil/carbon.md
@@ -14,7 +14,7 @@ kernelspec:
   name: vr_python3
 ---
 
-# API documentation for the {mod}`~virtual_rainforest.soil.carbon` module
+# API documentation for the {mod}`~virtual_rainforest.models.soil.carbon` module
 
 ```{eval-rst}
 .. automodule:: virtual_rainforest.models.soil.carbon

--- a/docs/source/api/soil/constants.md
+++ b/docs/source/api/soil/constants.md
@@ -1,0 +1,23 @@
+---
+jupytext:
+  cell_metadata_filter: -all
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.8
+kernelspec:
+  display_name: vr_python3
+  language: python
+  name: vr_python3
+---
+
+# API documentation for the {mod}`~virtual_rainforest.models.soil.constants` module
+
+```{eval-rst}
+.. automodule:: virtual_rainforest.models.soil.constants
+    :autosummary:
+    :members:
+```

--- a/docs/source/api/soil/soil_model.md
+++ b/docs/source/api/soil/soil_model.md
@@ -14,7 +14,7 @@ kernelspec:
   name: vr_python3
 ---
 
-# API documentation for the {mod}`~virtual_rainforest.soil.model` module
+# API documentation for the {mod}`~virtual_rainforest.soil.soil_model` module
 
 ```{eval-rst}
 .. automodule:: virtual_rainforest.models.soil.soil_model

--- a/docs/source/api/soil/soil_model.md
+++ b/docs/source/api/soil/soil_model.md
@@ -14,7 +14,7 @@ kernelspec:
   name: vr_python3
 ---
 
-# API documentation for the {mod}`~virtual_rainforest.soil.soil_model` module
+# API documentation for the {mod}`~virtual_rainforest.models.soil.soil_model` module
 
 ```{eval-rst}
 .. automodule:: virtual_rainforest.models.soil.soil_model

--- a/docs/source/api/soil/soil_model.md
+++ b/docs/source/api/soil/soil_model.md
@@ -17,7 +17,7 @@ kernelspec:
 # API documentation for the {mod}`~virtual_rainforest.soil.model` module
 
 ```{eval-rst}
-.. automodule:: virtual_rainforest.models.soil.model
+.. automodule:: virtual_rainforest.models.soil.soil_model
     :autosummary:
     :members:
 ```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,6 +75,7 @@ nitpicky = True
 nitpick_ignore = [
     ("py:class", "jsonschema.validators.Draft202012Validator"),
     ("py:class", "numpy.float32"),
+    ("py:class", "numpy.int64"),
 ]
 intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,7 +76,8 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "python": ("https://docs.python.org/3/", None),
     "xarray": ("https://docs.xarray.dev/en/stable/", None),
-    "shapely": ("https://shapely.readthedocs.io/en/latest/", None),
+    "shapely": ("https://shapely.readthedocs.io/en/stable/", None),
+    "jsonschema": ("https://python-jsonschema.readthedocs.io/en/stable/", None),
 }
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,6 +74,7 @@ autosummary_generate = True
 nitpicky = True
 nitpick_ignore = [
     ("py:class", "jsonschema.validators.Draft202012Validator"),
+    ("py:class", "numpy.float32"),
 ]
 intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,6 +72,9 @@ autosummary_generate = True
 
 # Reference checking
 nitpicky = True
+nitpick_ignore = [
+    ("py:class", "jsonschema.validators.Draft202012Validator"),
+]
 intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "python": ("https://docs.python.org/3/", None),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,6 +58,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "autodocsumm",
     "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.autosummary",
     # "sphinx.ext.autosectionlabel",  # Generates hard to trace exception
@@ -68,6 +69,16 @@ extensions = [
 ]
 autodoc_default_flags = ["members"]
 autosummary_generate = True
+
+# Reference checking
+nitpicky = True
+intersphinx_mapping = {
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "python": ("https://docs.python.org/3/", None),
+    "xarray": ("https://docs.xarray.dev/en/stable/", None),
+    "shapely": ("https://shapely.readthedocs.io/en/latest/", None),
+}
+
 
 # Set auto labelling to section level
 autosectionlabel_prefix_document = True

--- a/docs/source/development/defining_new_models.md
+++ b/docs/source/development/defining_new_models.md
@@ -47,7 +47,7 @@ from virtual_rainforest.core.logger import LOGGER
 # New model class will inherit from BaseModel.
 # InitialisationError is a custom exception, for case where a `Model` class cannot be
 # properly initialised based on the data contained in the configuration
-from virtual_rainforest.core.model import BaseModel, InitialisationError
+from virtual_rainforest.core.base_model import BaseModel, InitialisationError
 ```
 
 The new model class is created using a class method, which means that the model is

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -89,6 +89,7 @@ team.
   Soil Overview <api/soil.md>
   Soil Model <api/soil/soil_model.md>
   Soil Carbon <api/soil/carbon.md>
+  Soil Constants <api/soil/constants.md>
   Abiotic Overview <api/abiotic.md>
   Abiotic Model <api/abiotic/abiotic_model.md>
 ```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -85,12 +85,12 @@ team.
   Data <api/core/data.md>
   File readers <api/core/readers.md>
   Core axes <api/core/axes.md>
-  Base Model <api/core/model.md>
+  Base Model <api/core/base_model.md>
   Soil Overview <api/soil.md>
-  Soil Model <api/soil/model.md>
+  Soil Model <api/soil/soil_model.md>
   Soil Carbon <api/soil/carbon.md>
   Abiotic Overview <api/abiotic.md>
-  Abiotic Model <api/abiotic/model.md>
+  Abiotic Model <api/abiotic/abiotic_model.md>
 ```
 
 ```{eval-rst}

--- a/docs/source/virtual_rainforest/core/data.md
+++ b/docs/source/virtual_rainforest/core/data.md
@@ -103,7 +103,7 @@ two methods:
 data['var_name'] = load_to_dataarray('path/to/file.nc', var='temperature')
 ```
 
-1. The  {meth}`~virtual_rainforest.core.data.Data.load_from_config` method takes a
+1. The  {meth}`~virtual_rainforest.core.data.Data.load_data_config` method takes a
    loaded Data configuration - which is a set of named variables and source files - and
    then just uses {func}`~virtual_rainforest.core.readers.load_to_dataarray` to try and
    load each one.

--- a/tests/core/test_base_model.py
+++ b/tests/core/test_base_model.py
@@ -1,7 +1,7 @@
-"""Test module for model.py.
+"""Test module for base_model.py.
 
-This module tests the functionality of model.py, which defines the basic model API that
-specific models (e.g. `soil_model.py`) utilise.
+This module tests the functionality of base_model.py, which defines the basic model API
+that specific models (e.g. `soil_model.py`) utilise.
 """
 
 from contextlib import nullcontext as does_not_raise
@@ -11,7 +11,7 @@ import pytest
 from numpy import datetime64, timedelta64
 
 from tests.conftest import log_check
-from virtual_rainforest.core.model import BaseModel
+from virtual_rainforest.core.base_model import BaseModel
 
 
 def test_base_model_initialization(caplog, mocker):

--- a/tests/models/abiotic/test_abiotic_model.py
+++ b/tests/models/abiotic/test_abiotic_model.py
@@ -7,7 +7,7 @@ import pytest
 from numpy import datetime64, timedelta64
 
 from tests.conftest import log_check
-from virtual_rainforest.core.model import InitialisationError
+from virtual_rainforest.core.base_model import InitialisationError
 from virtual_rainforest.models.abiotic.abiotic_model import AbioticModel
 
 

--- a/tests/models/soil/test_carbon.py
+++ b/tests/models/soil/test_carbon.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 from tests.conftest import log_check
-from virtual_rainforest.core.model import InitialisationError
+from virtual_rainforest.core.base_model import InitialisationError
 from virtual_rainforest.models.soil.carbon import SoilCarbonPools
 
 

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -7,7 +7,7 @@ import pytest
 from numpy import datetime64, timedelta64
 
 from tests.conftest import log_check
-from virtual_rainforest.core.model import InitialisationError
+from virtual_rainforest.core.base_model import InitialisationError
 from virtual_rainforest.models.soil.soil_model import SoilModel
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 from numpy import datetime64, timedelta64
 
-from virtual_rainforest.core.model import BaseModel, InitialisationError
+from virtual_rainforest.core.base_model import BaseModel, InitialisationError
 from virtual_rainforest.main import (
     check_for_fast_models,
     configure_models,

--- a/virtual_rainforest/core/__init__.py
+++ b/virtual_rainforest/core/__init__.py
@@ -1,3 +1,32 @@
+"""The :mod:`~virtual_rainforest.core` module contains the key shared resources and
+building blocks used to develop the different component models of the Virtual Rainforest
+and then to configure them, populate them with data and provide logging.
+
+Each of the core sub-modules has its own API reference page:
+
+* The :mod:`~virtual_rainforest.core.config` submodule covers the
+  definition of formal configuration schema for components and the parsing and
+  validation of TOML configuration documents against those schema.
+* The :mod:`~virtual_rainforest.core.grid` submodule covers the
+  definition of the spatial layout to be used in a simulation and provides an interface
+  to the spatial relationships between cells.
+* The :mod:`~virtual_rainforest.core.data` submodule provides the
+  central data object used to store data required by the simulation and methods to
+  populate that data object for use in simulations.
+* The :mod:`~virtual_rainforest.core.axes` submodule provides validation for data to
+  ensure that it is congruent with the model configuration.
+* The :mod:`~virtual_rainforest.core.readers` submodule provides functionality to read
+  external data files into a standard internal format.
+* The :mod:`~virtual_rainforest.core.base_model` submodule provides an Abstract
+  Base Class describing the shared API to be used by science models within the Virtual
+  Rainforest.
+* The :mod:`~virtual_rainforest.core.logger` configures the :data:`~logging.LOGGER`
+  instance used throughout the package.
+
+The :mod:`~virtual_rainforest.core` module itself is only responsible for loading the
+configuration schema for the core submodules.
+"""  # noqa: D205, D415
+
 import json
 from pathlib import Path
 

--- a/virtual_rainforest/core/__init__.py
+++ b/virtual_rainforest/core/__init__.py
@@ -20,7 +20,7 @@ Each of the core sub-modules has its own API reference page:
 * The :mod:`~virtual_rainforest.core.base_model` submodule provides an Abstract
   Base Class describing the shared API to be used by science models within the Virtual
   Rainforest.
-* The :mod:`~virtual_rainforest.core.logger` configures the :data:`~logging.LOGGER`
+* The :mod:`~virtual_rainforest.core.logger` configures the :class:`~logging.Logger`
   instance used throughout the package.
 
 The :mod:`~virtual_rainforest.core` module itself is only responsible for loading the

--- a/virtual_rainforest/core/axes.py
+++ b/virtual_rainforest/core/axes.py
@@ -1,7 +1,7 @@
-"""The :mod:`core.axes` module handles the validation of data being loaded into the core
-data storage of the virtual rainforest simulation. The main functionality in this module
-is ensuring that any loaded data is congruent with the core axes of the simulation and
-the configuration of a given simulation.
+"""The :mod:`~virtual_rainforest.core.axes` module handles the validation of data being
+loaded into the core data storage of the virtual rainforest simulation. The main
+functionality in this module is ensuring that any loaded data is congruent with the core
+axes of the simulation and the configuration of a given simulation.
 
 The AxisValidator class
 =======================
@@ -16,8 +16,8 @@ then a validation routine to apply when it can.
 
 When new :class:`~virtual_rainforest.core.axes.AxisValidator` subclasses are defined,
 they are automatically added to the
-:attr:`~virtual_rainforest.core.axes.AXIS_VALIDATORS` registry. This maintains a list
-of the validators defined for each core axis.
+:attr:`~virtual_rainforest.core.axes.AXIS_VALIDATORS` registry. This maintains a list of
+the validators defined for each core axis.
 
 Note that the set of validators defined for a specific core axis should be mutually
 exclusive: only one should be applicable to any given dataset being tested on that axis.
@@ -25,12 +25,12 @@ exclusive: only one should be applicable to any given dataset being tested on th
 DataArray validation
 ====================
 
-The :func:`~virtual_rainforest.core.axes.validate_datarray` function takes an input Data
-Array and applies validation where applicable across all the core axes. The function
-returns the validated input (possibly altered to align with the core axes) along with a
-dictionary using the set of core axes as names: the value associated with each axis name
-is the name of the AxisValidator applied or None if the input did not match a validator
-on that axis.
+The :func:`~virtual_rainforest.core.axes.validate_dataarray` function takes an input
+Data Array and applies validation where applicable across all the core axes. The
+function returns the validated input (possibly altered to align with the core axes)
+along with a dictionary using the set of core axes as names: the value associated with
+each axis name is the name of the AxisValidator applied or None if the input did not
+match a validator on that axis.
 
 Core axes
 =========
@@ -90,11 +90,11 @@ class AxisValidator(ABC):
         :attr:`~virtual_rainforest.core.axes.AXIS_VALIDATORS` registry. AxisValidators
         are arranged in the registry dictionary as lists keyed under core axis names,
         and the core axis name for a given subclass is set in the  subclass
-        :attr:`~virtual_rainforest.core.axes.AxisValidator.AxisValidator.core_axis`
+        :attr:`~virtual_rainforest.core.axes.AxisValidator.core_axis`
         class attribute.
 
         Raises:
-            Value Error: if the subclass attributes are invalid.
+            ValueError: if the subclass attributes are invalid.
         """
 
         if not hasattr(cls, "core_axis"):

--- a/virtual_rainforest/core/base_model.py
+++ b/virtual_rainforest/core/base_model.py
@@ -1,11 +1,11 @@
-"""The :mod:`~virtual_rainforest.core.base_model` module provides a consistent API across
-models for the Virtual Rainforest model: that is, a common set of functions which work
-the same across all modules. This cannot exist at a low level, as the basic classes and
-functions will differ massively between modules (e.g. :mod:`~virtual_rainforest.abiotic`
-will not have functions to handle consumption). So, this common api has to be high level
-and define a basic set of functions to set up and run each model. These functions
-effectively convert a general instruction (i.e. "setup the model") into the steps needed
-to carry out that instruction for a specific model.
+"""The :mod:`~virtual_rainforest.core.base_model` module provides a consistent API
+across models for the Virtual Rainforest model: that is, a common set of functions which
+work the same across all modules. This cannot exist at a low level, as the basic classes
+and functions will differ massively between modules (e.g.
+:mod:`~virtual_rainforest.abiotic` will not have functions to handle consumption). So,
+this common api has to be high level and define a basic set of functions to set up and
+run each model. These functions effectively convert a general instruction (i.e. "setup
+the model") into the steps needed to carry out that instruction for a specific model.
 
 The :mod:`core.base_model` module defines the api that all individual models (e.g. the
 soil model) should conform to. This consists of a class

--- a/virtual_rainforest/core/base_model.py
+++ b/virtual_rainforest/core/base_model.py
@@ -2,13 +2,14 @@
 across models for the Virtual Rainforest model: that is, a common set of functions which
 work the same across all modules. This cannot exist at a low level, as the basic classes
 and functions will differ massively between modules (e.g.
-:mod:`~virtual_rainforest.abiotic` will not have functions to handle consumption). So,
-this common api has to be high level and define a basic set of functions to set up and
-run each model. These functions effectively convert a general instruction (i.e. "setup
-the model") into the steps needed to carry out that instruction for a specific model.
+:mod:`~virtual_rainforest.models.abiotic` will not have functions to handle
+consumption). So, this common api has to be high level and define a basic set of
+functions to set up and run each model. These functions effectively convert a general
+instruction (i.e. "setup the model") into the steps needed to carry out that instruction
+for a specific model.
 
-The :mod:`core.base_model` module defines the api that all individual models (e.g. the
-soil model) should conform to. This consists of a class
+The :mod:`~virtual_rainforest.core.base_model` module defines the api that all
+individual models (e.g. the soil model) should conform to. This consists of a class
 (:class:`~virtual_rainforest.core.base_model.BaseModel`), which defines the expected
 functions. Some functions of this class will be inherited and used by its child classes
 (e.g. :func:`~virtual_rainforest.core.base_model.BaseModel.__repr__` and
@@ -55,7 +56,7 @@ ensure that they are added to the registry.
 
 An example of ``Model`` inheritance from
 :class:`~virtual_rainforest.core.base_model.BaseModel` can been seen in the
-:mod:`soil.soil_model` module.
+:mod:`~virtual_rainforest.models.soil.soil_model` module.
 """  # noqa: D205, D415
 
 from __future__ import annotations

--- a/virtual_rainforest/core/base_model.py
+++ b/virtual_rainforest/core/base_model.py
@@ -1,4 +1,4 @@
-"""The :mod:`~virtual_rainforest.core.base_model`module provides a consistent API across
+"""The :mod:`~virtual_rainforest.core.base_model` module provides a consistent API across
 models for the Virtual Rainforest model: that is, a common set of functions which work
 the same across all modules. This cannot exist at a low level, as the basic classes and
 functions will differ massively between modules (e.g. :mod:`~virtual_rainforest.abiotic`

--- a/virtual_rainforest/core/base_model.py
+++ b/virtual_rainforest/core/base_model.py
@@ -1,4 +1,4 @@
-"""The :mod:`~virtual_rainforest.core.model` module provides a consistent API across
+"""The :mod:`~virtual_rainforest.core.base_model`module provides a consistent API across
 models for the Virtual Rainforest model: that is, a common set of functions which work
 the same across all modules. This cannot exist at a low level, as the basic classes and
 functions will differ massively between modules (e.g. :mod:`~virtual_rainforest.abiotic`
@@ -7,46 +7,46 @@ and define a basic set of functions to set up and run each model. These function
 effectively convert a general instruction (i.e. "setup the model") into the steps needed
 to carry out that instruction for a specific model.
 
-The :mod:`core.model` module defines the api that all individual models (e.g. the soil
-model) should conform to. This consists of a class
-(:class:`~virtual_rainforest.core.model.BaseModel`), which defines the expected
+The :mod:`core.base_model` module defines the api that all individual models (e.g. the
+soil model) should conform to. This consists of a class
+(:class:`~virtual_rainforest.core.base_model.BaseModel`), which defines the expected
 functions. Some functions of this class will be inherited and used by its child classes
-(e.g. :func:`~virtual_rainforest.core.model.BaseModel.__repr__` and
-:func:`~virtual_rainforest.core.model.BaseModel.__str__`), unless they are explicitly
-overwritten in the child class (which is generally necessary for ``__init__``). This is
-standard python class inheritance, which will be used in many places throughout the
-``virtual_rainforest`` model.
+(e.g. :func:`~virtual_rainforest.core.base_model.BaseModel.__repr__` and
+:func:`~virtual_rainforest.core.base_model.BaseModel.__str__`), unless they are
+explicitly overwritten in the child class (which is generally necessary for
+``__init__``). This is standard python class inheritance, which will be used in many
+places throughout the ``virtual_rainforest`` model.
 
 However, a more complex form of inheritance is required for functions that define the
 shared api. These should take the same input and perform an equivalent set of steps
 across models, but because they interact with radically different modules their internal
 workings will have little in common. Thus,
-:class:`~virtual_rainforest.core.model.BaseModel` is defined as an abstract base class,
-which is a class that is never intended to be instantiated itself but instead serves as
-a blueprint for inheriting classes. This type of class can define abstract methods
-(denoted by ``@abstractmethod``), which are merely placeholders. For these abstract
-methods, child classes have to overwrite the methods with new functions, otherwise class
-inheritance fails. This ensures that a consistent api (set of functions) is used across
-models, while also ensuring that functions don't default to an inappropriate generic
-behaviour due to a function not being defined for a particular model. At the moment, we
-expect every model to have a setup, spinup, update and cleanup process, though this
-might change in the future.
+:class:`~virtual_rainforest.core.base_model.BaseModel` is defined as an abstract base
+class, which is a class that is never intended to be instantiated itself but instead
+serves as a blueprint for inheriting classes. This type of class can define abstract
+methods (denoted by ``@abstractmethod``), which are merely placeholders. For these
+abstract methods, child classes have to overwrite the methods with new functions,
+otherwise class inheritance fails. This ensures that a consistent api (set of functions)
+is used across models, while also ensuring that functions don't default to an
+inappropriate generic behaviour due to a function not being defined for a particular
+model. At the moment, we expect every model to have a setup, spinup, update and cleanup
+process, though this might change in the future.
 
 We also define an abstract class method to perform model initialisation. This method
-(:func:`~virtual_rainforest.core.model.BaseModel.from_config`) is a factory method which
-unpacks the configuration dictionary, extracts the relevant tags and attempts to convert
-them into the form needed to initialise a class instance. This method must be defined
-for every child class of :class:`~virtual_rainforest.core.model.BaseModel`, as unpacking
-our complex configuration dictionary is a necessary before a class instance can be
-initialised.
+(:func:`~virtual_rainforest.core.base_model.BaseModel.from_config`) is a factory method
+which unpacks the configuration dictionary, extracts the relevant tags and attempts to
+convert them into the form needed to initialise a class instance. This method must be
+defined for every child class of :class:`~virtual_rainforest.core.base_model.BaseModel`,
+as unpacking our complex configuration dictionary is a necessary before a class instance
+can be initialised.
 
 As in the case of configuration schema, we make ``Model`` classes generally accessible
 by adding them to a registry. However, in this case the function to add to the registry
 isn't a decorator but rather a member function of
-:class:`~virtual_rainforest.core.model.BaseModel`. The existence of this
-:func:`~virtual_rainforest.core.model.BaseModel.__init_subclass__` function means that
-every child class is automatically added to the model registry (called
-:attr:`~virtual_rainforest.core.model.MODEL_REGISTRY`), but that in every case a
+:class:`~virtual_rainforest.core.base_model.BaseModel`. The existence of this
+:func:`~virtual_rainforest.core.base_model.BaseModel.__init_subclass__` function means
+that every child class is automatically added to the model registry (called
+:attr:`~virtual_rainforest.core.base_model.MODEL_REGISTRY`), but that in every case a
 ``model_name`` has to be provided to register it under. This model name should be
 unique. Although registration is automatic, it only happens when class definition
 happens, which requires the module which defines the child class to be imported
@@ -54,8 +54,8 @@ somewhere. At the moment, we import all child models in the top level ``__init__
 ensure that they are added to the registry.
 
 An example of ``Model`` inheritance from
-:class:`~virtual_rainforest.core.model.BaseModel` can been seen in the :mod:`soil.model`
-module.
+:class:`~virtual_rainforest.core.base_model.BaseModel` can been seen in the
+:mod:`soil.soil_model` module.
 """  # noqa: D205, D415
 
 from __future__ import annotations

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -1,7 +1,7 @@
-"""The :mod:`core.config` module is used to read in the various configuration files,
-validate their contents, and then configure a ready to run instance of the virtual
-rainforest model. The basic details of how this system is used can be found
-:doc:`here </virtual_rainforest/core/config>`.
+"""The :mod:`~virtual_rainforest.core.config` module is used to read in the various
+configuration files, validate their contents, and then configure a ready to run instance
+of the virtual rainforest model. The basic details of how this system is used can be
+found :doc:`here </virtual_rainforest/core/config>`.
 
 When a new module is defined a ``JSON`` file should be written, which includes the
 expected configuration tags, their expected types, and any constraints on their values
@@ -34,8 +34,8 @@ just be the module name. An example of decorator usage is shown below:
 It's important to note that the schema will only be added to the registry if the module
 ``__init__`` is run. This means that somewhere in your chain of imports the module must
 be imported. Currently this is tackled by importing all active modules in the top level
-``__init__``, i.e. :mod:`virtual_rainforest.__init__.py`. This ensures that any script
-that imports :mod:`virtual_rainforest` will have implicitly imported all modules which
+``__init__``, i.e. ``virtual_rainforest.__init__.py``. This ensures that any script
+that imports ``virtual_rainforest`` will have implicitly imported all modules which
 define schema, in turn ensuring that
 :attr:`~virtual_rainforest.core.config.SCHEMA_REGISTRY` contains all necessary schema.
 """  # noqa: D205, D415
@@ -107,6 +107,9 @@ def validate_and_add_defaults(
 
     Args:
         validator_class: Validator to be extended
+
+    Returns:
+        An extended validator class
     """
 
     validate_properties = validator_class.VALIDATORS["properties"]
@@ -206,7 +209,7 @@ def check_dict_leaves(
         conflicts: List of variables that are defined in multiple places
 
     Returns:
-        conflicts: List of variables that are defined in multiple places
+        List of variables that are defined in multiple places
     """
 
     if conflicts is None:

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -74,7 +74,7 @@ The general solution for programmatically adding data from a file is to:
 * use the :meth:`~virtual_rainforest.core.data.Data.__setitem__` method to validate and
   add it to a :class:`~virtual_rainforest.core.data.Data` instance.
 
-The  :meth:`~virtual_rainforest.core.reader.load_to_dataarray` implements data loading
+The  :func:`~virtual_rainforest.core.reader.load_to_dataarray` implements data loading
 to a DataArray for some known file formats, using file reader functions described in the
 :mod:`~virtual_rainforest.core.readers` module. See the details of that module for
 supported formats and for extending the system to additional file formats.
@@ -91,7 +91,7 @@ Using a data configuration
 --------------------------
 
 A :class:`~virtual_rainforest.core.data.Data` instance can also be populated using the
-:meth:`~virtual_rainforest.core.data.Data.load_from_config` method. This is expecting to
+:meth:`~virtual_rainforest.core.data.Data.load_data_config` method. This is expecting to
 take a properly validated configuration dictionary, typically loaded from a TOML file
 during configuration (see :class:`~virtual_rainforest.core.config`). The expected
 structure is as follows:

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -11,10 +11,10 @@ internal variables used in the simulation. The class behaves like a dictionary -
 can be retrieved and set using ``data_object['varname']`` - but also provide validation
 for data being added to the object.
 
-All data added to the class is stored in a :class:`~xarray.DataSet` object, and data
+All data added to the class is stored in a :class:`~xarray.Dataset` object, and data
 extracted from the object will be a :class:`~xarray.DataArray`. The ``Dataset`` can also
 be accessed directly using the :attr:`~virtual_rainforest.core.data.Data.data` attribute
-of the class instance to use any of the :class:`~xarray.DataSet` class methods.
+of the class instance to use any of the :class:`~xarray.Dataset` class methods.
 
 When data is added to a :class:`~virtual_rainforest.core.data.Data` instance, it is
 automatically validated against the configuration of a simulation before being added to
@@ -23,7 +23,7 @@ also stores information that allows models to can confirm that a given variable 
 successfully validated.
 
 The core of the :class:`~virtual_rainforest.core.data.Data` class is the
-:class:`~virtual_rainforest.core.data.Data.__setitem__` method. This method provides the
+:meth:`~virtual_rainforest.core.data.Data.__setitem__` method. This method provides the
 following functionality:
 
 * It allows a ``DataArray`` to be added to a :class:`~virtual_rainforest.core.data.Data`
@@ -33,7 +33,7 @@ following functionality:
   :mod:`~virtual_rainforest.core.axes` module for the details of the validation process,
   including the :class:`~virtual_rainforest.core.axes.AxisValidator` class and the
   concept of core axes.
-* It inserts the data into the :class:`~xarray.DataSet` instance stored in the
+* It inserts the data into the :class:`~xarray.Dataset` instance stored in the
   :attr:`~virtual_rainforest.core.data.Data.data` attribute.
 * Lastly, it records the data validation details in the
   :attr:`~virtual_rainforest.core.data.Data.variable_validation` attribute.
@@ -42,14 +42,14 @@ The :class:`~virtual_rainforest.core.data.Data` class also provides three shorth
 methods to get information and data from an instance.
 
 * The :meth:`~virtual_rainforest.core.data.Data.__contains__` method tests if a named
-  variable is included in the internal :class:`~xarray.DataSet` instance.
+  variable is included in the internal :class:`~xarray.Dataset` instance.
 
     .. code-block:: python
 
         # Equivalent code 'varname' in data 'varname' in data.data
 
 * The :meth:`~virtual_rainforest.core.data.Data.__getitem__` method is used to retrieve
-  a named variable from the internal :class:`~xarray.DataSet` instance.
+  a named variable from the internal :class:`~xarray.Dataset` instance.
 
     .. code-block:: python
 
@@ -74,7 +74,7 @@ The general solution for programmatically adding data from a file is to:
 * use the :meth:`~virtual_rainforest.core.data.Data.__setitem__` method to validate and
   add it to a :class:`~virtual_rainforest.core.data.Data` instance.
 
-The  :func:`~virtual_rainforest.core.reader.load_to_dataarray` implements data loading
+The  :func:`~virtual_rainforest.core.readers.load_to_dataarray` implements data loading
 to a DataArray for some known file formats, using file reader functions described in the
 :mod:`~virtual_rainforest.core.readers` module. See the details of that module for
 supported formats and for extending the system to additional file formats.

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -29,9 +29,9 @@ following functionality:
 * It allows a ``DataArray`` to be added to a :class:`~virtual_rainforest.core.data.Data`
   instance using the ``data['varname'] = data_array`` syntax.
 * It applies the validation step using the
-  :func:`~virtual_rainforest.core.axes.validate_datarray` function. See the
+  :func:`~virtual_rainforest.core.axes.validate_dataarray` function. See the
   :mod:`~virtual_rainforest.core.axes` module for the details of the validation process,
-  including the :class:`~virtual_rainforest.core.axes.AxisValidators` class and the
+  including the :class:`~virtual_rainforest.core.axes.AxisValidator` class and the
   concept of core axes.
 * It inserts the data into the :class:`~xarray.DataSet` instance stored in the
   :attr:`~virtual_rainforest.core.data.Data.data` attribute.
@@ -160,7 +160,7 @@ class Data:
 
         The validation details for each variable is stored in this dictionary using the
         variable name as a key. The validation details are a dictionary, keyed using
-        core axis names, of the :class:`~virtual_rainforest.core.axis.AxisValidator`
+        core axis names, of the :class:`~virtual_rainforest.core.axes.AxisValidator`
         subclass applied to that axis. If no validator was applied, the entry for that
         core axis will be ``None``.
         """

--- a/virtual_rainforest/core/grid.py
+++ b/virtual_rainforest/core/grid.py
@@ -223,7 +223,7 @@ class Grid:
         objects, in cell_id order"""
         self.ncells: int
         """The total number of cells in the grid."""
-        self.centroids: NDArray
+        self.centroids: np.ndarray
         """A list of the centroid of each cell as shapely.geometry.Point objects, in
         cell_id order."""
 

--- a/virtual_rainforest/core/logger.py
+++ b/virtual_rainforest/core/logger.py
@@ -1,4 +1,4 @@
-"""The :mod:`~virtual_rainforest.core.logging` module is used to setup the extend the
+"""The :mod:`~virtual_rainforest.core.logger` module is used to setup the extend the
 standard logging setup to provide additional functionality relevant to the virtual
 rainforest model.
 

--- a/virtual_rainforest/core/readers.py
+++ b/virtual_rainforest/core/readers.py
@@ -14,7 +14,7 @@ The FILE_FORMAT_REGISTRY
 
 The :attr:`~virtual_rainforest.core.reader.FILE_FORMAT_REGISTRY` is used to register a
 set of known file formats for use in
-:meth:`~virtual_rainforest.core.reader.load_to_dataarray`. This registry is extendable,
+:func:`~virtual_rainforest.core.reader.load_to_dataarray`. This registry is extendable,
 so that new functions that implement data loading for a given file format can be added.
 
 New file format readers are made available using the

--- a/virtual_rainforest/core/readers.py
+++ b/virtual_rainforest/core/readers.py
@@ -1,24 +1,24 @@
 """The :mod:`~virtual_rainforest.core.readers` module provides the function
-:func:`~virtual_rainforest.core.reader.load_to_dataarray`, which is used to load data
+:func:`~virtual_rainforest.core.readers.load_to_dataarray`, which is used to load data
 from a file and convert it into a :class:`~xarray.DataArray` object. The ``DataArray``
 can then be added to a :class:`~virtual_rainforest.core.data.Data` instance for use in a
 Virtual Rainforest simulation.
 
 The module also supports the registration of different reader functions, used to convert
 files in different storage formats into a ``DataArray``. The
-:func:`~virtual_rainforest.core.reader.load_to_dataarray` automatically uses an
+:func:`~virtual_rainforest.core.readers.load_to_dataarray` automatically uses an
 appropriate reader based on the file suffix.
 
 The FILE_FORMAT_REGISTRY
 ========================
 
-The :attr:`~virtual_rainforest.core.reader.FILE_FORMAT_REGISTRY` is used to register a
+The :attr:`~virtual_rainforest.core.readers.FILE_FORMAT_REGISTRY` is used to register a
 set of known file formats for use in
-:func:`~virtual_rainforest.core.reader.load_to_dataarray`. This registry is extendable,
+:func:`~virtual_rainforest.core.readers.load_to_dataarray`. This registry is extendable,
 so that new functions that implement data loading for a given file format can be added.
 
 New file format readers are made available using the
-:func:`~virtual_rainforest.core.reader.register_file_format_loader` decorator, which
+:func:`~virtual_rainforest.core.readers.register_file_format_loader` decorator, which
 needs to specify the file formats supported (as a tuple of file suffixes) and then
 decorates a function that returns a :class:`~xarray.DataArray` that can be added to a
 :class:`~virtual_rainforest.core.data.Data` instance and validated
@@ -45,7 +45,7 @@ This dictionary maps a tuple of file format suffixes onto a function that allows
 data to be loaded. That loader function should coerce the data into an xarray DataArray.
 
 Users can register their own functions to load from a particular file format using the
-:func:`~virtual_rainforest.core.data.register_file_format_loader` decorator. The
+:func:`~virtual_rainforest.core.readers.register_file_format_loader` decorator. The
 function itself should have the following signature:
 
 .. code-block:: python

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -10,9 +10,13 @@ from typing import Any, Type, Union
 import pint
 from numpy import datetime64, timedelta64
 
+from virtual_rainforest.core.base_model import (
+    MODEL_REGISTRY,
+    BaseModel,
+    InitialisationError,
+)
 from virtual_rainforest.core.config import validate_config
 from virtual_rainforest.core.logger import LOGGER
-from virtual_rainforest.core.model import MODEL_REGISTRY, BaseModel, InitialisationError
 
 
 def select_models(model_list: list[str]) -> list[Type[BaseModel]]:

--- a/virtual_rainforest/models/abiotic/__init__.py
+++ b/virtual_rainforest/models/abiotic/__init__.py
@@ -1,3 +1,15 @@
+"""The :mod:`~virtual_rainforest.models.abiotic` module is one of the component models
+of the Virtual Rainforest. It is comprised of several submodules that calculate the
+radiation balance, the energy balance, the water balance and the atmospheric CO2
+balance.
+
+Each of the abiotic sub-modules has its own API reference page:
+
+* The :mod:`~virtual_rainforest.models.abiotic.abiotic_model` submodule instantiates the
+  AbioticModel class which consolidates the functionality of the abiotic module into a
+  single class, which the high level functions of the Virtual Rainforest can then use.
+"""  # noqa: D205, D415
+
 import json
 from pathlib import Path
 

--- a/virtual_rainforest/models/abiotic/abiotic_model.py
+++ b/virtual_rainforest/models/abiotic/abiotic_model.py
@@ -1,6 +1,6 @@
-"""The :mod:`~virtual_rainforest.models.abiotic_model` module creates a
-:class:`~virtual_rainforest.models.abiotic_model.AbioticModel` class as a child of the
-:class:`~virtual_rainforest.core.base_model.BaseModel` class.
+"""The :mod:`~virtual_rainforest.models.abiotic.abiotic_model` module creates a
+:class:`~virtual_rainforest.models.abiotic.abiotic_model.AbioticModel` class as a child
+of the :class:`~virtual_rainforest.core.base_model.BaseModel` class.
 """  # noqa: D205, D415
 
 from __future__ import annotations

--- a/virtual_rainforest/models/abiotic/abiotic_model.py
+++ b/virtual_rainforest/models/abiotic/abiotic_model.py
@@ -1,5 +1,5 @@
-"""The :mod:`abiotic.model` module creates a
-:class:`~virtual_rainforest.abiotic.abiotic_model.AbioticModel` class as a child of the
+"""The :mod:`~virtual_rainforest.models.abiotic_model` module creates a
+:class:`~virtual_rainforest.models.abiotic_model.AbioticModel` class as a child of the
 :class:`~virtual_rainforest.core.base_model.BaseModel` class.
 """  # noqa: D205, D415
 

--- a/virtual_rainforest/models/abiotic/abiotic_model.py
+++ b/virtual_rainforest/models/abiotic/abiotic_model.py
@@ -1,6 +1,6 @@
 """The :mod:`abiotic.model` module creates a
 :class:`~virtual_rainforest.abiotic.abiotic_model.AbioticModel` class as a child of the
-:class:`~virtual_rainforest.core.model.BaseModel` class.
+:class:`~virtual_rainforest.core.base_model.BaseModel` class.
 """  # noqa: D205, D415
 
 from __future__ import annotations
@@ -10,8 +10,8 @@ from typing import Any
 import pint
 from numpy import datetime64, timedelta64
 
+from virtual_rainforest.core.base_model import BaseModel, InitialisationError
 from virtual_rainforest.core.logger import LOGGER
-from virtual_rainforest.core.model import BaseModel, InitialisationError
 
 
 class AbioticModel(BaseModel):

--- a/virtual_rainforest/models/soil/__init__.py
+++ b/virtual_rainforest/models/soil/__init__.py
@@ -8,6 +8,8 @@ Each of the soil sub-modules has its own API reference page:
   class, which the high level functions of the Virtual Rainforest can then make use of.
 * The :mod:`~virtual_rainforest.models.soil.carbon` provides a model for the soil carbon
   cycle.
+* The :mod:`~virtual_rainforest.models.soil.constants` provides a set of dataclasses
+  containing the constants required by the broader soil model.
 """  # noqa: D205, D415
 
 

--- a/virtual_rainforest/models/soil/__init__.py
+++ b/virtual_rainforest/models/soil/__init__.py
@@ -1,3 +1,16 @@
+"""The :mod:`~virtual_rainforest.models.soil` module is one of the component models of
+the Virtual Rainforest. It is comprised of a number of submodules.
+
+Each of the soil sub-modules has its own API reference page:
+
+* The :mod:`~virtual_rainforest.models.soil.soil_model` submodule instantiates the
+  SoilModel class which consolidates the functionality of the soil module into a single
+  class, which the high level functions of the Virtual Rainforest can then make use of.
+* The :mod:`~virtual_rainforest.models.soil.carbon` provides a model for the soil carbon
+  cycle.
+"""  # noqa: D205, D415
+
+
 import json
 from pathlib import Path
 

--- a/virtual_rainforest/models/soil/carbon.py
+++ b/virtual_rainforest/models/soil/carbon.py
@@ -7,8 +7,8 @@ interactions will be added at a later date.
 import numpy as np
 from numpy.typing import NDArray
 
+from virtual_rainforest.core.base_model import InitialisationError
 from virtual_rainforest.core.logger import LOGGER
-from virtual_rainforest.core.model import InitialisationError
 from virtual_rainforest.models.soil.constants import (
     BindingWithPH,
     MaxSorptionWithClay,

--- a/virtual_rainforest/models/soil/constants.py
+++ b/virtual_rainforest/models/soil/constants.py
@@ -1,7 +1,6 @@
-"""The `models.soil.carbon` module  simulates the soil carbon cycle for the Virtual
-Rainforest. At the moment only two pools are modelled, these are low molecular weight
-carbon (LMWC) and mineral associated organic matter (MAOM). More pools and their
-interactions will be added at a later date.
+"""The `models.soil.constants` module contains a set of dataclasses containing
+constants" (fitting relationships taken from the literature) required by the broader
+:mod:`~virtual_rainforest.models.soil` module
 """  # noqa: D205, D415
 
 from dataclasses import dataclass

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -1,9 +1,9 @@
 """The :mod:`~virtual_rainforest.models.soil.soil_model` module creates a
 :class:`~virtual_rainforest.models.soil.soil_model.SoilModel` class as a child of the
-:class:`~virtual_rainforest.core.model.BaseModel` class. At present a lot of the
+:class:`~virtual_rainforest.core.base_model.BaseModel` class. At present a lot of the
 abstract methods of the parent class (e.g.
-:func:`~virtual_rainforest.core.model.BaseModel.setup` and
-:func:`~virtual_rainforest.core.model.BaseModel.spinup`) are overwritten using
+:func:`~virtual_rainforest.core.base_model.BaseModel.setup` and
+:func:`~virtual_rainforest.core.base_model.BaseModel.spinup`) are overwritten using
 placeholder functions that don't do anything. This will change as the
 :mod:`virtual_rainforest` model develops. The factory method
 :func:`~virtual_rainforest.models.soil.soil_model.SoilModel.from_config` exists in a
@@ -23,8 +23,8 @@ from typing import Any
 import pint
 from numpy import datetime64, timedelta64
 
+from virtual_rainforest.core.base_model import BaseModel, InitialisationError
 from virtual_rainforest.core.logger import LOGGER
-from virtual_rainforest.core.model import BaseModel, InitialisationError
 
 
 class SoilModel(BaseModel):

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -4,8 +4,8 @@
 abstract methods of the parent class (e.g.
 :func:`~virtual_rainforest.core.base_model.BaseModel.setup` and
 :func:`~virtual_rainforest.core.base_model.BaseModel.spinup`) are overwritten using
-placeholder functions that don't do anything. This will change as the
-:mod:`virtual_rainforest` model develops. The factory method
+placeholder functions that don't do anything. This will change as the Virtual Rainforest
+model develops. The factory method
 :func:`~virtual_rainforest.models.soil.soil_model.SoilModel.from_config` exists in a
 more complete state, and unpacks a small number of parameters from our currently pretty
 minimal configuration dictionary. These parameters are then used to generate a class


### PR DESCRIPTION
# Description

We recently updated the model names from `model.py` to `{MODEL_NAME}_model.py`. In the process, we missed updating the docs which I've done here.

Solves issue #178

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [NA] Code is commented, particularly in hard-to-understand areas
- [NA] Tests added that prove fix is effective or that feature works
