### PR TITLE
Added docs build check to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
 
       - name: Install dependencies
         run: poetry install
+
+      - name: Set ipython kernel
+        run: poetry run python -m ipykernel install --user --name=vr_python3
       
       - name: Build docs using sphinx
         run: poetry run sphinx-build -W --keep-going docs/source build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,4 @@ jobs:
         run: poetry install
       
       - name: Build docs using sphinx
-          run: "poetry sphinx-build -W --keep-going . build"
+          run: poetry sphinx-build -W --keep-going docs/source build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,10 @@ jobs:
         uses: abatilo/actions-poetry@v2.1.6
         with:
           poetry-version: 1.2.2
-
-      - name: Install dependencies
-        run: poetry install
-
+      
       - name: Build docs using sphinx
-        run: poetry sphinx-build -W --keep-going docs/source build 
+        uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "docs/"
+          pre-build-command: "poetry install"
+          build-command: "sphinx-build -W --keep-going docs/source build"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,4 @@ jobs:
         run: poetry install
       
       - name: Build docs using sphinx
-          run: poetry sphinx-build -W --keep-going docs/source build
+        run: poetry sphinx-build -W --keep-going docs/source build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,4 +66,4 @@ jobs:
         uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/source"
-          build-command: "sphinx-build -W --keep-going . build"
+          build-command: "poetry sphinx-build -W --keep-going . build"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,14 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2.1.6
+        with:
+          poetry-version: 1.2.2
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Build docs using sphinx
+        run: sphinx-build -W --keep-going docs/source build 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2.1.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.9"
 
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2.1.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,4 @@ jobs:
         run: poetry install
 
       - name: Build docs using sphinx
-        run: sphinx-build -W --keep-going docs/source build 
+        run: poetry sphinx-build -W --keep-going docs/source build 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,4 +68,4 @@ jobs:
       - name: Build docs using sphinx
         run: |
           cd docs
-          poetry run sphinx-build -W --keep-going docs/source build
+          poetry run sphinx-build -W --keep-going source build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,4 +66,6 @@ jobs:
         run: poetry run python -m ipykernel install --user --name=vr_python3
       
       - name: Build docs using sphinx
-        run: poetry run sphinx-build -W --keep-going docs/source build
+        run: |
+          cd docs
+          poetry run sphinx-build -W --keep-going docs/source build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,6 @@ jobs:
       - name: Build docs using sphinx
         uses: ammaraskar/sphinx-action@master
         with:
-          docs-folder: "docs/"
+          docs-folder: "docs/source"
           pre-build-command: "poetry install"
-          build-command: "sphinx-build -W --keep-going docs/source build"
+          build-command: "sphinx-build -W --keep-going . build"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,12 @@ jobs:
         uses: abatilo/actions-poetry@v2.1.6
         with:
           poetry-version: 1.2.2
+
+      - name: Install dependencies
+        run: poetry install
       
       - name: Build docs using sphinx
         uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/source"
-          pre-build-command: "poetry install"
           build-command: "sphinx-build -W --keep-going . build"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,4 @@ jobs:
         run: poetry install
       
       - name: Build docs using sphinx
-        uses: ammaraskar/sphinx-action@master
-        with:
-          docs-folder: "docs/source"
-          build-command: "poetry sphinx-build -W --keep-going . build"
+          run: "poetry sphinx-build -W --keep-going . build"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,4 @@ jobs:
         run: poetry install
       
       - name: Build docs using sphinx
-        run: poetry sphinx-build -W --keep-going docs/source build
+        run: poetry run sphinx-build -W --keep-going docs/source build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,12 @@ jobs:
       run: |
         pip install codecov
         codecov
+
+  docs_build:
+    needs: qa
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,6 +73,7 @@ autosummary_generate = True
 # Reference checking
 nitpicky = True
 nitpick_ignore = [
+    ("py:class", "jsonschema.validators.Draft202012Validator"),
     ("py:class", "numpy.float32"),
     ("py:class", "numpy.int64"),
     # TODO - Delete this once Vivienne has merged this feature into develop

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,6 +76,8 @@ nitpick_ignore = [
     ("py:class", "jsonschema.validators.Draft202012Validator"),
     ("py:class", "numpy.float32"),
     ("py:class", "numpy.int64"),
+    # TODO - Delete this once Vivienne has merged this feature into develop
+    ("py:class", "virtual_rainforest.models.abiotic.Energy_balance"),
 ]
 intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,7 +73,6 @@ autosummary_generate = True
 # Reference checking
 nitpicky = True
 nitpick_ignore = [
-    ("py:class", "jsonschema.validators.Draft202012Validator"),
     ("py:class", "numpy.float32"),
     ("py:class", "numpy.int64"),
     # TODO - Delete this once Vivienne has merged this feature into develop

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -170,7 +170,7 @@ def get_schema(module_name: str, schema_file_path: Path) -> dict:
     Raises:
         FileNotFoundError: the schema path does not exist
         JSONDecodeError: the file at the schema path is not valid JSON
-        SchemaError: the file contents are not valid JSON Schema
+        jsonschema.SchemaError: the file contents are not valid JSON Schema
         ValueError: the JSON Schema is missing required keys
     """
 

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -13,7 +13,7 @@ should call the :func:`~virtual_rainforest.core.config.register_schema` function
 will load and validate the schema before adding it to the registry. You will need to
 provides a module name to register the schema under, which should be unique to that
 model. The function also requires the path to the schema file, which should be located
-using the :meth:`importlib.resources.path()` context manager:
+using the :func:`importlib.resources.path` context manager:
 
 .. code-block:: python
 
@@ -22,7 +22,7 @@ using the :meth:`importlib.resources.path()` context manager:
     ) as schema_file_path:
         register_schema(module_name="soil", schema_file_path=schema_file_path)
 
-The base :mod:`virtual_rainforest` module will automatically import modules when it is
+The base Virtual Rainforest module will automatically import modules when it is
 imported, which ensures that all modules schemas are registered in
 :attr:`~virtual_rainforest.core.config.SCHEMA_REGISTRY`.
 """  # noqa: D205, D415
@@ -169,7 +169,7 @@ def get_schema(module_name: str, schema_file_path: Path) -> dict:
 
     Raises:
         FileNotFoundError: the schema path does not exist
-        JSONDecodeError: the file at the schema path is not valid JSON
+        json.JSONDecodeError: the file at the schema path is not valid JSON
         jsonschema.SchemaError: the file contents are not valid JSON Schema
         ValueError: the JSON Schema is missing required keys
     """

--- a/virtual_rainforest/core/grid.py
+++ b/virtual_rainforest/core/grid.py
@@ -11,7 +11,7 @@ underlying the simulation and to identify the neighbourhood connections of cells
 """  # noqa: D205, D415
 
 import json
-from typing import Any, Callable, Optional, Sequence, Union
+from typing import Any, Callable, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -29,7 +29,7 @@ grid of that type. Users can register their own grid types using the `register_g
 decorator.
 """
 
-GRID_STRUCTURE_SIG = tuple[list[int], list[Polygon]]
+GRID_STRUCTURE_SIG = Tuple[list[int], list[Polygon]]
 """Signature of the data structure to be returned from grid creator functions.
 
 The first value is a list of integer cell ids, the second is a matching list of the

--- a/virtual_rainforest/core/grid.py
+++ b/virtual_rainforest/core/grid.py
@@ -11,7 +11,7 @@ underlying the simulation and to identify the neighbourhood connections of cells
 """  # noqa: D205, D415
 
 import json
-from typing import Any, Callable, Optional, Sequence, Union
+from typing import Any, Callable, Optional, Sequence, TypeVar, Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -29,7 +29,10 @@ grid of that type. Users can register their own grid types using the `register_g
 decorator.
 """
 
-GRID_STRUCTURE_SIG = tuple[list[int], list[Polygon]]
+T = TypeVar("T")
+TupleSig = tuple[T[int], T[Polygon]]
+
+GRID_STRUCTURE_SIG = TupleSig[list]
 """Signature of the data structure to be returned from grid creator functions.
 
 The first value is a list of integer cell ids, the second is a matching list of the

--- a/virtual_rainforest/core/grid.py
+++ b/virtual_rainforest/core/grid.py
@@ -11,7 +11,7 @@ underlying the simulation and to identify the neighbourhood connections of cells
 """  # noqa: D205, D415
 
 import json
-from typing import Any, Callable, Optional, Sequence, TypeVar, Union
+from typing import Any, Callable, Optional, Sequence, Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -29,10 +29,7 @@ grid of that type. Users can register their own grid types using the `register_g
 decorator.
 """
 
-T = TypeVar("T")
-TupleSig = tuple[T[int], T[Polygon]]
-
-GRID_STRUCTURE_SIG = TupleSig[list]
+GRID_STRUCTURE_SIG = tuple[list[int], list[Polygon]]
 """Signature of the data structure to be returned from grid creator functions.
 
 The first value is a list of integer cell ids, the second is a matching list of the


### PR DESCRIPTION
# Description

This pull request adds a task to the CI to check that the docs build correctly. This has been added as a separate job and runs using `python 3.9` on `ubuntu`. The documentation build is run using `-W` which converts all warnings to errors, this ensures that the build process fails for broken links in the documentation.

This pull request is being pushed with docs build errors not fixed as I couldn't find a simple fix for them. This problem relates to the `GRID_STRUCTURE_SIG` object in `core/grid.py`. `mypy` is quite happy with how this object is used, but `sphinx` build produces a number of warnings about being unable to find `GRID_STRUCTURE_SIG.__repr__`, `GRID_STRUCTURE_SIG.count`, or `GRID_STRUCTURE_SIG.index`. Interestingly these errors disappear if you build the docs using `python 3.11` (though that introduces another error, which may be easier to fix).

Let me know if you have any ideas how this could be fixed. Worse case scenario the specific problems could be added to `nitpick_ignore` to suppress the warnings.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
