### PR TITLE
Switched to using a consistent key format for citations

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,10 +13,14 @@ documentation root, use os.path.abspath to make it absolute, like shown here.
 
 import os
 import sys
+from dataclasses import dataclass, field
 
 # Import Matplotlib to avoid this message in notebooks:
 # "Matplotlib is building the font cache; this may take a moment."
 import matplotlib.pyplot  # noqa: F401
+import sphinxcontrib.bibtex.plugin
+from sphinxcontrib.bibtex.style.referencing import BracketStyle
+from sphinxcontrib.bibtex.style.referencing.author_year import AuthorYearReferenceStyle
 
 import virtual_rainforest as vr
 
@@ -69,8 +73,32 @@ extensions = [
 autodoc_default_flags = ["members"]
 autosummary_generate = True
 
+
+def bracket_style() -> BracketStyle:
+    """Function that defines round brackets citation style."""
+    return BracketStyle(
+        left="(",
+        right=")",
+    )
+
+
+@dataclass
+class MyReferenceStyle(AuthorYearReferenceStyle):
+    """Dataclass that allows new bracket style to be passed to the constructor."""
+
+    bracket_parenthetical: BracketStyle = field(default_factory=bracket_style)
+    bracket_textual: BracketStyle = field(default_factory=bracket_style)
+    bracket_author: BracketStyle = field(default_factory=bracket_style)
+    bracket_label: BracketStyle = field(default_factory=bracket_style)
+    bracket_year: BracketStyle = field(default_factory=bracket_style)
+
+
+sphinxcontrib.bibtex.plugin.register_plugin(
+    "sphinxcontrib.bibtex.style.referencing", "author_year_round", MyReferenceStyle
+)
+
 # Configure referencing style
-bibtex_reference_style = "author_year"
+bibtex_reference_style = "author_year_round"
 
 # Reference checking
 nitpicky = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,11 +64,13 @@ extensions = [
     # "sphinx.ext.autosectionlabel",  # Generates hard to trace exception
     "sphinxcontrib.bibtex",
     "myst_nb",
-    # "sphinx_astrorefs",  # Gives author year references
     "sphinx_rtd_theme",
 ]
 autodoc_default_flags = ["members"]
 autosummary_generate = True
+
+# Configure referencing style
+bibtex_reference_style = "author_year"
 
 # Reference checking
 nitpicky = True

--- a/docs/source/data_recipes/CDS_toolbox_template.md
+++ b/docs/source/data_recipes/CDS_toolbox_template.md
@@ -87,7 +87,7 @@ simulations:
   [here](https://cds.climate.copernicus.eu/cdsapp#!/dataset/satellite-carbon-dioxide?tab=overview)
   . Alternatively, reconstructed gridded monthly CO2 data for the historical period
   (1953 - 2013) and future CMIP6 scenarios (2015 - 2150) can be downloaded
-  [here](https://zenodo.org/record/5021361){cite:p}`cheng_wei_2021`.
+  [here](https://zenodo.org/record/5021361){cite:p}`cheng_wei_global_2021`.
   
 ## Step-by-step example
 

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1,3 +1,20 @@
+
+@article{mayes_relation_2012,
+  title    = {Relation between {Soil} {Order} and {Sorption} of {Dissolved} {Organic} {Carbon} in {Temperate} {Subsoils}},
+  volume   = {76},
+  issn     = {0361-5995, 1435-0661},
+  url      = {https://onlinelibrary.wiley.com/doi/10.2136/sssaj2011.0340},
+  doi      = {10.2136/sssaj2011.0340},
+  language = {en},
+  number   = {3},
+  urldate  = {2023-02-22},
+  journal  = {Soil Science Society of America Journal},
+  author   = {Mayes, Melanie A. and Heal, Katherine R. and Brandt, Craig C. and Phillips, Jana R. and Jardine, Philip M.},
+  month    = may,
+  year     = {2012},
+  pages    = {1027--1037}
+}
+
 @article{davis_simple_2017,
   title      = {Simple process-led algorithms for simulating habitats ({SPLASH} v.1.0): robust indices of radiation, evapotranspiration and plant-available moisture},
   volume     = {10},

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1,3 +1,260 @@
+@article{davis_simple_2017,
+  title      = {Simple process-led algorithms for simulating habitats ({SPLASH} v.1.0): robust indices of radiation, evapotranspiration and plant-available moisture},
+  volume     = {10},
+  issn       = {1991-9603},
+  shorttitle = {Simple process-led algorithms for simulating habitats ({SPLASH} v.1.0)},
+  url        = {https://gmd.copernicus.org/articles/10/689/2017/},
+  doi        = {10.5194/gmd-10-689-2017},
+  abstract   = {Abstract. Bioclimatic indices for use in studies of ecosystem function, species distribution, and vegetation dynamics under changing climate scenarios depend on estimates of surface fluxes and other quantities, such as radiation, evapotranspiration and soil moisture, for which direct observations are sparse. These quantities can be derived indirectly from meteorological variables, such as near-surface air temperature, precipitation and cloudiness. Here we present a consolidated set of simple process-led algorithms for simulating habitats (SPLASH) allowing robust approximations of key quantities at ecologically relevant timescales. We specify equations, derivations, simplifications, and assumptions for the estimation of daily and monthly quantities of top-of-the-atmosphere solar radiation, net surface radiation, photosynthetic photon flux density, evapotranspiration (potential, equilibrium, and actual), condensation, soil moisture, and runoff, based on analysis of their relationship to fundamental climatic drivers. The climatic drivers include a minimum of three meteorological inputs: precipitation, air temperature, and fraction of bright sunshine hours. Indices, such as the moisture index, the climatic water deficit, and the Priestley–Taylor coefficient, are also defined. The SPLASH code is transcribed in C++, FORTRAN, Python, and R. A total of 1 year of results are presented at the local and global scales to exemplify the spatiotemporal patterns of daily and monthly model outputs along with comparisons to other model results.},
+  language   = {en},
+  number     = {2},
+  urldate    = {2023-02-22},
+  journal    = {Geoscientific Model Development},
+  author     = {Davis, Tyler W. and Prentice, I. Colin and Stocker, Benjamin D. and Thomas, Rebecca T. and Whitley, Rhys J. and Wang, Han and Evans, Bradley J. and Gallego-Sala, Angela V. and Sykes, Martin T. and Cramer, Wolfgang},
+  month      = feb,
+  year       = {2017},
+  pages      = {689--708}
+}
+
+@article{purves_predicting_2008,
+  title    = {Predicting and understanding forest dynamics using a simple tractable model},
+  volume   = {105},
+  issn     = {0027-8424, 1091-6490},
+  url      = {https://pnas.org/doi/full/10.1073/pnas.0807754105},
+  doi      = {10.1073/pnas.0807754105},
+  abstract = {The perfect-plasticity approximation (PPA) is an analytically tractable model of forest dynamics, defined in terms of parameters for individual trees, including allometry, growth, and mortality. We estimated these parameters for the eight most common species on each of four soil types in the US Lake states (Michigan, Wisconsin, and Minnesota) by using short-term (≤15-year) inventory data from individual trees. We implemented 100-year PPA simulations given these parameters and compared these predictions to chronosequences of stand development. Predictions for the timing and magnitude of basal area dynamics and ecological succession on each soil were accurate, and predictions for the diameter distribution of 100-year-old stands were correct in form and slope. For a given species, the PPA provides analytical metrics for early-successional performance ( 
+              H 
+              20 
+              , height of a 20-year-old open-grown tree) and late-successional performance ( 
+              Ẑ 
+              *, equilibrium canopy height in monoculture). These metrics predicted which species were early or late successional on each soil type. Decomposing 
+              Ẑ 
+              * showed that ( 
+              i 
+              ) succession is driven both by superior understory performance and superior canopy performance of late-successional species, and ( 
+              ii 
+              ) performance differences primarily reflect differences in mortality rather than growth. The predicted late-successional dominants matched chronosequences on xeromesic ( 
+              Quercus rubra 
+              ) and mesic (codominance by 
+              Acer rubrum 
+              and 
+              Acer saccharum 
+              ) soil. On hydromesic and hydric soils, the literature reports that the current dominant species in old stands ( 
+              Thuja occidentalis 
+              ) is now failing to regenerate. Consistent with this, the PPA predicted that, on these soils, stands are now succeeding to dominance by other late-successional species (e.g., 
+              Fraxinus nigra 
+              , 
+              A. rubrum 
+              ).},
+  language = {en},
+  number   = {44},
+  urldate  = {2023-02-22},
+  journal  = {Proceedings of the National Academy of Sciences},
+  author   = {Purves, Drew W. and Lichstein, Jeremy W. and Strigul, Nikolay and Pacala, Stephen W.},
+  month    = nov,
+  year     = {2008},
+  pages    = {17018--17022}
+}
+
+@article{li_simulation_2014,
+  title    = {Simulation of tree-ring widths with a model for primary production, carbon allocation, and growth},
+  volume   = {11},
+  issn     = {1726-4189},
+  url      = {https://bg.copernicus.org/articles/11/6711/2014/},
+  doi      = {10.5194/bg-11-6711-2014},
+  abstract = {Abstract. We present a simple, generic model of annual tree growth, called "T". This model accepts input from a first-principles light-use efficiency model (the "P" model). The P model provides values for gross primary production (GPP) per unit of absorbed photosynthetically active radiation (PAR). Absorbed PAR is estimated from the current leaf area. GPP is allocated to foliage, transport tissue, and fine-root production and respiration in such a way as to satisfy well-understood dimensional and functional relationships. Our approach thereby integrates two modelling approaches separately developed in the global carbon-cycle and forest-science literature. The T model can represent both ontogenetic effects (the impact of ageing) and the effects of environmental variations and trends (climate and CO2) on growth. Driven by local climate records, the model was applied to simulate ring widths during the period 1958–2006 for multiple trees of Pinus koraiensis from the Changbai Mountains in northeastern China. Each tree was initialised at its actual diameter at the time when local climate records started. The model produces realistic simulations of the interannual variability in ring width for different age cohorts (young, mature, and old). Both the simulations and observations show a significant positive response of tree-ring width to growing-season total photosynthetically active radiation (PAR0) and the ratio of actual to potential evapotranspiration (α), and a significant negative response to mean annual temperature (MAT). The slopes of the simulated and observed relationships with PAR0 and α are similar; the negative response to MAT is underestimated by the model. Comparison of simulations with fixed and changing atmospheric CO2 concentration shows that CO2 fertilisation over the past 50 years is too small to be distinguished in the ring-width data, given ontogenetic trends and interannual variability in climate.},
+  language = {en},
+  number   = {23},
+  urldate  = {2023-02-22},
+  journal  = {Biogeosciences},
+  author   = {Li, G. and Harrison, S. P. and Prentice, I. C. and Falster, D.},
+  month    = dec,
+  year     = {2014},
+  pages    = {6711--6724}
+}
+
+@article{prentice_balancing_2014,
+  title      = {Balancing the costs of carbon gain and water transport: testing a new theoretical framework for plant functional ecology},
+  volume     = {17},
+  issn       = {1461023X},
+  shorttitle = {Balancing the costs of carbon gain and water transport},
+  url        = {https://onlinelibrary.wiley.com/doi/10.1111/ele.12211},
+  doi        = {10.1111/ele.12211},
+  language   = {en},
+  number     = {1},
+  urldate    = {2023-02-22},
+  journal    = {Ecology Letters},
+  author     = {Prentice, I. Colin and Dong, Ning and Gleason, Sean M. and Maire, Vincent and Wright, Ian J.},
+  editor     = {Penuelas, Josep},
+  month      = jan,
+  year       = {2014},
+  pages      = {82--91}
+}
+
+@article{wang_towards_2017,
+  title    = {Towards a universal model for carbon dioxide uptake by plants},
+  volume   = {3},
+  issn     = {2055-0278},
+  url      = {https://www.nature.com/articles/s41477-017-0006-8},
+  doi      = {10.1038/s41477-017-0006-8},
+  language = {en},
+  number   = {9},
+  urldate  = {2023-02-22},
+  journal  = {Nature Plants},
+  author   = {Wang, Han and Prentice, I. Colin and Keenan, Trevor F. and Davis, Tyler W. and Wright, Ian J. and Cornwell, William K. and Evans, Bradley J. and Peng, Changhui},
+  month    = sep,
+  year     = {2017},
+  pages    = {734--741}
+}
+
+@article{federer_transpirational_1982,
+  title      = {Transpirational supply and demand: {Plant}, soil, and atmospheric effects evaluated by simulation},
+  volume     = {18},
+  issn       = {00431397},
+  shorttitle = {Transpirational supply and demand},
+  url        = {http://doi.wiley.com/10.1029/WR018i002p00355},
+  doi        = {10.1029/WR018i002p00355},
+  language   = {en},
+  number     = {2},
+  urldate    = {2023-02-22},
+  journal    = {Water Resources Research},
+  author     = {Federer, C. Anthony},
+  month      = apr,
+  year       = {1982},
+  pages      = {355--362}
+}
+
+@article{abramoff_millennial_2018,
+  title      = {The {Millennial} model: in search of measurable pools and transformations for modeling soil carbon in the new century},
+  volume     = {137},
+  issn       = {0168-2563, 1573-515X},
+  shorttitle = {The {Millennial} model},
+  url        = {http://link.springer.com/10.1007/s10533-017-0409-7},
+  doi        = {10.1007/s10533-017-0409-7},
+  language   = {en},
+  number     = {1-2},
+  urldate    = {2023-02-22},
+  journal    = {Biogeochemistry},
+  author     = {Abramoff, Rose and Xu, Xiaofeng and Hartman, Melannie and O’Brien, Sarah and Feng, Wenting and Davidson, Eric and Finzi, Adrien and Moorhead, Daryl and Schimel, Josh and Torn, Margaret and Mayes, Melanie A.},
+  month      = jan,
+  year       = {2018},
+  pages      = {51--71}
+}
+
+@article{parton_analysis_1987,
+  title    = {Analysis of {Factors} {Controlling} {Soil} {Organic} {Matter} {Levels} in {Great} {Plains} {Grasslands}},
+  volume   = {51},
+  issn     = {03615995},
+  url      = {http://doi.wiley.com/10.2136/sssaj1987.03615995005100050015x},
+  doi      = {10.2136/sssaj1987.03615995005100050015x},
+  language = {en},
+  number   = {5},
+  urldate  = {2023-02-22},
+  journal  = {Soil Science Society of America Journal},
+  author   = {Parton, W. J. and Schimel, D. S. and Cole, C. V. and Ojima, D. S.},
+  month    = sep,
+  year     = {1987},
+  pages    = {1173--1179}
+}
+
+@article{kirschbaum_modelling_2002,
+  title    = {Modelling {C} and {N} dynamics in forest soils with a modified version of the {CENTURY} model},
+  volume   = {34},
+  issn     = {00380717},
+  url      = {https://linkinghub.elsevier.com/retrieve/pii/S0038071701001894},
+  doi      = {10.1016/S0038-0717(01)00189-4},
+  language = {en},
+  number   = {3},
+  urldate  = {2023-02-22},
+  journal  = {Soil Biology and Biochemistry},
+  author   = {Kirschbaum, Miko U.F. and Paul, Keryn I.},
+  month    = mar,
+  year     = {2002},
+  pages    = {341--354}
+}
+
+@article{fatichi_mechanistic_2019,
+  title      = {A {Mechanistic} {Model} of {Microbially} {Mediated} {Soil} {Biogeochemical} {Processes}: {A} {Reality} {Check}},
+  volume     = {33},
+  issn       = {0886-6236, 1944-9224},
+  shorttitle = {A {Mechanistic} {Model} of {Microbially} {Mediated} {Soil} {Biogeochemical} {Processes}},
+  url        = {https://onlinelibrary.wiley.com/doi/abs/10.1029/2018GB006077},
+  doi        = {10.1029/2018GB006077},
+  language   = {en},
+  number     = {6},
+  urldate    = {2023-02-22},
+  journal    = {Global Biogeochemical Cycles},
+  author     = {Fatichi, Simone and Manzoni, Stefano and Or, Dani and Paschalis, Athanasios},
+  month      = jun,
+  year       = {2019},
+  pages      = {620--648}
+}
+
+@article{cucchi_wfde5_2020,
+  title      = {{WFDE5}: bias-adjusted {ERA5} reanalysis data for impact studies},
+  volume     = {12},
+  issn       = {1866-3516},
+  shorttitle = {{WFDE5}},
+  url        = {https://essd.copernicus.org/articles/12/2097/2020/},
+  doi        = {10.5194/essd-12-2097-2020},
+  abstract   = {Abstract. The WFDE5 dataset has been generated using the WATCH Forcing Data (WFD) methodology applied to surface meteorological variables from the ERA5 reanalysis. The WFDEI dataset had previously been generated by applying the WFD methodology to ERA-Interim. The WFDE5 is provided at 0.5∘ spatial resolution but has higher temporal resolution (hourly) compared to WFDEI (3-hourly). It also has higher spatial variability since it was generated by aggregation of the higher-resolution ERA5 rather than by interpolation of the lower-resolution ERA-Interim data. Evaluation against meteorological observations at 13 globally distributed FLUXNET2015 sites shows that, on average, WFDE5 has lower mean absolute error and higher correlation than WFDEI for all variables. Bias-adjusted monthly precipitation totals of WFDE5 result in more plausible global hydrological water balance components when analysed in an uncalibrated hydrological model (WaterGAP) than with the use of raw ERA5 data for model forcing. The dataset, which can be downloaded from https://doi.org/10.24381/cds.20d54e34 (C3S, 2020b), is distributed by the Copernicus Climate Change Service (C3S) through its Climate Data Store (CDS, C3S, 2020a) and currently spans from the start of January 1979 to the end of 2018. The dataset has been produced using a number of CDS Toolbox applications, whose source code is available with the data – allowing users to regenerate part of the dataset or apply the same approach to other data. Future updates are expected spanning from 1950 to the most recent year. A sample of the complete dataset, which covers the whole of the year 2016, is accessible without registration to the CDS at https://doi.org/10.21957/935p-cj60 (Cucchi et al., 2020).},
+  language   = {en},
+  number     = {3},
+  urldate    = {2023-02-22},
+  journal    = {Earth System Science Data},
+  author     = {Cucchi, Marco and Weedon, Graham P. and Amici, Alessandro and Bellouin, Nicolas and Lange, Stefan and Müller Schmied, Hannes and Hersbach, Hans and Buontempo, Carlo},
+  month      = sep,
+  year       = {2020},
+  pages      = {2097--2120}
+}
+
+@article{maclean_microclimc_2021,
+  title      = {Microclimc: {A} mechanistic model of above, below and within-canopy microclimate},
+  volume     = {451},
+  issn       = {03043800},
+  shorttitle = {Microclimc},
+  url        = {https://linkinghub.elsevier.com/retrieve/pii/S0304380021001265},
+  doi        = {10.1016/j.ecolmodel.2021.109567},
+  language   = {en},
+  urldate    = {2023-02-22},
+  journal    = {Ecological Modelling},
+  author     = {Maclean, Ilya M.D. and Klinges, David H.},
+  month      = jul,
+  year       = {2021},
+  pages      = {109567}
+}
+
+@article{metcalfe_dynamic_2015,
+  title      = {Dynamic {TOPMODEL}: {A} new implementation in {R} and its sensitivity to time and space steps},
+  volume     = {72},
+  issn       = {13648152},
+  shorttitle = {Dynamic {TOPMODEL}},
+  url        = {https://linkinghub.elsevier.com/retrieve/pii/S1364815215001735},
+  doi        = {10.1016/j.envsoft.2015.06.010},
+  language   = {en},
+  urldate    = {2023-02-22},
+  journal    = {Environmental Modelling \& Software},
+  author     = {Metcalfe, Peter and Beven, Keith and Freer, Jim},
+  month      = oct,
+  year       = {2015},
+  pages      = {155--172}
+}
+
+@misc{cheng_wei_global_2021,
+  title     = {Global monthly distributions of atmospheric {CO2} concentrations under the historical and future scenarios},
+  copyright = {Creative Commons Attribution 4.0 International, Open Access},
+  url       = {https://zenodo.org/record/5021361},
+  abstract  = {Increases in atmospheric carbon dioxide (CO$_{\textrm{2}}$) concentrations is the main driver of global warming. Satellite observations provide continuous global CO$_{\textrm{2}}$ retrieval products, that reveal the nonuniform distributions of atmospheric CO$_{\textrm{2 }}$concentrations. However, climate simulation studies are almost based on a globally uniform mean or latitudinally resolved CO$_{\textrm{2}}$ concentrations assumption. In this study, we reconstructed the historical global monthly distributions of atmospheric CO$_{\textrm{2}}$ concentrations with 1º resolution from 1850 to 2013. We followed the historical monthly and latitudinally resolved CO$_{\textrm{2 }}$concentrations accounting longitudinal features retrieved from fossil-fuel CO$_{\textrm{2}}$ emissions from Carbon Dioxide Information Analysis Center. And the spatial distributions of nonuniform CO$_{\textrm{2}}$ under Shared Socio-economic Pathways and Representative Concentration Pathways scenarios were generated based on the spatial, seasonal and interannual scales of the current CO$_{\textrm{2}}$ concentrations from 2015 to 2150. Including the heterogenous CO$_{\textrm{2 }}$distributions could enhance the realism of global climate modeling, to better anticipate the potential socio-economic implications, adaptation practices, and mitigation of climate change.},
+  urldate   = {2023-02-22},
+  publisher = {Zenodo},
+  author    = {{Cheng, Wei} and {Dan, Li} and {Deng, Xiangzheng} and {Feng, Jinming} and {Wang, Yongli} and {Peng, Jing} and {Tian, Jing} and {Qi, Wei} and {Liu, Zhu} and {Zheng, Xinqi} and {Zhou, Demin} and {Jiang, Sijian} and {Zhao, Haipeng} and {Wang, Xiaoyu}},
+  month     = jun,
+  year      = {2021},
+  doi       = {10.5281/ZENODO.5021361},
+  note      = {Type: dataset},
+  keywords  = {Atmospheric chemistry, Atmospheric dynamics, Climate and Earth system modelling}
+}
+
 @article{meek_generalized_1984,
   title    = {A {Generalized} {Relationship} between {Photosynthetically} {Active} {Radiation} and {Solar} {Radiation}},
   volume   = {76},
@@ -6,7 +263,7 @@
   doi      = {10.2134/agronj1984.00021962007600060018x},
   language = {en},
   number   = {6},
-  urldate  = {2023-02-21},
+  urldate  = {2023-02-22},
   journal  = {Agronomy Journal},
   author   = {Meek, D. W. and Hatfield, J. L. and Howell, T. A. and Idso, S. B. and Reginato, R. J.},
   month    = nov,
@@ -30,86 +287,6 @@
   pages    = {97--106}
 }
 
-@article{cucchi_wfde5_2020,
-  title      = {{WFDE5}: bias-adjusted {ERA5} reanalysis data for impact studies},
-  volume     = {12},
-  issn       = {1866-3516},
-  shorttitle = {{WFDE5}},
-  url        = {https://essd.copernicus.org/articles/12/2097/2020/},
-  doi        = {10.5194/essd-12-2097-2020},
-  language   = {en},
-  number     = {3},
-  urldate    = {2023-02-21},
-  journal    = {Earth System Science Data},
-  author     = {Cucchi, Marco and Weedon, Graham P. and Amici, Alessandro and Bellouin, Nicolas and Lange, Stefan and Müller Schmied, Hannes and Hersbach, Hans and Buontempo, Carlo},
-  month      = sep,
-  year       = {2020},
-  pages      = {2097--2120}
-}
-
-@article{li_simulation_2014,
-  title    = {Simulation of tree-ring widths with a model for primary production, carbon allocation, and growth},
-  volume   = {11},
-  issn     = {1726-4189},
-  url      = {https://bg.copernicus.org/articles/11/6711/2014/},
-  doi      = {10.5194/bg-11-6711-2014},
-  language = {en},
-  number   = {23},
-  urldate  = {2023-02-21},
-  journal  = {Biogeosciences},
-  author   = {Li, G. and Harrison, S. P. and Prentice, I. C. and Falster, D.},
-  month    = dec,
-  year     = {2014},
-  pages    = {6711--6724}
-}
-
-@article{purves_predicting_2008,
-  title    = {Predicting and understanding forest dynamics using a simple tractable model},
-  volume   = {105},
-  issn     = {0027-8424, 1091-6490},
-  url      = {https://pnas.org/doi/full/10.1073/pnas.0807754105},
-  doi      = {10.1073/pnas.0807754105},
-  language = {en},
-  number   = {44},
-  urldate  = {2023-02-21},
-  journal  = {Proceedings of the National Academy of Sciences},
-  author   = {Purves, Drew W. and Lichstein, Jeremy W. and Strigul, Nikolay and Pacala, Stephen W.},
-  month    = nov,
-  year     = {2008},
-  pages    = {17018--17022}
-}
-
-@article{davis_simple_2017,
-  title      = {Simple process-led algorithms for simulating habitats ({SPLASH} v.1.0): robust indices of radiation, evapotranspiration and plant-available moisture},
-  volume     = {10},
-  issn       = {1991-9603},
-  shorttitle = {Simple process-led algorithms for simulating habitats ({SPLASH} v.1.0)},
-  url        = {https://gmd.copernicus.org/articles/10/689/2017/},
-  doi        = {10.5194/gmd-10-689-2017},
-  language   = {en},
-  number     = {2},
-  urldate    = {2023-02-21},
-  journal    = {Geoscientific Model Development},
-  author     = {Davis, Tyler W. and Prentice, I. Colin and Stocker, Benjamin D. and Thomas, Rebecca T. and Whitley, Rhys J. and Wang, Han and Evans, Bradley J. and Gallego-Sala, Angela V. and Sykes, Martin T. and Cramer, Wolfgang},
-  month      = feb,
-  year       = {2017},
-  pages      = {689--708}
-}
-
-@misc{cheng_wei_global_2021,
-  title     = {Global monthly distributions of atmospheric {CO2} concentrations under the historical and future scenarios},
-  copyright = {Creative Commons Attribution 4.0 International, Open Access},
-  url       = {https://zenodo.org/record/5021361},
-  urldate   = {2023-02-21},
-  publisher = {Zenodo},
-  author    = {{Cheng, Wei} and {Dan, Li} and {Deng, Xiangzheng} and {Feng, Jinming} and {Wang, Yongli} and {Peng, Jing} and {Tian, Jing} and {Qi, Wei} and {Liu, Zhu} and {Zheng, Xinqi} and {Zhou, Demin} and {Jiang, Sijian} and {Zhao, Haipeng} and {Wang, Xiaoyu}},
-  month     = jun,
-  year      = {2021},
-  doi       = {10.5281/ZENODO.5021361},
-  note      = {Type: dataset},
-  keywords  = {Atmospheric chemistry, Atmospheric dynamics, Climate and Earth system modelling}
-}
-
 @article{linacre_estimating_1968,
   title    = {Estimating the net-radiation flux},
   volume   = {5},
@@ -124,153 +301,4 @@
   month    = jan,
   year     = {1968},
   pages    = {49--63}
-}
-
-@article{metcalfe_dynamic_2015,
-  title      = {Dynamic {TOPMODEL}: {A} new implementation in {R} and its sensitivity to time and space steps},
-  volume     = {72},
-  issn       = {13648152},
-  shorttitle = {Dynamic {TOPMODEL}},
-  url        = {https://linkinghub.elsevier.com/retrieve/pii/S1364815215001735},
-  doi        = {10.1016/j.envsoft.2015.06.010},
-  language   = {en},
-  urldate    = {2023-02-21},
-  journal    = {Environmental Modelling \& Software},
-  author     = {Metcalfe, Peter and Beven, Keith and Freer, Jim},
-  month      = oct,
-  year       = {2015},
-  pages      = {155--172}
-}
-
-@article{maclean_microclimc_2021,
-  title      = {Microclimc: {A} mechanistic model of above, below and within-canopy microclimate},
-  volume     = {451},
-  issn       = {03043800},
-  shorttitle = {Microclimc},
-  url        = {https://linkinghub.elsevier.com/retrieve/pii/S0304380021001265},
-  doi        = {10.1016/j.ecolmodel.2021.109567},
-  language   = {en},
-  urldate    = {2023-02-21},
-  journal    = {Ecological Modelling},
-  author     = {Maclean, Ilya M.D. and Klinges, David H.},
-  month      = jul,
-  year       = {2021},
-  pages      = {109567}
-}
-
-@article{fatichi_mechanistic_2019,
-  title      = {A {Mechanistic} {Model} of {Microbially} {Mediated} {Soil} {Biogeochemical} {Processes}: {A} {Reality} {Check}},
-  volume     = {33},
-  issn       = {0886-6236, 1944-9224},
-  shorttitle = {A {Mechanistic} {Model} of {Microbially} {Mediated} {Soil} {Biogeochemical} {Processes}},
-  url        = {https://onlinelibrary.wiley.com/doi/abs/10.1029/2018GB006077},
-  doi        = {10.1029/2018GB006077},
-  language   = {en},
-  number     = {6},
-  urldate    = {2023-02-21},
-  journal    = {Global Biogeochemical Cycles},
-  author     = {Fatichi, Simone and Manzoni, Stefano and Or, Dani and Paschalis, Athanasios},
-  month      = jun,
-  year       = {2019},
-  pages      = {620--648}
-}
-
-@article{kirschbaum_modelling_2002,
-  title    = {Modelling {C} and {N} dynamics in forest soils with a modified version of the {CENTURY} model},
-  volume   = {34},
-  issn     = {00380717},
-  url      = {https://linkinghub.elsevier.com/retrieve/pii/S0038071701001894},
-  doi      = {10.1016/S0038-0717(01)00189-4},
-  language = {en},
-  number   = {3},
-  urldate  = {2023-02-21},
-  journal  = {Soil Biology and Biochemistry},
-  author   = {Kirschbaum, Miko U.F. and Paul, Keryn I.},
-  month    = mar,
-  year     = {2002},
-  pages    = {341--354}
-}
-
-@article{parton_analysis_1987,
-  title    = {Analysis of {Factors} {Controlling} {Soil} {Organic} {Matter} {Levels} in {Great} {Plains} {Grasslands}},
-  volume   = {51},
-  issn     = {03615995},
-  url      = {http://doi.wiley.com/10.2136/sssaj1987.03615995005100050015x},
-  doi      = {10.2136/sssaj1987.03615995005100050015x},
-  language = {en},
-  number   = {5},
-  urldate  = {2023-02-21},
-  journal  = {Soil Science Society of America Journal},
-  author   = {Parton, W. J. and Schimel, D. S. and Cole, C. V. and Ojima, D. S.},
-  month    = sep,
-  year     = {1987},
-  pages    = {1173--1179}
-}
-
-@article{abramoff_millennial_2018,
-  title      = {The {Millennial} model: in search of measurable pools and transformations for modeling soil carbon in the new century},
-  volume     = {137},
-  issn       = {0168-2563, 1573-515X},
-  shorttitle = {The {Millennial} model},
-  url        = {http://link.springer.com/10.1007/s10533-017-0409-7},
-  doi        = {10.1007/s10533-017-0409-7},
-  language   = {en},
-  number     = {1-2},
-  urldate    = {2023-02-21},
-  journal    = {Biogeochemistry},
-  author     = {Abramoff, Rose and Xu, Xiaofeng and Hartman, Melannie and O’Brien, Sarah and Feng, Wenting and Davidson, Eric and Finzi, Adrien and Moorhead, Daryl and Schimel, Josh and Torn, Margaret and Mayes, Melanie A.},
-  month      = jan,
-  year       = {2018},
-  pages      = {51--71}
-}
-
-@article{federer_transpirational_1982,
-  title      = {Transpirational supply and demand: {Plant}, soil, and atmospheric effects evaluated by simulation},
-  volume     = {18},
-  issn       = {00431397},
-  shorttitle = {Transpirational supply and demand},
-  url        = {http://doi.wiley.com/10.1029/WR018i002p00355},
-  doi        = {10.1029/WR018i002p00355},
-  language   = {en},
-  number     = {2},
-  urldate    = {2023-02-21},
-  journal    = {Water Resources Research},
-  author     = {Federer, C. Anthony},
-  month      = apr,
-  year       = {1982},
-  pages      = {355--362}
-}
-
-@article{prentice_balancing_2014,
-  title      = {Balancing the costs of carbon gain and water transport: testing a new theoretical framework for plant functional ecology},
-  volume     = {17},
-  issn       = {1461023X},
-  shorttitle = {Balancing the costs of carbon gain and water transport},
-  url        = {https://onlinelibrary.wiley.com/doi/10.1111/ele.12211},
-  doi        = {10.1111/ele.12211},
-  language   = {en},
-  number     = {1},
-  urldate    = {2023-02-21},
-  journal    = {Ecology Letters},
-  author     = {Prentice, I. Colin and Dong, Ning and Gleason, Sean M. and Maire, Vincent and Wright, Ian J.},
-  editor     = {Penuelas, Josep},
-  month      = jan,
-  year       = {2014},
-  pages      = {82--91}
-}
-
-@article{wang_towards_2017,
-  title    = {Towards a universal model for carbon dioxide uptake by plants},
-  volume   = {3},
-  issn     = {2055-0278},
-  url      = {https://www.nature.com/articles/s41477-017-0006-8},
-  doi      = {10.1038/s41477-017-0006-8},
-  language = {en},
-  number   = {9},
-  urldate  = {2023-02-21},
-  journal  = {Nature Plants},
-  author   = {Wang, Han and Prentice, I. Colin and Keenan, Trevor F. and Davis, Tyler W. and Wright, Ian J. and Cornwell, William K. and Evans, Bradley J. and Peng, Changhui},
-  month    = sep,
-  year     = {2017},
-  pages    = {734--741}
 }

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1,43 +1,69 @@
-
-@article{Wang:2017go,
-  title    = {Towards a universal model for carbon dioxide uptake by plants},
-  url      = {http://dx.doi.org/10.1038/s41477-017-0006-8},
-  doi      = {10.1038/s41477-017-0006-8},
-  abstract = {Nature Plants, doi:10.1038/s41477-017-0006-8},
-  journal  = {Nature Plants},
-  author   = {Wang, Han and Prentice, I. Colin and Keenan, Trevor F and Davis, Tyler W and Wright, Ian J. and Cornwell, William K and Evans, Bradley J and Peng, Changhui},
-  month    = sep,
-  year     = {2017},
-  pages    = {1--8}
+@article{meek_generalized_1984,
+  title    = {A {Generalized} {Relationship} between {Photosynthetically} {Active} {Radiation} and {Solar} {Radiation}},
+  volume   = {76},
+  issn     = {0002-1962, 1435-0645},
+  url      = {https://onlinelibrary.wiley.com/doi/10.2134/agronj1984.00021962007600060018x},
+  doi      = {10.2134/agronj1984.00021962007600060018x},
+  language = {en},
+  number   = {6},
+  urldate  = {2023-02-21},
+  journal  = {Agronomy Journal},
+  author   = {Meek, D. W. and Hatfield, J. L. and Howell, T. A. and Idso, S. B. and Reginato, R. J.},
+  month    = nov,
+  year     = {1984},
+  pages    = {939--945}
 }
 
-@article{Prentice:2014bc,
-  title    = {Balancing the costs of carbon gain and water transport: testing a new theoretical framework for plant functional ecology},
-  volume   = {17},
-  url      = {http://doi.wiley.com/10.1111/ele.12211},
-  doi      = {10.1111/ele.12211},
-  language = {english},
-  number   = {1},
-  journal  = {Ecology Letters},
-  author   = {Prentice, I. Colin and Dong, Ning and Gleason, Sean M and Maire, Vincent and Wright, Ian J.},
-  year     = {2014},
-  pages    = {82--91}
+@article{allen_assessing_1996,
+  title    = {Assessing {Integrity} of {Weather} {Data} for {Reference} {Evapotranspiration} {Estimation}},
+  volume   = {122},
+  issn     = {0733-9437, 1943-4774},
+  url      = {https://ascelibrary.org/doi/10.1061/%28ASCE%290733-9437%281996%29122%3A2%2897%29},
+  doi      = {10.1061/(ASCE)0733-9437(1996)122:2(97)},
+  language = {en},
+  number   = {2},
+  urldate  = {2023-02-22},
+  journal  = {Journal of Irrigation and Drainage Engineering},
+  author   = {Allen, Richard G.},
+  month    = mar,
+  year     = {1996},
+  pages    = {97--106}
 }
 
-@article{Li:2014bc,
+@article{cucchi_wfde5_2020,
+  title      = {{WFDE5}: bias-adjusted {ERA5} reanalysis data for impact studies},
+  volume     = {12},
+  issn       = {1866-3516},
+  shorttitle = {{WFDE5}},
+  url        = {https://essd.copernicus.org/articles/12/2097/2020/},
+  doi        = {10.5194/essd-12-2097-2020},
+  language   = {en},
+  number     = {3},
+  urldate    = {2023-02-21},
+  journal    = {Earth System Science Data},
+  author     = {Cucchi, Marco and Weedon, Graham P. and Amici, Alessandro and Bellouin, Nicolas and Lange, Stefan and Müller Schmied, Hannes and Hersbach, Hans and Buontempo, Carlo},
+  month      = sep,
+  year       = {2020},
+  pages      = {2097--2120}
+}
+
+@article{li_simulation_2014,
   title    = {Simulation of tree-ring widths with a model for primary production, carbon allocation, and growth},
   volume   = {11},
+  issn     = {1726-4189},
   url      = {https://bg.copernicus.org/articles/11/6711/2014/},
   doi      = {10.5194/bg-11-6711-2014},
-  language = {english},
+  language = {en},
   number   = {23},
-  journal  = {Biogeosciences (Online)},
-  author   = {Li, G and Harrison, S P and Prentice, I. C. and Falster, D},
+  urldate  = {2023-02-21},
+  journal  = {Biogeosciences},
+  author   = {Li, G. and Harrison, S. P. and Prentice, I. C. and Falster, D.},
+  month    = dec,
   year     = {2014},
   pages    = {6711--6724}
 }
 
-@article{purves:2008a,
+@article{purves_predicting_2008,
   title    = {Predicting and understanding forest dynamics using a simple tractable model},
   volume   = {105},
   issn     = {0027-8424, 1091-6490},
@@ -45,7 +71,7 @@
   doi      = {10.1073/pnas.0807754105},
   language = {en},
   number   = {44},
-  urldate  = {2022-06-20},
+  urldate  = {2023-02-21},
   journal  = {Proceedings of the National Academy of Sciences},
   author   = {Purves, Drew W. and Lichstein, Jeremy W. and Strigul, Nikolay and Pacala, Stephen W.},
   month    = nov,
@@ -53,78 +79,83 @@
   pages    = {17018--17022}
 }
 
-@article{Davis:2017,
-  author  = {Davis, Tyler and Prentice, I. and Stocker, Benjamin and Thomas, Rebecca and Whitley, Rhys and Wang, Han and Evans, Bradley and Gallego-Sala, Angela and Sykes, Martin and Cramer, Wolfgang},
-  year    = {2017},
-  month   = {02},
-  pages   = {689-708},
-  title   = {Simple process-led algorithms for simulating habitats (SPLASH v.1.0): Robust indices of radiation, evapotranspiration and plant-available moisture},
-  volume  = {10},
-  journal = {Geoscientific Model Development},
-  doi     = {10.5194/gmd-10-689-2017}
-}
-
-@article{Federer1982,
-  author  = {{Federer}, C. Anthony},
-  title   = {{Transpirational Supply and Demand: Plant, Soil, and Atmospheric Effects Evaluated by Simulation}},
-  journal = {Water Resources Research},
-  year    = 1982,
-  month   = apr,
-  volume  = {18},
-  number  = {2},
-  pages   = {355-362},
-  doi     = {10.1029/WR018i002p00355},
-  adsurl  = {https://ui.adsabs.harvard.edu/abs/1982WRR....18..355F},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@article{abramoff_millennial_2018,
-  title      = {The {Millennial} model: in search of measurable pools and transformations for modeling soil carbon in the new century},
-  volume     = {137},
-  issn       = {0168-2563, 1573-515X},
-  shorttitle = {The {Millennial} model},
-  url        = {http://link.springer.com/10.1007/s10533-017-0409-7},
-  doi        = {10.1007/s10533-017-0409-7},
+@article{davis_simple_2017,
+  title      = {Simple process-led algorithms for simulating habitats ({SPLASH} v.1.0): robust indices of radiation, evapotranspiration and plant-available moisture},
+  volume     = {10},
+  issn       = {1991-9603},
+  shorttitle = {Simple process-led algorithms for simulating habitats ({SPLASH} v.1.0)},
+  url        = {https://gmd.copernicus.org/articles/10/689/2017/},
+  doi        = {10.5194/gmd-10-689-2017},
   language   = {en},
-  number     = {1-2},
-  urldate    = {2021-10-27},
-  journal    = {Biogeochemistry},
-  author     = {Abramoff, Rose and Xu, Xiaofeng and Hartman, Melannie and O’Brien, Sarah and Feng, Wenting and Davidson, Eric and Finzi, Adrien and Moorhead, Daryl and Schimel, Josh and Torn, Margaret and Mayes, Melanie A.},
-  month      = jan,
-  year       = {2018},
-  pages      = {51--71}
+  number     = {2},
+  urldate    = {2023-02-21},
+  journal    = {Geoscientific Model Development},
+  author     = {Davis, Tyler W. and Prentice, I. Colin and Stocker, Benjamin D. and Thomas, Rebecca T. and Whitley, Rhys J. and Wang, Han and Evans, Bradley J. and Gallego-Sala, Angela V. and Sykes, Martin T. and Cramer, Wolfgang},
+  month      = feb,
+  year       = {2017},
+  pages      = {689--708}
 }
 
-@article{parton_analysis_1987,
-  title    = {Analysis of {Factors} {Controlling} {Soil} {Organic} {Matter} {Levels} in {Great} {Plains} {Grasslands}},
-  volume   = {51},
-  issn     = {03615995},
-  url      = {http://doi.wiley.com/10.2136/sssaj1987.03615995005100050015x},
-  doi      = {10.2136/sssaj1987.03615995005100050015x},
-  language = {en},
-  number   = {5},
-  urldate  = {2022-07-06},
-  journal  = {Soil Science Society of America Journal},
-  author   = {Parton, W. J. and Schimel, D. S. and Cole, C. V. and Ojima, D. S.},
-  month    = sep,
-  year     = {1987},
-  pages    = {1173--1179}
+@misc{cheng_wei_global_2021,
+  title     = {Global monthly distributions of atmospheric {CO2} concentrations under the historical and future scenarios},
+  copyright = {Creative Commons Attribution 4.0 International, Open Access},
+  url       = {https://zenodo.org/record/5021361},
+  urldate   = {2023-02-21},
+  publisher = {Zenodo},
+  author    = {{Cheng, Wei} and {Dan, Li} and {Deng, Xiangzheng} and {Feng, Jinming} and {Wang, Yongli} and {Peng, Jing} and {Tian, Jing} and {Qi, Wei} and {Liu, Zhu} and {Zheng, Xinqi} and {Zhou, Demin} and {Jiang, Sijian} and {Zhao, Haipeng} and {Wang, Xiaoyu}},
+  month     = jun,
+  year      = {2021},
+  doi       = {10.5281/ZENODO.5021361},
+  note      = {Type: dataset},
+  keywords  = {Atmospheric chemistry, Atmospheric dynamics, Climate and Earth system modelling}
 }
 
-@article{kirschbaum_modelling_2002,
-  title    = {Modelling {C} and {N} dynamics in forest soils with a modified version of the {CENTURY} model},
-  volume   = {34},
-  issn     = {00380717},
-  url      = {https://linkinghub.elsevier.com/retrieve/pii/S0038071701001894},
-  doi      = {10.1016/S0038-0717(01)00189-4},
+@article{linacre_estimating_1968,
+  title    = {Estimating the net-radiation flux},
+  volume   = {5},
+  issn     = {00021571},
+  url      = {https://linkinghub.elsevier.com/retrieve/pii/0002157168900228},
+  doi      = {10.1016/0002-1571(68)90022-8},
   language = {en},
-  number   = {3},
-  urldate  = {2022-06-22},
-  journal  = {Soil Biology and Biochemistry},
-  author   = {Kirschbaum, Miko U.F. and Paul, Keryn I.},
-  month    = mar,
-  year     = {2002},
-  pages    = {341--354}
+  number   = {1},
+  urldate  = {2023-02-21},
+  journal  = {Agricultural Meteorology},
+  author   = {Linacre, E.T.},
+  month    = jan,
+  year     = {1968},
+  pages    = {49--63}
+}
+
+@article{metcalfe_dynamic_2015,
+  title      = {Dynamic {TOPMODEL}: {A} new implementation in {R} and its sensitivity to time and space steps},
+  volume     = {72},
+  issn       = {13648152},
+  shorttitle = {Dynamic {TOPMODEL}},
+  url        = {https://linkinghub.elsevier.com/retrieve/pii/S1364815215001735},
+  doi        = {10.1016/j.envsoft.2015.06.010},
+  language   = {en},
+  urldate    = {2023-02-21},
+  journal    = {Environmental Modelling \& Software},
+  author     = {Metcalfe, Peter and Beven, Keith and Freer, Jim},
+  month      = oct,
+  year       = {2015},
+  pages      = {155--172}
+}
+
+@article{maclean_microclimc_2021,
+  title      = {Microclimc: {A} mechanistic model of above, below and within-canopy microclimate},
+  volume     = {451},
+  issn       = {03043800},
+  shorttitle = {Microclimc},
+  url        = {https://linkinghub.elsevier.com/retrieve/pii/S0304380021001265},
+  doi        = {10.1016/j.ecolmodel.2021.109567},
+  language   = {en},
+  urldate    = {2023-02-21},
+  journal    = {Ecological Modelling},
+  author     = {Maclean, Ilya M.D. and Klinges, David H.},
+  month      = jul,
+  year       = {2021},
+  pages      = {109567}
 }
 
 @article{fatichi_mechanistic_2019,
@@ -136,7 +167,7 @@
   doi        = {10.1029/2018GB006077},
   language   = {en},
   number     = {6},
-  urldate    = {2021-10-18},
+  urldate    = {2023-02-21},
   journal    = {Global Biogeochemical Cycles},
   author     = {Fatichi, Simone and Manzoni, Stefano and Or, Dani and Paschalis, Athanasios},
   month      = jun,
@@ -144,119 +175,102 @@
   pages      = {620--648}
 }
 
-@article{WFDE5-2020,
-  author  = {Cucchi, M. and Weedon, G. P. and Amici, A. and Bellouin, N. and Lange, S. and M\"uller Schmied, H. and Hersbach, H. and Buontempo, C.},
-  title   = {WFDE5: bias-adjusted ERA5 reanalysis data for impact studies},
-  journal = {Earth System Science Data},
-  volume  = {12},
-  year    = {2020},
-  number  = {3},
-  pages   = {2097--2120},
-  url     = {https://essd.copernicus.org/articles/12/2097/2020/},
-  doi     = {10.5194/essd-12-2097-2020}
+@article{kirschbaum_modelling_2002,
+  title    = {Modelling {C} and {N} dynamics in forest soils with a modified version of the {CENTURY} model},
+  volume   = {34},
+  issn     = {00380717},
+  url      = {https://linkinghub.elsevier.com/retrieve/pii/S0038071701001894},
+  doi      = {10.1016/S0038-0717(01)00189-4},
+  language = {en},
+  number   = {3},
+  urldate  = {2023-02-21},
+  journal  = {Soil Biology and Biochemistry},
+  author   = {Kirschbaum, Miko U.F. and Paul, Keryn I.},
+  month    = mar,
+  year     = {2002},
+  pages    = {341--354}
 }
 
-@article{MACLEAN2021,
-  title    = {Microclimc: A mechanistic model of above, below and within-canopy microclimate},
-  journal  = {Ecological Modelling},
-  volume   = {451},
-  pages    = {109567},
-  year     = {2021},
-  issn     = {0304-3800},
-  doi      = {https://doi.org/10.1016/j.ecolmodel.2021.109567},
-  url      = {https://www.sciencedirect.com/science/article/pii/S0304380021001265},
-  author   = {Ilya M.D. Maclean and David H. Klinges},
-  keywords = {Temperature, Climate, Mechanistic model, Biophysical ecology, Evapotranspiration, R package},
-  abstract = {Climate strongly influences ecological patterns and processes at scales ranging from local to global. Studies of ecological responses to climate usually rely on data derived from weather stations, where temperature and humidity may differ substantially from that in the microenvironments in which organisms reside. To help remedy this, we present a model that leverages first principles physics to predict microclimate above, within, and below the canopy in any terrestrial location on earth, made freely available as an R software package. The model can be run in one of two modes. In the first, heat and vapour exchange within and below canopy are modelled as transient processes, thus accounting for fine temporal-resolution changes. In the second, steady-state conditions are assumed, enabling conditions at hourly intervals or longer to be estimated with greater computational efficiency. We validated both modes of the model with empirical below-canopy thermal measurements from several locations globally, resulting in hourly predictions with mean absolute error of 2.77 °C and 2.79 °C for the transient and steady-state modes respectively. Alongside the microclimate model, several functions are provided to assist data assimilation, as well as different parameterizations to capture a variety of habitats, allowing flexible application even when little is known about the study location. The model's modular design in a programming language familiar to ecological researchers provides easy access to the modelling of site-specific climate forcing, in an attempt to more closely unify the fields of micrometeorology and ecology.}
+@article{parton_analysis_1987,
+  title    = {Analysis of {Factors} {Controlling} {Soil} {Organic} {Matter} {Levels} in {Great} {Plains} {Grasslands}},
+  volume   = {51},
+  issn     = {03615995},
+  url      = {http://doi.wiley.com/10.2136/sssaj1987.03615995005100050015x},
+  doi      = {10.2136/sssaj1987.03615995005100050015x},
+  language = {en},
+  number   = {5},
+  urldate  = {2023-02-21},
+  journal  = {Soil Science Society of America Journal},
+  author   = {Parton, W. J. and Schimel, D. S. and Cole, C. V. and Ojima, D. S.},
+  month    = sep,
+  year     = {1987},
+  pages    = {1173--1179}
 }
 
-
-@article{Metcalfe2015,
-  author  = {Peter Metcalfe, Keith Beven, Jim Freer},
-  title   = {Dynamic TOPMODEL: A new implementation in R and its sensitivity to time and space steps},
-  journal = {Environmental Modelling & Software},
-  volume  = {72},
-  year    = {2015},
-  pages   = {155-172},
-  issn    = {1364-8152},
-  doi     = {https://doi.org/10.1016/j.envsoft.2015.06.010}
+@article{abramoff_millennial_2018,
+  title      = {The {Millennial} model: in search of measurable pools and transformations for modeling soil carbon in the new century},
+  volume     = {137},
+  issn       = {0168-2563, 1573-515X},
+  shorttitle = {The {Millennial} model},
+  url        = {http://link.springer.com/10.1007/s10533-017-0409-7},
+  doi        = {10.1007/s10533-017-0409-7},
+  language   = {en},
+  number     = {1-2},
+  urldate    = {2023-02-21},
+  journal    = {Biogeochemistry},
+  author     = {Abramoff, Rose and Xu, Xiaofeng and Hartman, Melannie and O’Brien, Sarah and Feng, Wenting and Davidson, Eric and Finzi, Adrien and Moorhead, Daryl and Schimel, Josh and Torn, Margaret and Mayes, Melanie A.},
+  month      = jan,
+  year       = {2018},
+  pages      = {51--71}
 }
 
-@article{cheng_wei_2021,
-  author  = {Cheng, Wei and
-             Dan, Li and
-             Deng, Xiangzheng and
-             Feng, Jinming and
-             Wang, Yongli and
-             Peng, Jing and
-             Tian, Jing and
-             Qi, Wei and
-             Liu, Zhu and
-             Zheng, Xinqi and
-             Zhou, Demin and
-             Jiang, Sijian and
-             Zhao, Haipeng and
-             Wang, Xiaoyu},
-  title   = {{Global monthly distributions of atmospheric CO2 
-             concentrations under the historical and future
-             scenarios [Data set]}},
-  journal = {Zenodo},
-  month   = jun,
-  year    = 2021,
-  doi     = {10.5281/zenodo.5021361},
-  url     = {https://doi.org/10.5281/zenodo.5021361}
+@article{federer_transpirational_1982,
+  title      = {Transpirational supply and demand: {Plant}, soil, and atmospheric effects evaluated by simulation},
+  volume     = {18},
+  issn       = {00431397},
+  shorttitle = {Transpirational supply and demand},
+  url        = {http://doi.wiley.com/10.1029/WR018i002p00355},
+  doi        = {10.1029/WR018i002p00355},
+  language   = {en},
+  number     = {2},
+  urldate    = {2023-02-21},
+  journal    = {Water Resources Research},
+  author     = {Federer, C. Anthony},
+  month      = apr,
+  year       = {1982},
+  pages      = {355--362}
 }
 
-@Article{Davis2017,
-AUTHOR = {Davis, T. W. and Prentice, I. C. and Stocker, B. D. and Thomas, R. T. and Whitley, R. J. and Wang, H. and Evans, B. J. and Gallego-Sala, A. V. and Sykes, M. T. and Cramer, W.},
-TITLE = {Simple process-led algorithms for simulating habitats (SPLASH v.1.0): robust indices of radiation, evapotranspiration   and plant-available moisture},
-JOURNAL = {Geoscientific Model Development},
-VOLUME = {10},
-YEAR = {2017},
-NUMBER = {2},
-PAGES = {689--708},
-URL = {https://gmd.copernicus.org/articles/10/689/2017/},
-DOI = {10.5194/gmd-10-689-2017}
+@article{prentice_balancing_2014,
+  title      = {Balancing the costs of carbon gain and water transport: testing a new theoretical framework for plant functional ecology},
+  volume     = {17},
+  issn       = {1461023X},
+  shorttitle = {Balancing the costs of carbon gain and water transport},
+  url        = {https://onlinelibrary.wiley.com/doi/10.1111/ele.12211},
+  doi        = {10.1111/ele.12211},
+  language   = {en},
+  number     = {1},
+  urldate    = {2023-02-21},
+  journal    = {Ecology Letters},
+  author     = {Prentice, I. Colin and Dong, Ning and Gleason, Sean M. and Maire, Vincent and Wright, Ian J.},
+  editor     = {Penuelas, Josep},
+  month      = jan,
+  year       = {2014},
+  pages      = {82--91}
 }
 
-@article{Linacre1968,
-title = {Estimating the net-radiation flux},
-journal = {Agricultural Meteorology},
-volume = {5},
-number = {1},
-pages = {49-63},
-year = {1968},
-issn = {0002-1571},
-doi = {https://doi.org/10.1016/0002-1571(68)90022-8},
-url = {https://www.sciencedirect.com/science/article/pii/0002157168900228},
-author = {E.T. Linacre},
-abstract = {A major influence controlling the water loss from irrigated crops is the net-radiation intensity Qn, but measurements of this are not normally available, and so attempts are often made to deduce it from other climatic data, such as the solar-radiation. Here it is shown that the relationship between net and solar-radiation intensities depends on the degree of cloudiness and the ambient temperature. By making appropriate assumptions, a series of expressions for Qn is derived, with decreasing accuracy but increasing simplicity of estimation. It appears that clouds lower the net-radiation intensity when it exceeds a critical value in the region of 0.02 cal./cm2 min, but increase it when the intensity is lower.}
+@article{wang_towards_2017,
+  title    = {Towards a universal model for carbon dioxide uptake by plants},
+  volume   = {3},
+  issn     = {2055-0278},
+  url      = {https://www.nature.com/articles/s41477-017-0006-8},
+  doi      = {10.1038/s41477-017-0006-8},
+  language = {en},
+  number   = {9},
+  urldate  = {2023-02-21},
+  journal  = {Nature Plants},
+  author   = {Wang, Han and Prentice, I. Colin and Keenan, Trevor F. and Davis, Tyler W. and Wright, Ian J. and Cornwell, William K. and Evans, Bradley J. and Peng, Changhui},
+  month    = sep,
+  year     = {2017},
+  pages    = {734--741}
 }
-
-@article{Meek1984,
-author = {Meek, D. W. and Hatfield, J. L. and Howell, T. A. and Idso, S. B. and Reginato, R. J.},
-title = {A Generalized Relationship between Photosynthetically Active Radiation and Solar Radiation1},
-journal = {Agronomy Journal},
-volume = {76},
-number = {6},
-pages = {939-945},
-keywords = {Photosynthetic photon flux density, Quantum sensor, Pyranometer},
-doi = {https://doi.org/10.2134/agronj1984.00021962007600060018x},
-url = {https://acsess.onlinelibrary.wiley.com/doi/abs/10.2134/agronj1984.00021962007600060018x},
-eprint = {https://acsess.onlinelibrary.wiley.com/doi/pdf/10.2134/agronj1984.00021962007600060018x},
-year = {1984}
-}
-
-@article{Allen1996,
-author = {Allen, R.G.},
-title = {Assessing integrity of weather data for reference evapotranspiration estimation},
-journal = {Journal of Irrigation and Drainage Engineering},
-volume = {122},
-issiue = {2},
-pages = {97-106},
-year = {1996},
-country = {Food and Agriculture Organization of the United Nations (FAO)},
-url = {http://inis.iaea.org/search/search.aspx?orig_q=RN:46129940}
-}
-
-

--- a/docs/source/virtual_rainforest/module_overview.md
+++ b/docs/source/virtual_rainforest/module_overview.md
@@ -32,7 +32,7 @@ The `core` module is responsible for:
 ## Plant Module
 
 The Plant Module models the primary production from plants in the Virtual Rainforest. We
-use the P Model ({cite}`prentice_balancing_2014,wang_towards_2017`), to estimate the
+use the P Model {cite}`prentice_balancing_2014,wang_towards_2017`, to estimate the
 optimal balance between water loss and photosynthetic productivity and hence gross
 primary productivity (GPP). The P Model requires estimates of the following drivers:
 
@@ -44,12 +44,12 @@ primary productivity (GPP). The P Model requires estimates of the following driv
 - Photosynthetic photon flux density (PPFD, $\mu \text{mol}, m^{-2}, s^{-1}$)
 
 GPP is then allocated to plant maintenance, respiration and growth using the T Model
-({cite}`li_simulation_2014`).
+{cite}`li_simulation_2014`.
 
 This growth model is used to simulate the demographics of cohorts of key plant
 functional types (PFTs) under physiologically structured population models developed in
 the [Plant-FATE](https://jaideep777.github.io/libpspm/) framework. The framework uses
-the perfect-plasticity approximation (PPA, {cite}`purves_predicting_2008`) to model the
+the perfect-plasticity approximation (PPA, {cite:t}`purves_predicting_2008`) to model the
 canopy structure of the plant community, the light environments of different PFTs and
 hence the change in the size-structured demography of each PFT through time.
 
@@ -65,12 +65,12 @@ incorporated into this module:
 ### Carbon cycle
 
 The Carbon cycle uses as its basic structure a recently described soil-pool model termed
-the Millennial model ({cite}`abramoff_millennial_2018`). This model splits carbon into
+the Millennial model {cite}`abramoff_millennial_2018`. This model splits carbon into
 five separate pools: particulate organic matter, low molecular weight carbon (LMWC),
 mineral associated organic matter, aggregates and microbial biomass. Though plant root
 exudates feed directly into the LMWC pool, most biomass input will less direct and occur
 via litter decomposition. Thus, we utilize a common set of litter pools
-({cite}`kirschbaum_modelling_2002`), that are divided between above- and below-ground
+{cite}`kirschbaum_modelling_2002`, that are divided between above- and below-ground
 pools, and by biomass source (e.g. deadwood).
 
 ### Nitrogen cycle
@@ -101,7 +101,7 @@ Further theoretical background for the soil module can be found
 
 The abiotic module provides the microclimate and hydrology for the Virtual Rainforest.
 Using a small set of input variables from external sources such as WFDE5
-({cite}`cucchi_wfde5_2020`) or regional climate models, the module calculates
+{cite}`cucchi_wfde5_2020` or regional climate models, the module calculates
 atmospheric and soil parameters that drive the dynamics of plants, animals, and microbes
 at different vertical levels. Four subroutines - the radiation balance, the energy
 balance, the water balance, and the atmospheric $\ce{CO_{2}}$ balance - provide the
@@ -144,7 +144,7 @@ The Energy balance submodule derives sensible and latent heat fluxes from canopy
 surface to the atmosphere, and updates air temperature, relative humidity, and vapor
 pressure deficit at each level. The vertical mixing between levels is assumed to be
 driven by heat conductance because turbulence is typically low below the canopy
-({cite}`maclean_microclimc_2021`). Part of the net radiation is converted into soil heat
+{cite}`maclean_microclimc_2021`. Part of the net radiation is converted into soil heat
 flux. The vertical exchange of heat between soil levels is coupled to the atmospheric
 mixing.
 
@@ -157,7 +157,7 @@ infiltration, percolation (= vertical flow), soil moisture profile, water table 
 and subsurface flow out of the grid cell.
 
 The second part of the module caluclates the water balance across the full model grid
-based on the TOPMODEL (e.g. {cite}`metcalfe_dynamic_2015`) including surface runoff,
+based on the TOPMODEL (e.g. {cite:t}`metcalfe_dynamic_2015`) including surface runoff,
 subsurface flow, return flow, and streamflow.
 
 ### The atmospheric $\ce{CO_{2}}$ balance

--- a/docs/source/virtual_rainforest/module_overview.md
+++ b/docs/source/virtual_rainforest/module_overview.md
@@ -32,9 +32,9 @@ The `core` module is responsible for:
 ## Plant Module
 
 The Plant Module models the primary production from plants in the Virtual Rainforest. We
-use the P Model ({cite}`Prentice:2014bc,Wang:2017go`), to estimate the optimal balance
-between water loss and photosynthetic productivity and hence gross primary productivity
-(GPP). The P Model requires estimates of the following drivers:
+use the P Model ({cite}`prentice_balancing_2014,wang_towards_2017`), to estimate the
+optimal balance between water loss and photosynthetic productivity and hence gross
+primary productivity (GPP). The P Model requires estimates of the following drivers:
 
 - Air temperature (°C)
 - Vapour pressure deficit (VPD, Pa)
@@ -44,14 +44,14 @@ between water loss and photosynthetic productivity and hence gross primary produ
 - Photosynthetic photon flux density (PPFD, $\mu \text{mol}, m^{-2}, s^{-1}$)
 
 GPP is then allocated to plant maintenance, respiration and growth using the T Model
-({cite}`Li:2014bc`).
+({cite}`li_simulation_2014`).
 
 This growth model is used to simulate the demographics of cohorts of key plant
 functional types (PFTs) under physiologically structured population models developed in
 the [Plant-FATE](https://jaideep777.github.io/libpspm/) framework. The framework uses
-the perfect-plasticity approximation (PPA, {cite}`purves:2008a`) to model the canopy
-structure of the plant community, the light environments of different PFTs and hence the
-change in the size-structured demography of each PFT through time.
+the perfect-plasticity approximation (PPA, {cite}`purves_predicting_2008`) to model the
+canopy structure of the plant community, the light environments of different PFTs and
+hence the change in the size-structured demography of each PFT through time.
 
 ## Soil Module
 
@@ -101,11 +101,11 @@ Further theoretical background for the soil module can be found
 
 The abiotic module provides the microclimate and hydrology for the Virtual Rainforest.
 Using a small set of input variables from external sources such as WFDE5
-({cite}`WFDE5-2020`) or regional climate models, the module calculates atmospheric and
-soil parameters that drive the dynamics of plants, animals, and microbes at different
-vertical levels. Four subroutines - the radiation balance, the energy balance, the water
-balance, and the atmospheric $\ce{CO_{2}}$ balance - provide the following variables at
-different vertical levels:
+({cite}`cucchi_wfde5_2020`) or regional climate models, the module calculates
+atmospheric and soil parameters that drive the dynamics of plants, animals, and microbes
+at different vertical levels. Four subroutines - the radiation balance, the energy
+balance, the water balance, and the atmospheric $\ce{CO_{2}}$ balance - provide the
+following variables at different vertical levels:
 
 - Net radiation and Photosynthetic photon flux density
 - Air temperature, relative humidity, and vapor pressure deficit
@@ -144,8 +144,9 @@ The Energy balance submodule derives sensible and latent heat fluxes from canopy
 surface to the atmosphere, and updates air temperature, relative humidity, and vapor
 pressure deficit at each level. The vertical mixing between levels is assumed to be
 driven by heat conductance because turbulence is typically low below the canopy
-({cite}`MACLEAN2021`). Part of the net radiation is converted into soil heat flux. The
-vertical exchange of heat between soil levels is coupled to the atmospheric mixing.
+({cite}`maclean_microclimc_2021`). Part of the net radiation is converted into soil heat
+flux. The vertical exchange of heat between soil levels is coupled to the atmospheric
+mixing.
 
 ### The Water balance
 
@@ -156,8 +157,8 @@ infiltration, percolation (= vertical flow), soil moisture profile, water table 
 and subsurface flow out of the grid cell.
 
 The second part of the module caluclates the water balance across the full model grid
-based on the TOPMODEL (e.g. {cite}`Metcalfe2015`)
-including surface runoff, subsurface flow, return flow, and streamflow.
+based on the TOPMODEL (e.g. {cite}`metcalfe_dynamic_2015`) including surface runoff,
+subsurface flow, return flow, and streamflow.
 
 ### The atmospheric $\ce{CO_{2}}$ balance
 

--- a/docs/source/virtual_rainforest/soil/soil_details.md
+++ b/docs/source/virtual_rainforest/soil/soil_details.md
@@ -7,14 +7,14 @@ should probably be split into multiple pages.
 
 The fundamental basis of this module are carbon pools. Historically, the predominant
 framework for modelling soil carbon has been the CENTURY model
-({cite}`parton_analysis_1987`), which divides soil organic matter into three pools
+{cite}`parton_analysis_1987`, which divides soil organic matter into three pools
 (active, slow and passive). These pools are characterised primarily by their turnover
 rates, but are also differentiated by lignin content of the organic matter that flows
 into each pool. This framework has come under sustained criticism as these pools are
 conceptual and not directly measurable. In response to this there has been a movement
 towards using soil carbon pool definitions that defined by measurable physical and
 chemical properties. The Millennial model combines the most commonly used of these soil
-carbon pools into a single model ({cite}`abramoff_millennial_2018`). This model
+carbon pools into a single model {cite}`abramoff_millennial_2018`. This model
 framework is both comprehensive and defines measurable pools, and for this reason we
 make use of it in our soil module.
 
@@ -64,10 +64,10 @@ microbial respiration is one of the major sources of carbon loss to the system.
 ## Litter pools
 
 We also select our litter pools from a pre-existing framework
-({cite}`kirschbaum_modelling_2002`). Here, pools are principally defined by input type,
+{cite}`kirschbaum_modelling_2002`. Here, pools are principally defined by input type,
 e.g. coarse wood, fine wood, structural and metabolic. They are then further subdivided
 into above- and below-ground pools. Some of these pools cannot be fully characterised
-due to insufficient data and so following ({cite}`fatichi_mechanistic_2019`), we neglect
+due to insufficient data and so following {cite}`fatichi_mechanistic_2019`, we neglect
 them. This means that we use a single above-ground woody litter pool, rather than coarse
 and fine woody, and we do not include any below-ground woody pool. This leaves us with
 the following pools

--- a/virtual_rainforest/models/abiotic/radiation.py
+++ b/virtual_rainforest/models/abiotic/radiation.py
@@ -1,6 +1,4 @@
-"""The `abiotic.radiation` module.
-
-The radiation balance at the top of the canopy at a given location depends on
+"""The radiation balance at the top of the canopy at a given location depends on
 
 1. extra-terrestrial radiation (affected by the earth's orbit, date, and location),
 2. terrestrial radiation (affected by atmospheric composition and clouds),
@@ -23,7 +21,7 @@ At this stage, scattering and re-absorption of longwave radiation are not consid
 # series (possibly as part of AbioticModel) and update other variables for each time
 # step with inputs from other modules via the data object (for example absorbed
 # radiation from the plant module)
-"""
+"""  # noqa: D205, D415
 
 from dataclasses import dataclass
 from typing import Union

--- a/virtual_rainforest/models/abiotic/radiation.py
+++ b/virtual_rainforest/models/abiotic/radiation.py
@@ -12,7 +12,7 @@ The preprocessing module takes extra-terrestrial radiation as an input and adjus
 the effects of topography (slope and aspect). Here, the effects of atmospheric
 filtering (elevation-dependent) and cloud cover are added to calculate photosynthetic
 photon flux density (PPFD) at the top of the canopy which is a crucial input to the
-plant module. The implementation is based on :cite:t:`Davis2017`.
+plant module. The implementation is based on :cite:t:`davis_simple_2017`.
 
 Cloud cover and surface albedo also determine how much of the shortwave radiation that
 reaches the top of the canopy is reflected and how much remains to be absorbed via
@@ -42,11 +42,11 @@ class RadiationConstants:
     """Radiation constants dataclass."""
 
     cloudy_transmissivity: float = 0.25
-    """Cloudy transmittivity :cite:p:`Linacre1968`"""
+    """Cloudy transmittivity :cite:p:`linacre_estimating_1968`"""
     transmissivity_coefficient: float = 0.50
-    """Angular coefficient of transmittivity :cite:p:`Linacre1968`"""
+    """Angular coefficient of transmittivity :cite:p:`linacre_estimating_1968`"""
     flux_to_energy: float = 2.04
-    """From flux to energy conversion, umol J-1 :cite:p:`Meek1984`"""
+    """From flux to energy conversion, umol J-1 :cite:p:`meek_generalized_1984`"""
     stefan_boltzmann_constant: float = 5.67e-8
     """Stefan-Boltzmann constant W m-2 K-4"""
     soil_emissivity: float = 0.95
@@ -55,7 +55,7 @@ class RadiationConstants:
     """Canopy emissivity, default for tropical rainforest"""
     beer_regression: float = 2.67e-5
     """Parameter in equation for atmospheric transmissivity based on regression of
-    Beer's radiation extinction function :cite:p:`Allen1996`"""
+    Beer's radiation extinction function :cite:p:`allen_assessing_1996`"""
     celsius_to_kelvin: float = 273.15
     """Factor to convert temperature in Celsius to absolute temperature in Kelvin"""
     albedo_vis_default: float = 0.03
@@ -214,13 +214,13 @@ def calculate_atmospheric_transmissivity(
         elevation: elevation above sea level, [m]
         sunshine_fraction: fraction of sunshine hours, between 0 (100% cloud cover)
             and 1 (cloud free sky), default = 1
-        cloudy_transmissivity: cloudy transmittivity :cite:p:`Linacre1968`, default set
-            in config
-        transmissivity_coefficient: angular coefficient of transmittivity
-            :cite:p:`Linacre1968`, default set in config
-        beer_regression: parameter in equation for atmospheric transmissivity based on
-            regression of Beer's radiation extinction function :cite:p:`Allen1996`,
+        cloudy_transmissivity: cloudy transmittivity :cite:p:`linacre_estimating_1968`,
             default set in config
+        transmissivity_coefficient: angular coefficient of transmittivity
+            :cite:p:`linacre_estimating_1968`, default set in config
+        beer_regression: parameter in equation for atmospheric transmissivity based on
+            regression of Beer's radiation extinction function
+            :cite:p:`allen_assessing_1996`, default set in config
 
     Returns:
         atmospheric transmissivity, unitless
@@ -256,7 +256,7 @@ def calculate_ppfd(
     Returns:
         photosynthetic photon flux density, [mol m-2]
 
-    Reference: :cite:t:`Davis2017`
+    Reference: :cite:t:`davis_simple_2017`
     """
 
     return (1.0e-6) * flux_to_energy * (1.0 - albedo_vis) * tau * shortwave_in

--- a/virtual_rainforest/models/soil/carbon.py
+++ b/virtual_rainforest/models/soil/carbon.py
@@ -1,4 +1,4 @@
-"""The `models.soil.carbon` module  simulates the soil carbon cycle for the Virtual
+"""The ``models.soil.carbon`` module  simulates the soil carbon cycle for the Virtual
 Rainforest. At the moment only two pools are modelled, these are low molecular weight
 carbon (LMWC) and mineral associated organic matter (MAOM). More pools and their
 interactions will be added at a later date.
@@ -96,11 +96,12 @@ class SoilCarbonPools:
     ) -> NDArray[np.float32]:
         """Calculates net rate of LMWC association with soil minerals.
 
-        Following Abramoff et al. (2018), mineral adsorption of carbon is controlled by
-        a Langmuir saturation function. At present, binding affinity and Q_max are
-        recalculated on every function called based on pH, bulk density and clay
-        content. Once a decision has been reached as to how fast pH and bulk density
-        will change (if at all), this calculation may need to be moved elsewhere.
+        Following :cite:t:`abramoff_millennial_2018`, mineral adsorption of carbon is
+        controlled by a Langmuir saturation function. At present, binding affinity and
+        Q_max are recalculated on every function called based on pH, bulk density and
+        clay content. Once a decision has been reached as to how fast pH and bulk
+        density will change (if at all), this calculation may need to be moved
+        elsewhere.
 
         Args:
             pH: pH values for each soil grid cell
@@ -133,8 +134,8 @@ def calculate_max_sorption_capacity(
 
     The maximum sorption capacity is the maximum amount of mineral associated organic
     matter that can exist per unit volume. This expression and its parameters are also
-    drawn from Mayes et al. (2012). In that paper max sorption also depends on Fe
-    content, but we are ignoring this for now.
+    drawn from :cite:t:`mayes_relation_2012`. In that paper max sorption also depends on
+    Fe content, but we are ignoring this for now.
 
     Args:
         bulk_density: bulk density values for each soil grid cell (kg m^-3)
@@ -185,7 +186,8 @@ def calculate_binding_coefficient(
 ) -> NDArray[np.float32]:
     """Calculate Langmuir binding coefficient based on pH.
 
-    This specific expression and its parameters are drawn from (Mayes et al. (2012)).
+    This specific expression and its parameters are drawn from
+    :cite:t:`mayes_relation_2012`.
 
     Args:
         pH: pH values for each soil grid cell
@@ -203,8 +205,8 @@ def convert_temperature_to_scalar(
 ) -> NDArray[np.float32]:
     """Convert soil temperature into a factor to multiply rates by.
 
-    This form is used in Abramoff et al. (2018) to minimise differences with the
-    CENTURY model. We very likely want to define our own functional form here. I'm
+    This form is used in :cite:t:`abramoff_millennial_2018` to minimise differences with
+    the CENTURY model. We very likely want to define our own functional form here. I'm
     also a bit unsure how this form was even obtained, so further work here is very
     needed.
 
@@ -232,8 +234,8 @@ def convert_moisture_to_scalar(
 ) -> NDArray[np.float32]:
     """Convert soil moisture into a factor to multiply rates by.
 
-    This form is used in Abramoff et al. (2018) to minimise differences with the
-    CENTURY model. We very likely want to define our own functional form here. I'm
+    This form is used in :cite:t:`abramoff_millennial_2018` to minimise differences with
+    the CENTURY model. We very likely want to define our own functional form here. I'm
     also a bit unsure how this form was even obtained, so further work here is very
     needed.
 

--- a/virtual_rainforest/models/soil/constants.py
+++ b/virtual_rainforest/models/soil/constants.py
@@ -1,4 +1,4 @@
-"""The `models.soil.constants` module contains a set of dataclasses containing
+"""The ``models.soil.constants`` module contains a set of dataclasses containing
 constants" (fitting relationships taken from the literature) required by the broader
 :mod:`~virtual_rainforest.models.soil` module
 """  # noqa: D205, D415
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 
 @dataclass
 class BindingWithPH:
-    """From linear regression (Mayes et al. (2012))."""
+    """From linear regression :cite:p:`mayes_relation_2012`."""
 
     slope: float = -0.186
     """Units of pH^-1."""
@@ -18,7 +18,7 @@ class BindingWithPH:
 
 @dataclass
 class MaxSorptionWithClay:
-    """From linear regression (Mayes et al. (2012))."""
+    """From linear regression :cite:p:`mayes_relation_2012`."""
 
     slope: float = 0.483
     """Units of (% clay)^-1."""
@@ -28,7 +28,7 @@ class MaxSorptionWithClay:
 
 @dataclass
 class MoistureScalar:
-    """Used in Abramoff et al. (2018), but can't trace it back to anything concrete."""
+    """Used in :cite:t:`abramoff_millennial_2018`, can't find original source."""
 
     coefficient: float = 30.0
     """Value at zero relative water content (RWC) [unit less]."""
@@ -38,7 +38,7 @@ class MoistureScalar:
 
 @dataclass
 class TempScalar:
-    """Used in Abramoff et al. (2018), but can't trace it back to anything concrete."""
+    """Used in :cite:t:`abramoff_millennial_2018`, can't find original source."""
 
     t_1: float = 15.4
     """Unclear exactly what this parameter is [degrees C]"""


### PR DESCRIPTION
# Description

This pull request changes the bibliography file (`refs.bib`) to use the `BibTeX` output of our shared Zotero reference library (found [here](www.zotero.org/virtual_rainforest/)). The links have been updated to match this new system of tags. 

In future, whenever items are added to the bibliography they should be added to the shared Zotero library and the `refs.bib` file should be redownloaded and used to replace the previous `refs.bib` file.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
