### PR TITLE
Change SoilModel to use the data object

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -104,7 +104,6 @@ bibtex_reference_style = "author_year_round"
 nitpicky = True
 nitpick_ignore = [
     ("py:class", "jsonschema.validators.Draft202012Validator"),
-    ("py:class", "numpy.float32"),
     ("py:class", "numpy.int64"),
     # TODO - Delete this once Vivienne has merged this feature into develop
     ("py:class", "virtual_rainforest.models.abiotic.Energy_balance"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,8 +18,7 @@ def log_check(caplog: pytest.LogCaptureFixture, expected_log: tuple[tuple]) -> N
 
     Arguments:
         caplog: An instance of the caplog fixture
-        expected_log: An iterable of 2-tuples containing the
-            log level and message.
+        expected_log: An iterable of 2-tuples containing the log level and message.
     """
 
     assert len(expected_log) == len(caplog.records)
@@ -112,7 +111,10 @@ def dummy_carbon_data():
     grid = Grid(cell_nx=4, cell_ny=1)
     data = Data(grid)
 
-    # Add the required data.
+    # The required data is now added. This includes the two carbon pools: mineral
+    # associated organic matter and low molecular weight carbon. It also includes
+    # various factors of the physical environment: pH, bulk density, soil moisture, soil
+    # temperature, percentage clay in soil.
     data["mineral_associated_om"] = DataArray([2.5, 1.7, 4.5, 0.5], dims=["cell_id"])
     """Mineral associated organic matter pool (kg C m^-3)"""
     data["low_molecular_weight_c"] = DataArray(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,29 @@ def data_instance():
 
 
 @pytest.fixture
+def dummy_carbon_data():
+    """Creates a dummy carbon data object for use in tests."""
+
+    from virtual_rainforest.core.data import Data
+    from virtual_rainforest.core.grid import Grid
+
+    # Setup the data object with four cells.
+    grid = Grid(cell_nx=4, cell_ny=1)
+    data = Data(grid)
+
+    # Add the required data.
+    data["maom"] = DataArray([2.5, 1.7, 4.5, 0.5], dims=["cell_id"])
+    data["lmwc"] = DataArray([0.05, 0.02, 0.1, 0.005], dims=["cell_id"])
+    data["pH"] = DataArray([3.0, 7.5, 9.0, 5.7], dims=["cell_id"])
+    data["bulk_density"] = DataArray([1350.0, 1800.0, 1000.0, 1500.0], dims=["cell_id"])
+    data["soil_moisture"] = DataArray([0.5, 0.7, 0.6, 0.2], dims=["cell_id"])
+    data["soil_temperature"] = DataArray([35.0, 37.5, 40.0, 25.0], dims=["cell_id"])
+    data["percent_clay"] = DataArray([80.0, 30.0, 10.0, 90.0], dims=["cell_id"])
+
+    return data
+
+
+@pytest.fixture
 def new_axis_validators():
     """Create new axis validators to test methods and registration."""
     from virtual_rainforest.core.axes import AxisValidator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,9 +113,11 @@ def dummy_carbon_data():
     data = Data(grid)
 
     # Add the required data.
-    data["maom"] = DataArray([2.5, 1.7, 4.5, 0.5], dims=["cell_id"])
+    data["mineral_associated_om"] = DataArray([2.5, 1.7, 4.5, 0.5], dims=["cell_id"])
     """Mineral associated organic matter pool (kg C m^-3)"""
-    data["lmwc"] = DataArray([0.05, 0.02, 0.1, 0.005], dims=["cell_id"])
+    data["low_molecular_weight_c"] = DataArray(
+        [0.05, 0.02, 0.1, 0.005], dims=["cell_id"]
+    )
     """Low molecular weight carbon pool (kg C m^-3)"""
     data["pH"] = DataArray([3.0, 7.5, 9.0, 5.7], dims=["cell_id"])
     data["bulk_density"] = DataArray([1350.0, 1800.0, 1000.0, 1500.0], dims=["cell_id"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,7 +114,9 @@ def dummy_carbon_data():
 
     # Add the required data.
     data["maom"] = DataArray([2.5, 1.7, 4.5, 0.5], dims=["cell_id"])
+    """Mineral associated organic matter pool (kg C m^-3)"""
     data["lmwc"] = DataArray([0.05, 0.02, 0.1, 0.005], dims=["cell_id"])
+    """Low molecular weight carbon pool (kg C m^-3)"""
     data["pH"] = DataArray([3.0, 7.5, 9.0, 5.7], dims=["cell_id"])
     data["bulk_density"] = DataArray([1350.0, 1800.0, 1000.0, 1500.0], dims=["cell_id"])
     data["soil_moisture"] = DataArray([0.5, 0.7, 0.6, 0.2], dims=["cell_id"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Collection of fixtures to assist the testing scripts."""
+from logging import DEBUG
 from typing import Any
 
 import pytest
@@ -6,7 +7,10 @@ from xarray import DataArray
 
 # An import of LOGGER is required for INFO logging events to be visible to tests
 # This can be removed as soon as a script that imports logger is imported
-import virtual_rainforest.core.logger  # noqa
+from virtual_rainforest.core.logger import LOGGER
+
+# Class uses DEBUG
+LOGGER.setLevel(DEBUG)
 
 
 def log_check(caplog: pytest.LogCaptureFixture, expected_log: tuple[tuple]) -> None:

--- a/tests/core/data/all_config.toml
+++ b/tests/core/data/all_config.toml
@@ -22,5 +22,4 @@ pft_name = "broadleaf"
 maxh = 50.0
 
 [soil]
-no_layers = 1
 model_time_step = "5 days"

--- a/tests/core/test_base_model.py
+++ b/tests/core/test_base_model.py
@@ -303,11 +303,6 @@ def test_check_required_init_vars(
 
     from virtual_rainforest.core.base_model import BaseModel
     from virtual_rainforest.core.data import Data
-    from virtual_rainforest.core.logger import LOGGER
-
-    # Class uses DEBUG
-    # TODO - might want to do this centrally in conftest.py
-    LOGGER.setLevel(DEBUG)
 
     class TestCaseModel(BaseModel):
         model_name = "init_var"

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -458,7 +458,8 @@ def test_missing_core_schema(caplog, mocker):
                 ),
                 (
                     ERROR,
-                    "[soil][no_layers]: -1 is less than or equal to the minimum of 0",
+                    "[soil]: Additional properties are not allowed ('no_layers' was "
+                    "unexpected)",
                 ),
                 (
                     CRITICAL,

--- a/tests/core/test_readers.py
+++ b/tests/core/test_readers.py
@@ -45,11 +45,7 @@ def test_file_format_loader(caplog, file_types, expected_log):
 
     # Import register_data_loader - this triggers the registration of existing data
     # loaders so need to clear those log messages before trying new ones
-    from virtual_rainforest.core.logger import LOGGER
     from virtual_rainforest.core.readers import register_file_format_loader
-
-    # Capture debug/setup messages
-    LOGGER.setLevel("DEBUG")
 
     # Create an existing one to test replace modes
     @register_file_format_loader(file_types=".ghi")

--- a/tests/models/soil/test_carbon.py
+++ b/tests/models/soil/test_carbon.py
@@ -85,15 +85,15 @@ def test_pool_updates(dummy_carbon_data):
     )
 
     # Check that the updates are correctly calculated
-    assert np.allclose(delta_pools.delta_maom, np.array(change_in_pools[0]))
-    assert np.allclose(delta_pools.delta_lmwc, np.array(change_in_pools[1]))
+    assert np.allclose(delta_pools.delta_maom, change_in_pools[0])
+    assert np.allclose(delta_pools.delta_lmwc, change_in_pools[1])
 
     # Use this update to update the soil carbon pools
     soil_carbon.update_soil_carbon_pools(delta_pools)
 
     # Then check that pools are correctly incremented based on update
-    assert np.allclose(soil_carbon.maom, np.array(end_maom))
-    assert np.allclose(soil_carbon.lmwc, np.array(end_lmwc))
+    assert np.allclose(soil_carbon.maom, end_maom)
+    assert np.allclose(soil_carbon.lmwc, end_lmwc)
 
 
 def test_mineral_association(dummy_carbon_data):
@@ -127,7 +127,7 @@ def test_calculate_equilibrium_maom(dummy_carbon_data):
     equib_maoms = calculate_equilibrium_maom(
         dummy_carbon_data["pH"], Q_max, dummy_carbon_data["lmwc"]
     )
-    assert np.allclose(equib_maoms, np.array(output_eqb_maoms))
+    assert np.allclose(equib_maoms, output_eqb_maoms)
 
 
 @pytest.mark.parametrize(
@@ -176,7 +176,7 @@ def test_calculate_max_sorption_capacity(
                 dummy_carbon_data["bulk_density"], dummy_carbon_data["percent_clay"]
             )
 
-        assert np.allclose(max_capacities, np.array(output_capacities))
+        assert np.allclose(max_capacities, output_capacities)
 
     log_check(caplog, expected_log_entries)
 
@@ -189,7 +189,7 @@ def test_calculate_binding_coefficient(dummy_carbon_data):
 
     binding_coefs = calculate_binding_coefficient(dummy_carbon_data["pH"])
 
-    assert np.allclose(binding_coefs, np.array(output_coefs))
+    assert np.allclose(binding_coefs, output_coefs)
 
 
 def test_convert_temperature_to_scalar(dummy_carbon_data):
@@ -200,7 +200,7 @@ def test_convert_temperature_to_scalar(dummy_carbon_data):
 
     temp_scalar = convert_temperature_to_scalar(dummy_carbon_data["soil_temperature"])
 
-    assert np.allclose(temp_scalar, np.array(output_scalars))
+    assert np.allclose(temp_scalar, output_scalars)
 
 
 @pytest.mark.parametrize(
@@ -238,6 +238,6 @@ def test_convert_moisture_to_scalar(
                 dummy_carbon_data["soil_moisture"]
             )
 
-        assert np.allclose(moist_scalar, np.array(output_scalars))
+        assert np.allclose(moist_scalar, output_scalars)
 
     log_check(caplog, expected_log_entries)

--- a/tests/models/soil/test_carbon.py
+++ b/tests/models/soil/test_carbon.py
@@ -15,29 +15,6 @@ from virtual_rainforest.core.base_model import InitialisationError
 from virtual_rainforest.models.soil.carbon import SoilCarbonPools
 
 
-@pytest.fixture
-def dummy_carbon_data():
-    """Creates a dummy carbon data object for use in tests."""
-
-    from virtual_rainforest.core.data import Data
-    from virtual_rainforest.core.grid import Grid
-
-    # Setup the data object with four cells.
-    grid = Grid(cell_nx=4, cell_ny=1)
-    data = Data(grid)
-
-    # Add the required data.
-    data["maom"] = DataArray([2.5, 1.7, 4.5, 0.5], dims=["cell_id"])
-    data["lmwc"] = DataArray([0.05, 0.02, 0.1, 0.005], dims=["cell_id"])
-    data["pH"] = DataArray([3.0, 7.5, 9.0, 5.7], dims=["cell_id"])
-    data["bulk_density"] = DataArray([1350.0, 1800.0, 1000.0, 1500.0], dims=["cell_id"])
-    data["soil_moisture"] = DataArray([0.5, 0.7, 0.6, 0.2], dims=["cell_id"])
-    data["soil_temperature"] = DataArray([35.0, 37.5, 40.0, 25.0], dims=["cell_id"])
-    data["percent_clay"] = DataArray([80.0, 30.0, 10.0, 90.0], dims=["cell_id"])
-
-    return data
-
-
 def test_soil_carbon_class(dummy_carbon_data):
     """Test SoilCarbon class can be initialised."""
 

--- a/tests/models/soil/test_carbon.py
+++ b/tests/models/soil/test_carbon.py
@@ -147,7 +147,8 @@ def test_pool_updates(
     )
 
     # Check that the updates are correctly calculated
-    assert np.allclose(delta_pools, np.array(change_in_pools))
+    assert np.allclose(delta_pools.delta_maom, np.array(change_in_pools[0]))
+    assert np.allclose(delta_pools.delta_lmwc, np.array(change_in_pools[1]))
 
     # Use this update to update the soil carbon pools
     soil_carbon.update_soil_carbon_pools(delta_pools)

--- a/tests/models/soil/test_carbon.py
+++ b/tests/models/soil/test_carbon.py
@@ -33,8 +33,8 @@ def test_bad_soil_carbon_class(caplog):
     data = Data(grid)
 
     # Add the required data.
-    data["maom"] = DataArray([2.5], dims=["cell_id"])
-    data["lmwc"] = DataArray([-0.05], dims=["cell_id"])
+    data["mineral_associated_om"] = DataArray([2.5], dims=["cell_id"])
+    data["low_molecular_weight_c"] = DataArray([-0.05], dims=["cell_id"])
 
     # Check that initialisation fails as expected
     with pytest.raises(InitialisationError):
@@ -43,11 +43,11 @@ def test_bad_soil_carbon_class(caplog):
     expected_log_entries = (
         (
             INFO,
-            "Adding data array for 'maom'",
+            "Adding data array for 'mineral_associated_om'",
         ),
         (
             INFO,
-            "Adding data array for 'lmwc'",
+            "Adding data array for 'low_molecular_weight_c'",
         ),
         (
             ERROR,
@@ -90,8 +90,8 @@ def test_pool_updates(dummy_carbon_data):
     soil_carbon.update_soil_carbon_pools(dummy_carbon_data, delta_pools)
 
     # Then check that pools are correctly incremented based on update
-    assert np.allclose(dummy_carbon_data["maom"], end_maom)
-    assert np.allclose(dummy_carbon_data["lmwc"], end_lmwc)
+    assert np.allclose(dummy_carbon_data["mineral_associated_om"], end_maom)
+    assert np.allclose(dummy_carbon_data["low_molecular_weight_c"], end_lmwc)
 
 
 def test_mineral_association(dummy_carbon_data):
@@ -124,7 +124,7 @@ def test_calculate_equilibrium_maom(dummy_carbon_data):
     output_eqb_maoms = [19900.19, 969.4813, 832.6088, 742.4128]
 
     equib_maoms = calculate_equilibrium_maom(
-        dummy_carbon_data["pH"], Q_max, dummy_carbon_data["lmwc"]
+        dummy_carbon_data["pH"], Q_max, dummy_carbon_data["low_molecular_weight_c"]
     )
     assert np.allclose(equib_maoms, output_eqb_maoms)
 

--- a/tests/models/soil/test_carbon.py
+++ b/tests/models/soil/test_carbon.py
@@ -19,10 +19,7 @@ def test_soil_carbon_class(dummy_carbon_data):
     """Test SoilCarbon class can be initialised."""
 
     # Check that initialisation succeeds as expected
-    soil_carbon = SoilCarbonPools(dummy_carbon_data)
-
-    assert (soil_carbon.maom == dummy_carbon_data["maom"]).all()
-    assert (soil_carbon.lmwc == dummy_carbon_data["lmwc"]).all()
+    _ = SoilCarbonPools(dummy_carbon_data)
 
 
 def test_bad_soil_carbon_class(caplog):
@@ -76,6 +73,7 @@ def test_pool_updates(dummy_carbon_data):
     end_lmwc = [0.04980117, 0.01999411, 0.09992829, 0.00499986]
 
     delta_pools = soil_carbon.calculate_soil_carbon_updates(
+        dummy_carbon_data,
         dummy_carbon_data["pH"],
         dummy_carbon_data["bulk_density"],
         dummy_carbon_data["soil_moisture"],
@@ -89,11 +87,11 @@ def test_pool_updates(dummy_carbon_data):
     assert np.allclose(delta_pools.delta_lmwc, change_in_pools[1])
 
     # Use this update to update the soil carbon pools
-    soil_carbon.update_soil_carbon_pools(delta_pools)
+    soil_carbon.update_soil_carbon_pools(dummy_carbon_data, delta_pools)
 
     # Then check that pools are correctly incremented based on update
-    assert np.allclose(soil_carbon.maom, end_maom)
-    assert np.allclose(soil_carbon.lmwc, end_lmwc)
+    assert np.allclose(dummy_carbon_data["maom"], end_maom)
+    assert np.allclose(dummy_carbon_data["lmwc"], end_lmwc)
 
 
 def test_mineral_association(dummy_carbon_data):
@@ -106,6 +104,7 @@ def test_mineral_association(dummy_carbon_data):
 
     # Then calculate mineral association rate
     lmwc_to_maom = soil_carbon.mineral_association(
+        dummy_carbon_data,
         dummy_carbon_data["pH"],
         dummy_carbon_data["bulk_density"],
         dummy_carbon_data["soil_moisture"],

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -1,13 +1,12 @@
 """Test module for soil_model.py."""
 
 from contextlib import nullcontext as does_not_raise
-from logging import ERROR, INFO
+from logging import INFO
 
 import pytest
 from numpy import datetime64, timedelta64
 
 from tests.conftest import log_check
-from virtual_rainforest.core.base_model import InitialisationError
 from virtual_rainforest.models.soil.soil_model import SoilModel
 
 
@@ -19,26 +18,6 @@ from virtual_rainforest.models.soil.soil_model import SoilModel
             does_not_raise(),
             (),
         ),
-        (
-            -2,
-            pytest.raises(InitialisationError),
-            (
-                (
-                    ERROR,
-                    "There has to be at least one soil layer in the soil model!",
-                ),
-            ),
-        ),
-        (
-            2.5,
-            pytest.raises(InitialisationError),
-            (
-                (
-                    ERROR,
-                    "The number of soil layers must be an integer!",
-                ),
-            ),
-        ),
     ],
 )
 def test_soil_model_initialization(
@@ -48,9 +27,7 @@ def test_soil_model_initialization(
 
     with raises:
         # Initialize model
-        model = SoilModel(
-            data_instance, timedelta64(1, "W"), datetime64("2022-11-01"), no_layers
-        )
+        model = SoilModel(data_instance, timedelta64(1, "W"), datetime64("2022-11-01"))
 
         # In cases where it passes then checks that the object has the right properties
         assert set(["setup", "spinup", "update", "cleanup"]).issubset(dir(model))
@@ -58,8 +35,7 @@ def test_soil_model_initialization(
         assert str(model) == "A soil model instance"
         assert (
             repr(model)
-            == f"SoilModel(update_interval = 1 weeks, next_update = 2022-11-08, "
-            f"no_layers = {int(no_layers)})"
+            == "SoilModel(update_interval = 1 weeks, next_update = 2022-11-08)"
         )
 
     # Final check that expected logging entries are produced
@@ -78,7 +54,7 @@ def test_soil_model_initialization(
         (
             {
                 "core": {"timing": {"start_time": "2020-01-01"}},
-                "soil": {"no_layers": 2, "model_time_step": "12 hours"},
+                "soil": {"model_time_step": "12 hours"},
             },
             timedelta64(12, "h"),
             does_not_raise(),
@@ -100,7 +76,6 @@ def test_generate_soil_model(
     # Check whether model is initialised (or not) as expected
     with raises:
         model = SoilModel.from_config(data_instance, config)
-        assert model.no_layers == config["soil"]["no_layers"]
         assert model.update_interval == time_interval
         assert (
             model.next_update

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -169,6 +169,8 @@ def test_soil_model_initialization(
                     DEBUG,
                     "soil model: required var 'percent_clay' checked",
                 ),
+                (INFO, "Replacing data array for 'maom'"),
+                (INFO, "Replacing data array for 'lmwc'"),
             ),
             [
                 [2.50019883, 1.70000589, 4.50007171, 0.50000014],
@@ -202,10 +204,7 @@ def test_generate_soil_model(
             model.next_update
             == datetime64(config["core"]["timing"]["start_time"]) + 2 * time_interval
         )
-        # Check that updates are correct
-        assert allclose(model.carbon.maom, end_carbon[0])
-        assert allclose(model.carbon.lmwc, end_carbon[1])
-        # Check that the data fixture has also been updated
+        # Check that updates to data fixture are correct
         assert allclose(dummy_carbon_data["maom"], end_carbon[0])
         assert allclose(dummy_carbon_data["lmwc"], end_carbon[1])
 

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -21,13 +21,15 @@ from virtual_rainforest.models.soil.soil_model import SoilModel
     ],
 )
 def test_soil_model_initialization(
-    caplog, data_instance, no_layers, raises, expected_log_entries
+    caplog, dummy_carbon_data, no_layers, raises, expected_log_entries
 ):
     """Test `SoilModel` initialization."""
 
     with raises:
         # Initialize model
-        model = SoilModel(data_instance, timedelta64(1, "W"), datetime64("2022-11-01"))
+        model = SoilModel(
+            dummy_carbon_data, timedelta64(1, "W"), datetime64("2022-11-01")
+        )
 
         # In cases where it passes then checks that the object has the right properties
         assert set(["setup", "spinup", "update", "cleanup"]).issubset(dir(model))
@@ -69,13 +71,13 @@ def test_soil_model_initialization(
     ],
 )
 def test_generate_soil_model(
-    caplog, data_instance, config, time_interval, raises, expected_log_entries
+    caplog, dummy_carbon_data, config, time_interval, raises, expected_log_entries
 ):
     """Test that the function to initialise the soil model behaves as expected."""
 
     # Check whether model is initialised (or not) as expected
     with raises:
-        model = SoilModel.from_config(data_instance, config)
+        model = SoilModel.from_config(dummy_carbon_data, config)
         assert model.update_interval == time_interval
         assert (
             model.next_update

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -19,11 +19,11 @@ from virtual_rainforest.models.soil.soil_model import SoilModel
             (
                 (
                     DEBUG,
-                    "soil model: required var 'maom' checked",
+                    "soil model: required var 'mineral_associated_om' checked",
                 ),
                 (
                     DEBUG,
-                    "soil model: required var 'lmwc' checked",
+                    "soil model: required var 'low_molecular_weight_c' checked",
                 ),
                 (
                     DEBUG,
@@ -53,11 +53,13 @@ from virtual_rainforest.models.soil.soil_model import SoilModel
             (
                 (
                     ERROR,
-                    "soil model: init data missing required var 'maom'",
+                    "soil model: init data missing required var "
+                    "'mineral_associated_om'",
                 ),
                 (
                     ERROR,
-                    "soil model: init data missing required var 'lmwc'",
+                    "soil model: init data missing required var "
+                    "'low_molecular_weight_c'",
                 ),
                 (
                     ERROR,
@@ -143,11 +145,11 @@ def test_soil_model_initialization(
                 ),
                 (
                     DEBUG,
-                    "soil model: required var 'maom' checked",
+                    "soil model: required var 'mineral_associated_om' checked",
                 ),
                 (
                     DEBUG,
-                    "soil model: required var 'lmwc' checked",
+                    "soil model: required var 'low_molecular_weight_c' checked",
                 ),
                 (
                     DEBUG,
@@ -169,8 +171,8 @@ def test_soil_model_initialization(
                     DEBUG,
                     "soil model: required var 'percent_clay' checked",
                 ),
-                (INFO, "Replacing data array for 'maom'"),
-                (INFO, "Replacing data array for 'lmwc'"),
+                (INFO, "Replacing data array for 'mineral_associated_om'"),
+                (INFO, "Replacing data array for 'low_molecular_weight_c'"),
             ),
             [
                 [2.50019883, 1.70000589, 4.50007171, 0.50000014],
@@ -205,8 +207,8 @@ def test_generate_soil_model(
             == datetime64(config["core"]["timing"]["start_time"]) + 2 * time_interval
         )
         # Check that updates to data fixture are correct
-        assert allclose(dummy_carbon_data["maom"], end_carbon[0])
-        assert allclose(dummy_carbon_data["lmwc"], end_carbon[1])
+        assert allclose(dummy_carbon_data["mineral_associated_om"], end_carbon[0])
+        assert allclose(dummy_carbon_data["low_molecular_weight_c"], end_carbon[1])
 
     # Final check that expected logging entries are produced
     log_check(caplog, expected_log_entries)

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -1,7 +1,7 @@
 """Test module for soil_model.py."""
 
 from contextlib import nullcontext as does_not_raise
-from logging import INFO
+from logging import DEBUG, INFO
 
 import pytest
 from numpy import datetime64, timedelta64
@@ -16,7 +16,36 @@ from virtual_rainforest.models.soil.soil_model import SoilModel
         (
             2,
             does_not_raise(),
-            (),
+            (
+                (
+                    DEBUG,
+                    "soil model: required var 'maom' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'lmwc' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'pH' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'bulk_density' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'soil_moisture' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'soil_temperature' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'percent_clay' checked",
+                ),
+            ),
         ),
     ],
 )
@@ -65,6 +94,34 @@ def test_soil_model_initialization(
                     INFO,
                     "Information required to initialise the soil model successfully "
                     "extracted.",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'maom' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'lmwc' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'pH' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'bulk_density' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'soil_moisture' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'soil_temperature' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'percent_clay' checked",
                 ),
             ),
         ),

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -1,7 +1,7 @@
 """Test module for soil_model.py."""
 
 from contextlib import nullcontext as does_not_raise
-from logging import DEBUG, INFO
+from logging import DEBUG, ERROR, INFO
 
 import pytest
 from numpy import datetime64, timedelta64
@@ -11,10 +11,10 @@ from virtual_rainforest.models.soil.soil_model import SoilModel
 
 
 @pytest.mark.parametrize(
-    "no_layers,raises,expected_log_entries",
+    "bad_data,raises,expected_log_entries",
     [
         (
-            2,
+            False,
             does_not_raise(),
             (
                 (
@@ -47,18 +47,63 @@ from virtual_rainforest.models.soil.soil_model import SoilModel
                 ),
             ),
         ),
+        (
+            True,
+            pytest.raises(ValueError),
+            (
+                (
+                    ERROR,
+                    "soil model: init data missing required var 'maom'",
+                ),
+                (
+                    ERROR,
+                    "soil model: init data missing required var 'lmwc'",
+                ),
+                (
+                    ERROR,
+                    "soil model: init data missing required var 'pH'",
+                ),
+                (
+                    ERROR,
+                    "soil model: init data missing required var 'bulk_density'",
+                ),
+                (
+                    ERROR,
+                    "soil model: init data missing required var 'soil_moisture'",
+                ),
+                (
+                    ERROR,
+                    "soil model: init data missing required var 'soil_temperature'",
+                ),
+                (
+                    ERROR,
+                    "soil model: init data missing required var 'percent_clay'",
+                ),
+                (
+                    ERROR,
+                    "soil model: error checking required_init_vars, see log.",
+                ),
+            ),
+        ),
     ],
 )
 def test_soil_model_initialization(
-    caplog, dummy_carbon_data, no_layers, raises, expected_log_entries
+    caplog, dummy_carbon_data, bad_data, raises, expected_log_entries
 ):
     """Test `SoilModel` initialization."""
 
     with raises:
         # Initialize model
-        model = SoilModel(
-            dummy_carbon_data, timedelta64(1, "W"), datetime64("2022-11-01")
-        )
+        if bad_data:
+            model = SoilModel(
+                [3.0, 4.0],
+                timedelta64(1, "W"),
+                datetime64("2022-11-01"),
+            )
+        else:
+            model = SoilModel(
+                dummy_carbon_data, timedelta64(1, "W"), datetime64("2022-11-01")
+            )
 
         # In cases where it passes then checks that the object has the right properties
         assert set(["setup", "spinup", "update", "cleanup"]).issubset(dir(model))

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -205,7 +205,9 @@ def test_generate_soil_model(
         # Check that updates are correct
         assert allclose(model.carbon.maom, end_carbon[0])
         assert allclose(model.carbon.lmwc, end_carbon[1])
-        # TODO - Check what has happened with the data fixture
+        # Check that the data fixture has also been updated
+        assert allclose(dummy_carbon_data["maom"], end_carbon[0])
+        assert allclose(dummy_carbon_data["lmwc"], end_carbon[1])
 
     # Final check that expected logging entries are produced
     log_check(caplog, expected_log_entries)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,13 +12,7 @@ import pytest
 from numpy import datetime64, timedelta64
 
 from virtual_rainforest.core.base_model import BaseModel, InitialisationError
-from virtual_rainforest.main import (
-    check_for_fast_models,
-    configure_models,
-    extract_timing_details,
-    select_models,
-    vr_run,
-)
+from virtual_rainforest.main import vr_run
 from virtual_rainforest.models.soil.soil_model import SoilModel
 
 from .conftest import log_check
@@ -73,6 +67,7 @@ from .conftest import log_check
 )
 def test_select_models(caplog, model_list, no_models, raises, expected_log_entries):
     """Test the model selecting function."""
+    from virtual_rainforest.main import select_models
 
     with raises:
         models = select_models(model_list)
@@ -130,14 +125,15 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
     ],
 )
 def test_configure_models(
-    caplog, data_instance, config, output, raises, expected_log_entries
+    caplog, dummy_carbon_data, config, output, raises, expected_log_entries
 ):
     """Test the function that configures the models."""
+    from virtual_rainforest.main import configure_models, select_models
 
     with raises:
         model_list = select_models(["soil"])
 
-        models = configure_models(config, data_instance, model_list)
+        models = configure_models(config, dummy_carbon_data, model_list)
 
         if output is None:
             assert models == [None]
@@ -313,6 +309,7 @@ def test_vr_run_bad_model(mocker, caplog):
 )
 def test_extract_timing_details(caplog, config, output, raises, expected_log_entries):
     """Test that function to extract main loop timing works as intended."""
+    from virtual_rainforest.main import extract_timing_details
 
     with raises:
         current_time, update_interval, end_time = extract_timing_details(config)
@@ -342,6 +339,7 @@ def test_extract_timing_details(caplog, config, output, raises, expected_log_ent
 )
 def test_check_for_fast_models(caplog, update_interval, expected_log_entries):
     """Test that function to warn user about short module time steps works."""
+    from virtual_rainforest.main import check_for_fast_models
 
     # Create SoilModel instance and then populate the update_interval
     model = SoilModel.__new__(SoilModel)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -87,11 +87,11 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
     [
         pytest.param(
             {  # valid config
-                "soil": {"no_layers": 1, "model_time_step": "7 days"},
+                "soil": {"model_time_step": "7 days"},
                 "core": {"timing": {"start_time": "2020-01-01"}},
             },
-            "SoilModel(update_interval = 10080 minutes, next_update = 2020-01-08T00:00,"
-            " no_layers = 1)",
+            "SoilModel(update_interval = 10080 minutes, next_update = 2020-01-08T00:00"
+            ")",
             does_not_raise(),
             (
                 (INFO, "Attempting to configure the following models: ['soil']"),
@@ -104,34 +104,8 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
             id="valid config",
         ),
         pytest.param(
-            {  # invalid soil config tag
-                "soil": {"no_layers": -1, "model_time_step": "7 days"},
-                "core": {"timing": {"start_time": "2020-01-01"}},
-            },
-            None,
-            pytest.raises(InitialisationError),
-            (
-                (INFO, "Attempting to configure the following models: ['soil']"),
-                (
-                    INFO,
-                    "Information required to initialise the soil model successfully "
-                    "extracted.",
-                ),
-                (
-                    ERROR,
-                    "There has to be at least one soil layer in the soil model!",
-                ),
-                (
-                    CRITICAL,
-                    "Could not configure all the desired models, ending the "
-                    "simulation.",
-                ),
-            ),
-            id="invalid soil config tag",
-        ),
-        pytest.param(
             {  # model_time_step missing units
-                "soil": {"no_layers": 1, "model_time_step": "7"},
+                "soil": {"model_time_step": "7"},
                 "core": {"timing": {}},
             },
             None,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ defined in main.py that it calls.
 """
 
 from contextlib import nullcontext as does_not_raise
-from logging import CRITICAL, ERROR, INFO, WARNING
+from logging import CRITICAL, DEBUG, ERROR, INFO, WARNING
 from pathlib import Path
 
 import pytest
@@ -94,6 +94,34 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
                     INFO,
                     "Information required to initialise the soil model successfully "
                     "extracted.",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'maom' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'lmwc' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'pH' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'bulk_density' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'soil_moisture' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'soil_temperature' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'percent_clay' checked",
                 ),
             ),
             id="valid config",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -97,11 +97,11 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
                 ),
                 (
                     DEBUG,
-                    "soil model: required var 'maom' checked",
+                    "soil model: required var 'mineral_associated_om' checked",
                 ),
                 (
                     DEBUG,
-                    "soil model: required var 'lmwc' checked",
+                    "soil model: required var 'low_molecular_weight_c' checked",
                 ),
                 (
                     DEBUG,

--- a/virtual_rainforest/models/soil/carbon.py
+++ b/virtual_rainforest/models/soil/carbon.py
@@ -33,7 +33,9 @@ class SoilCarbonPools:
     def __init__(self, data: Data) -> None:
         """Initialise set of carbon pools."""
 
-        if np.any(data["maom"] < 0.0) or np.any(data["lmwc"] < 0.0):
+        if np.any(data["mineral_associated_om"] < 0.0) or np.any(
+            data["low_molecular_weight_c"] < 0.0
+        ):
             to_raise = InitialisationError(
                 "Initial carbon pools contain at least one negative value!"
             )
@@ -55,8 +57,8 @@ class SoilCarbonPools:
             delta_pools: Array of updates for every pool
         """
 
-        data["maom"] += delta_pools["delta_maom"]
-        data["lmwc"] += delta_pools["delta_lmwc"]
+        data["mineral_associated_om"] += delta_pools["delta_maom"]
+        data["low_molecular_weight_c"] += delta_pools["delta_lmwc"]
 
     def calculate_soil_carbon_updates(
         self,
@@ -84,7 +86,7 @@ class SoilCarbonPools:
             dt: time step (days)
 
         Returns:
-            A vector containing net changes to each pool. Order [lmwc, moam].
+            A vector containing net changes to each pool. Order [lmwc, maom].
         """
         # TODO - Add interactions which involve the three missing carbon pools
 
@@ -135,7 +137,9 @@ class SoilCarbonPools:
 
         # Calculate
         Q_max = calculate_max_sorption_capacity(bulk_density, percent_clay)
-        equib_maom = calculate_equilibrium_maom(pH, Q_max, data["lmwc"])
+        equib_maom = calculate_equilibrium_maom(
+            pH, Q_max, data["low_molecular_weight_c"]
+        )
 
         # Find scalar factors that multiple rates
         temp_scalar = convert_temperature_to_scalar(soil_temp)
@@ -144,8 +148,8 @@ class SoilCarbonPools:
         return (
             temp_scalar
             * moist_scalar
-            * data["lmwc"]
-            * (equib_maom - data["maom"])
+            * data["low_molecular_weight_c"]
+            * (equib_maom - data["mineral_associated_om"])
             / Q_max
         )
 

--- a/virtual_rainforest/models/soil/carbon.py
+++ b/virtual_rainforest/models/soil/carbon.py
@@ -8,6 +8,7 @@ import numpy as np
 from xarray import DataArray, Dataset
 
 from virtual_rainforest.core.base_model import InitialisationError
+from virtual_rainforest.core.data import Data
 from virtual_rainforest.core.logger import LOGGER
 from virtual_rainforest.models.soil.constants import (
     BindingWithPH,
@@ -29,28 +30,19 @@ class SoilCarbonPools:
     carbon pools, other pools in the soil module, or other modules.
     """
 
-    def __init__(self, maom: DataArray, lmwc: DataArray) -> None:
+    def __init__(self, data: Data) -> None:
         """Initialise set of carbon pools."""
 
-        # Check that arrays are of equal size and shape
-        if maom.shape != lmwc.shape:
-            to_raise = InitialisationError(
-                "Dimension mismatch for initial carbon pools!",
-            )
-            LOGGER.error(to_raise)
-            raise to_raise
-
-        # Check that negative initial values are not given
-        if np.any(maom < 0) or np.any(lmwc < 0):
+        if np.any(data["maom"] < 0.0) or np.any(data["lmwc"] < 0.0):
             to_raise = InitialisationError(
                 "Initial carbon pools contain at least one negative value!"
             )
             LOGGER.error(to_raise)
             raise to_raise
 
-        self.maom = maom
+        self.maom = data["maom"]
         """Mineral associated organic matter pool (kg C m^-3)"""
-        self.lmwc = lmwc
+        self.lmwc = data["lmwc"]
         """Low molecular weight carbon pool (kg C m^-3)"""
 
     def update_soil_carbon_pools(self, delta_pools: Dataset) -> None:

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -57,28 +57,11 @@ class SoilModel(BaseModel):
         data: Data,
         update_interval: timedelta64,
         start_time: datetime64,
-        no_layers: int,
         **kwargs: Any,
     ):
-        if no_layers < 1:
-            to_raise = InitialisationError(
-                "There has to be at least one soil layer in the soil model!"
-            )
-            LOGGER.error(to_raise)
-            raise to_raise
-
-        if no_layers != int(no_layers):
-            to_raise = InitialisationError(
-                "The number of soil layers must be an integer!"
-            )
-            LOGGER.error(to_raise)
-            raise to_raise
-
         super().__init__(data, update_interval, start_time, **kwargs)
-        self.no_layers = int(no_layers)
-        """The number of soil layers to be modelled."""
         # Save variables names to be used by the __repr__
-        self._repr.append("no_layers")
+        # self._repr.append("")
 
         self.data
         """A Data instance providing access to the shared simulation data."""
@@ -112,7 +95,6 @@ class SoilModel(BaseModel):
             # Round raw time interval to nearest minute
             update_interval = timedelta64(int(round(raw_interval.magnitude)), "m")
             start_time = datetime64(config["core"]["timing"]["start_time"])
-            no_layers = config["soil"]["no_layers"]
         except (
             ValueError,
             pint.errors.DimensionalityError,
@@ -130,7 +112,7 @@ class SoilModel(BaseModel):
                 "Information required to initialise the soil model successfully "
                 "extracted."
             )
-            return cls(data, update_interval, start_time, no_layers)
+            return cls(data, update_interval, start_time)
         else:
             raise InitialisationError()
 

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -45,7 +45,15 @@ class SoilModel(BaseModel):
 
     model_name = "soil"
     """An internal name used to register the model and schema"""
-    required_init_vars = ()
+    required_init_vars = (
+        ("maom", ("spatial",)),
+        ("lmwc", ("spatial",)),
+        ("pH", ("spatial",)),
+        ("bulk_density", ("spatial",)),
+        ("soil_moisture", ("spatial",)),
+        ("soil_temperature", ("spatial",)),
+        ("percent_clay", ("spatial",)),
+    )
     """Required initialisation variables for the soil model.
 
     This is a set of variables that must be present in the data object used to create a

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -134,14 +134,8 @@ class SoilModel(BaseModel):
         else:
             raise InitialisationError()
 
-    # THIS IS BASICALLY JUST A PLACEHOLDER TO DEMONSTRATE HOW THE FUNCTION OVERWRITING
-    # SHOULD WORK
-    # AT THIS STEP COMMUNICATION BETWEEN MODELS CAN OCCUR IN ORDER TO DEFINE INITIAL
-    # STATE
     def setup(self) -> None:
-        """Function to set up the soil model."""
-        for layer in range(0, self.no_layers):
-            LOGGER.info("Setting up soil layer %s" % layer)
+        """Placeholder function to setup up the soil model."""
 
     def spinup(self) -> None:
         """Placeholder function to spin up the soil model."""

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -47,8 +47,8 @@ class SoilModel(BaseModel):
     model_name = "soil"
     """An internal name used to register the model and schema"""
     required_init_vars = (
-        ("maom", ("spatial",)),
-        ("lmwc", ("spatial",)),
+        ("mineral_associated_om", ("spatial",)),
+        ("low_molecular_weight_c", ("spatial",)),
         ("pH", ("spatial",)),
         ("bulk_density", ("spatial",)),
         ("soil_moisture", ("spatial",)),

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -26,6 +26,7 @@ from numpy import datetime64, timedelta64
 from virtual_rainforest.core.base_model import BaseModel, InitialisationError
 from virtual_rainforest.core.data import Data
 from virtual_rainforest.core.logger import LOGGER
+from virtual_rainforest.models.soil.carbon import SoilCarbonPools
 
 
 class SoilModel(BaseModel):
@@ -68,8 +69,6 @@ class SoilModel(BaseModel):
         **kwargs: Any,
     ):
         super().__init__(data, update_interval, start_time, **kwargs)
-        # Save variables names to be used by the __repr__
-        # self._repr.append("")
 
         self.data
         """A Data instance providing access to the shared simulation data."""
@@ -77,6 +76,11 @@ class SoilModel(BaseModel):
         """The time interval between model updates."""
         self.next_update
         """The simulation time at which the model should next run the update method"""
+        self.carbon = SoilCarbonPools(data)
+        """Set of soil carbon pools used by the model"""
+
+        # Save variables names to be used by the __repr__
+        # self._repr.append("")
 
     @classmethod
     def from_config(cls, data: Data, config: dict[str, Any]) -> SoilModel:

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -152,8 +152,8 @@ class SoilModel(BaseModel):
         )
 
         # Update carbon pools (attributes and data object)
+        # n.b. this also updates the data object automatically
         self.carbon.update_soil_carbon_pools(carbon_pool_updates)
-        # UPDATE DATA (OR DOES THE ABOVE ACTUALLY DO THIS?)
 
         # Finally increment timing
         self.next_update += self.update_interval

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -79,9 +79,6 @@ class SoilModel(BaseModel):
         self.carbon = SoilCarbonPools(data)
         """Set of soil carbon pools used by the model"""
 
-        # Save variables names to be used by the __repr__
-        # self._repr.append("")
-
     @classmethod
     def from_config(cls, data: Data, config: dict[str, Any]) -> SoilModel:
         """Factory function to initialise the soil model from configuration.

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -137,6 +137,24 @@ class SoilModel(BaseModel):
     def update(self) -> None:
         """Placeholder function to update the soil model."""
 
+        # Convert time step from seconds to days
+        dt = self.update_interval.astype("timedelta64[s]").astype(float) / (
+            60.0 * 60.0 * 24.0
+        )
+
+        carbon_pool_updates = self.carbon.calculate_soil_carbon_updates(
+            self.data["pH"],
+            self.data["bulk_density"],
+            self.data["soil_moisture"],
+            self.data["soil_temperature"],
+            self.data["percent_clay"],
+            dt,
+        )
+
+        # Update carbon pools (attributes and data object)
+        self.carbon.update_soil_carbon_pools(carbon_pool_updates)
+        # UPDATE DATA (OR DOES THE ABOVE ACTUALLY DO THIS?)
+
         # Finally increment timing
         self.next_update += self.update_interval
 

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -143,6 +143,7 @@ class SoilModel(BaseModel):
         )
 
         carbon_pool_updates = self.carbon.calculate_soil_carbon_updates(
+            self.data,
             self.data["pH"],
             self.data["bulk_density"],
             self.data["soil_moisture"],
@@ -153,7 +154,7 @@ class SoilModel(BaseModel):
 
         # Update carbon pools (attributes and data object)
         # n.b. this also updates the data object automatically
-        self.carbon.update_soil_carbon_pools(carbon_pool_updates)
+        self.carbon.update_soil_carbon_pools(self.data, carbon_pool_updates)
 
         # Finally increment timing
         self.next_update += self.update_interval

--- a/virtual_rainforest/models/soil/soil_schema.json
+++ b/virtual_rainforest/models/soil/soil_schema.json
@@ -5,12 +5,6 @@
          "description": "Configuration settings for the soil module",
          "type": "object",
          "properties": {
-            "no_layers": {
-               "description": "Number of soil layers to simulate",
-               "type": "integer",
-               "exclusiveMinimum": 0,
-               "default": 2
-            },
             "model_time_step": {
                "description": "Time step for soil module, units must be provided!",
                "desc_cont": "The time grain of the model is 10 minutes, so your choice",
@@ -21,7 +15,6 @@
          },
          "default": {},
          "required": [
-            "no_layers",
             "model_time_step"
          ]
       }


### PR DESCRIPTION
# Description

This pull request alters the `SoilModel` so that it uses the `data` object to initialise itself and updates the data object as it goes. As part of this, the soil carbon pools are no longer attributes of the `SoilCarbonPools` class, instead these soil carbon pools are only stored as part of the data object. This is mainly for the sake of code clarity, as changes to the attributes (initialised from `data`) would change the `data` object for everyone. This still happens now but the code is explicit about it happening.
 
This PR also sets the logger level used by `pytest` has been to `DEBUG` globally, in order to ensure that debug messages are always seen by `pytest`. Previously, they were seen if `pytest` was run on the entire repo, but not if it was run on individual testing files. This option can be overridden in individual test functions or files, but if it proves to be problematic we can set it to another level.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
