### PR TITLE
Add 'writable' DataArray accessor

### DIFF
--- a/virtual_rainforest/core/accessors.py
+++ b/virtual_rainforest/core/accessors.py
@@ -1,0 +1,38 @@
+import xarray as xr
+
+
+@xr.register_dataarray_accessor("writable")
+class WritableArray:
+    def __init__(self, xarray_obj):
+        self._obj = xarray_obj
+        self._flag = xarray_obj.data.flags["WRITEABLE"]
+
+    def __enter__(self):
+        self._obj.data.setflags(write=True)
+        return self._obj
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        self._obj.data.setflags(write=self._flag)
+
+
+if __name__ == "__main__":
+    import numpy as np
+
+    T = xr.DataArray(np.ones(3))
+    T.data.setflags(write=False)
+
+    try:
+        T[1] = 42
+    except:
+        print("T is not writable!")
+
+    with T.writable:
+        T[1] = 42
+        print("Now it is writable.")
+
+    try:
+        T[0] = 42
+    except:
+        print("T is not writable... again!")
+    
+    print(T)

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -209,6 +209,7 @@ class Data:
         # Validate and store the data array
         value, valid_dict = validate_dataarray(value=value, grid=self.grid)
         self.data[key] = value
+        self.data[key].data.setflags(write=False)
         self.variable_validation[key] = valid_dict
 
     def __getitem__(self, key: str) -> DataArray:


### PR DESCRIPTION
# Description

I was thinking on adding this in a discussion point but it takes the same effort to make it in a draft PR and, if we all agree, developed it further into a proper PR. If not, we just close the PR.

Based on the conversations today, it seems advisable to protect the Data object from accidental writing given that all the DataArrays it contains are always passed by reference and modifying them somewhere will affect the calculations everywhere else.

This PRs makes **all** DataArrays added to the Data object read-only and implements a DataArray accessor that doubles as context manager and makes the chosen DataArray (any DataArray, not just those in the Data object) temporarily writable. It requires explicitly setting the context manager for the particular array to modify a requirement in order to modify it, reducing the chances - although not eliminating completely - of things being modified where they should not.

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
