### PR TITLE
Added utility function to extract model specific timing details

### DIFF
--- a/docs/source/api/core/utility_functions.md
+++ b/docs/source/api/core/utility_functions.md
@@ -1,0 +1,23 @@
+---
+jupytext:
+  cell_metadata_filter: -all
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.8
+kernelspec:
+  display_name: vr_python3
+  language: python
+  name: vr_python3
+---
+
+# API documentation for the {mod}`~virtual_rainforest.core.utility_functions` module
+
+```{eval-rst}
+.. automodule:: virtual_rainforest.core.utility_functions
+    :autosummary:
+    :members:
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,6 +115,7 @@ intersphinx_mapping = {
     "xarray": ("https://docs.xarray.dev/en/stable/", None),
     "shapely": ("https://shapely.readthedocs.io/en/stable/", None),
     "jsonschema": ("https://python-jsonschema.readthedocs.io/en/stable/", None),
+    "pint": ("https://pint.readthedocs.io/en/stable/", None),
 }
 
 

--- a/docs/source/development/defining_new_models.md
+++ b/docs/source/development/defining_new_models.md
@@ -85,6 +85,9 @@ from virtual_rainforest.core.logger import LOGGER
 # InitialisationError is a custom exception, for case where a `Model` class cannot be
 # properly initialised based on the data contained in the configuration
 from virtual_rainforest.core.base_model import BaseModel, InitialisationError
+
+# A utility function to unpack the model specific timing details from the config
+from virtual_rainforest.core.utility_functions import extract_model_time_details
 ```
 
 ### Defining the new class and class attributes
@@ -283,7 +286,7 @@ The job of the `from_config` method is to take that dictionary, along with the s
 configuration into the arguments required by the `__init__` method.
 
 The method then uses those parsed arguments to actually call the `__init__` method and
-return an initialised instance of the model using the setttings. The `from_config`
+return an initialised instance of the model using the settings. The `from_config`
 method should raise an `InitialisationError` if the configuration fails.
 
 As an example:
@@ -311,10 +314,9 @@ def from_config(cls, config: dict[str, Any]) -> FreshWaterModel:
         raw_interval = pint.Quantity(config["freshwater"]["model_time_step"]).to(
             "minutes"
         )
-        # Round raw time interval to nearest minute
-        update_interval = timedelta64(int(round(raw_interval.magnitude)), "m")
-        start_time = datetime64(config["core"]["timing"]["start_time"])
-        no_of_pools = config["freshwater"]["no_of_pools"]
+        start_date, update_interval = extract_model_time_details(
+                config, cls.model_name
+            )
     # Catch cases where Values or dimensions are wrong
     except (
         ValueError,

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -86,6 +86,7 @@ team.
   File readers <api/core/readers.md>
   Core axes <api/core/axes.md>
   Base Model <api/core/base_model.md>
+  Utility functions <api/core/utility_functions.md>
   Soil Overview <api/soil.md>
   Soil Model <api/soil/soil_model.md>
   Soil Carbon <api/soil/carbon.md>

--- a/tests/core/test_utility_functions.py
+++ b/tests/core/test_utility_functions.py
@@ -4,13 +4,11 @@ from contextlib import nullcontext as does_not_raise
 
 import pint
 import pytest
+from numpy import datetime64, timedelta64
 
 
-# BASICALLY WANT TO CHUCK A LOAD OF CONFIGS AT THIS
-# CHECK CORRECT ERRORS ARE THROWN
-# AND THAT DETAILS ARE EXTRACTED CORRECTLY
 @pytest.mark.parametrize(
-    argnames=["config", "raises"],
+    argnames=["config", "raises", "timestep", "initial_time"],
     argvalues=[
         (
             {
@@ -18,6 +16,8 @@ import pytest
                 "soil": {"model_time_step": "12 hours"},
             },
             does_not_raise(),
+            timedelta64(720, "m"),
+            datetime64("2020-01-01"),
         ),
         (
             {
@@ -25,6 +25,8 @@ import pytest
                 "soil": {"model_time_step": "12 interminable hours"},
             },
             pytest.raises(pint.errors.UndefinedUnitError),
+            None,
+            None,
         ),
         (
             {
@@ -32,13 +34,17 @@ import pytest
                 "soil": {"model_time_step": "12 kilograms"},
             },
             pytest.raises(pint.errors.DimensionalityError),
+            None,
+            None,
         ),
     ],
 )
-def test_extract_model_time_details(config, raises):
+def test_extract_model_time_details(config, raises, timestep, initial_time):
     """Tests timing details extraction utility."""
 
     from virtual_rainforest.core.utility_functions import extract_model_time_details
 
     with raises:
         start_time, update_interval = extract_model_time_details(config, "soil")
+        assert start_time == initial_time
+        assert update_interval == timestep

--- a/tests/core/test_utility_functions.py
+++ b/tests/core/test_utility_functions.py
@@ -1,0 +1,44 @@
+"""Testing the utility functions."""
+
+from contextlib import nullcontext as does_not_raise
+
+import pint
+import pytest
+
+
+# BASICALLY WANT TO CHUCK A LOAD OF CONFIGS AT THIS
+# CHECK CORRECT ERRORS ARE THROWN
+# AND THAT DETAILS ARE EXTRACTED CORRECTLY
+@pytest.mark.parametrize(
+    argnames=["config", "raises"],
+    argvalues=[
+        (
+            {
+                "core": {"timing": {"start_date": "2020-01-01"}},
+                "soil": {"model_time_step": "12 hours"},
+            },
+            does_not_raise(),
+        ),
+        (
+            {
+                "core": {"timing": {"start_date": "2020-01-01"}},
+                "soil": {"model_time_step": "12 interminable hours"},
+            },
+            pytest.raises(pint.errors.UndefinedUnitError),
+        ),
+        (
+            {
+                "core": {"timing": {"start_date": "2020-01-01"}},
+                "soil": {"model_time_step": "12 kilograms"},
+            },
+            pytest.raises(pint.errors.DimensionalityError),
+        ),
+    ],
+)
+def test_extract_model_time_details(config, raises):
+    """Tests timing details extraction utility."""
+
+    from virtual_rainforest.core.utility_functions import extract_model_time_details
+
+    with raises:
+        start_time, update_interval = extract_model_time_details(config, "soil")

--- a/tests/models/abiotic/test_abiotic_model.py
+++ b/tests/models/abiotic/test_abiotic_model.py
@@ -108,7 +108,7 @@ def test_abiotic_model_initialization(
         ),
         (
             {
-                "core": {"timing": {"start_time": "2020-01-01"}},
+                "core": {"timing": {"start_date": "2020-01-01"}},
                 "abiotic": {
                     "soil_layers": 2,
                     "canopy_layers": 3,

--- a/tests/models/abiotic/test_abiotic_model.py
+++ b/tests/models/abiotic/test_abiotic_model.py
@@ -140,13 +140,13 @@ def test_generate_abiotic_model(
         assert model.update_interval == time_interval
         assert (
             model.next_update
-            == datetime64(config["core"]["timing"]["start_time"]) + time_interval
+            == datetime64(config["core"]["timing"]["start_date"]) + time_interval
         )
         # Run the update step and check that next_update has incremented properly
         model.update()
         assert (
             model.next_update
-            == datetime64(config["core"]["timing"]["start_time"]) + 2 * time_interval
+            == datetime64(config["core"]["timing"]["start_date"]) + 2 * time_interval
         )
 
     # Final check that expected logging entries are produced

--- a/tests/models/animals/test_animal_model.py
+++ b/tests/models/animals/test_animal_model.py
@@ -82,13 +82,13 @@ def test_generate_animal_model(
         assert model.update_interval == time_interval
         assert (
             model.next_update
-            == datetime64(config["core"]["timing"]["start_time"]) + time_interval
+            == datetime64(config["core"]["timing"]["start_date"]) + time_interval
         )
         # Run the update step and check that next_update has incremented properly
         model.update()
         assert (
             model.next_update
-            == datetime64(config["core"]["timing"]["start_time"]) + 2 * time_interval
+            == datetime64(config["core"]["timing"]["start_date"]) + 2 * time_interval
         )
 
     # Final check that expected logging entries are produced

--- a/tests/models/animals/test_animal_model.py
+++ b/tests/models/animals/test_animal_model.py
@@ -38,7 +38,7 @@ def test_animal_model_initialization(caplog, data_instance):
         ),
         (
             {
-                "core": {"timing": {"start_time": "2020-01-01"}},
+                "core": {"timing": {"start_date": "2020-01-01"}},
                 "animal": {"model_time_step": "12 hours"},
             },
             timedelta64(12, "h"),
@@ -53,7 +53,7 @@ def test_animal_model_initialization(caplog, data_instance):
         ),
         (
             {
-                "core": {"timing": {"start_time": "2020-01-01"}},
+                "core": {"timing": {"start_date": "2020-01-01"}},
                 "animal": {"model_time_step": "20 interminable minutes"},
             },
             None,

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -77,7 +77,7 @@ def test_soil_model_initialization(
         ),
         (
             {
-                "core": {"timing": {"start_time": "2020-01-01"}},
+                "core": {"timing": {"start_date": "2020-01-01"}},
                 "soil": {"no_layers": 2, "model_time_step": "12 hours"},
             },
             timedelta64(12, "h"),
@@ -104,13 +104,13 @@ def test_generate_soil_model(
         assert model.update_interval == time_interval
         assert (
             model.next_update
-            == datetime64(config["core"]["timing"]["start_time"]) + time_interval
+            == datetime64(config["core"]["timing"]["start_date"]) + time_interval
         )
         # Run the update step and check that next_update has incremented properly
         model.update()
         assert (
             model.next_update
-            == datetime64(config["core"]["timing"]["start_time"]) + 2 * time_interval
+            == datetime64(config["core"]["timing"]["start_date"]) + 2 * time_interval
         )
 
     # Final check that expected logging entries are produced

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -88,7 +88,7 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
         pytest.param(
             {  # valid config
                 "soil": {"no_layers": 1, "model_time_step": "7 days"},
-                "core": {"timing": {"start_time": "2020-01-01"}},
+                "core": {"timing": {"start_date": "2020-01-01"}},
             },
             "SoilModel(update_interval = 10080 minutes, next_update = 2020-01-08T00:00,"
             " no_layers = 1)",
@@ -106,7 +106,7 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
         pytest.param(
             {  # invalid soil config tag
                 "soil": {"no_layers": -1, "model_time_step": "7 days"},
-                "core": {"timing": {"start_time": "2020-01-01"}},
+                "core": {"timing": {"start_date": "2020-01-01"}},
             },
             None,
             pytest.raises(InitialisationError),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -90,8 +90,8 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
                 "soil": {"no_layers": 1, "model_time_step": "7 days"},
                 "core": {"timing": {"start_date": "2020-01-01"}},
             },
-            "SoilModel(update_interval = 10080 minutes, next_update = 2020-01-08T00:00,"
-            " no_layers = 1)",
+            "SoilModel(update_interval = 604800 seconds, next_update = "
+            "2020-01-08T00:00:00, no_layers = 1)",
             does_not_raise(),
             (
                 (INFO, "Attempting to configure the following models: ['soil']"),
@@ -143,7 +143,7 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
                     "Configuration types appear not to have been properly validated. "
                     "This problem prevents initialisation of the soil model. The first "
                     "instance of this problem is as follows: Cannot convert from "
-                    "'dimensionless' (dimensionless) to 'minute' ([time])",
+                    "'dimensionless' (dimensionless) to 'second' ([time])",
                 ),
                 (
                     CRITICAL,

--- a/virtual_rainforest/core/utility_functions.py
+++ b/virtual_rainforest/core/utility_functions.py
@@ -1,0 +1,6 @@
+"""The ``core.utility_functions`` module contains functions that are used across the
+Virtual Rainforest, but which don't have a natural home in a specific module. At the
+moment, this module only contains a single function, but it will probably expand in
+future. Adding functions here can be a good way to reduce the amount boiler plate code
+generated for tasks that are repeated across modules.
+"""  # noqa: D205, D415

--- a/virtual_rainforest/core/utility_functions.py
+++ b/virtual_rainforest/core/utility_functions.py
@@ -29,9 +29,9 @@ def extract_model_time_details(
         pint.errors.UndefinedUnitError: If the unit is not known to pint.
     """
 
-    raw_interval = pint.Quantity(config[model_name]["model_time_step"]).to("minutes")
+    raw_interval = pint.Quantity(config[model_name]["model_time_step"]).to("seconds")
     # Round raw time interval to nearest minute
-    update_interval = timedelta64(int(round(raw_interval.magnitude)), "m")
+    update_interval = timedelta64(int(round(raw_interval.magnitude)), "s")
 
     start_date = datetime64(config["core"]["timing"]["start_date"])
 

--- a/virtual_rainforest/core/utility_functions.py
+++ b/virtual_rainforest/core/utility_functions.py
@@ -4,3 +4,37 @@ moment, this module only contains a single function, but it will probably expand
 future. Adding functions here can be a good way to reduce the amount boiler plate code
 generated for tasks that are repeated across modules.
 """  # noqa: D205, D415
+
+from typing import Any
+
+import pint
+from numpy import datetime64, timedelta64
+
+
+# TODO - WRITE TEST FOR THIS
+# TODO - IMPROVE MODEL SETUP DOCUMENTATION TO REFLECT THIS
+def extract_model_time_details(
+    config: dict[str, Any], model_name: str
+) -> tuple[datetime64, timedelta64]:
+    """Function to extract the timing details required to setup a specific model.
+
+    Args:
+        config: The configuration for the Virtual Rainforest simulation.
+        model_name: The name of the specific model of interest.
+
+    Returns:
+        A tuple containing the start date and the update interval for the model
+
+    Raises:
+        pint.errors.DimensionalityError: If the desired conversion between units isn't
+        possible, e.g. kg to s.
+        pint.errors.UndefinedUnitError: If the unit is not known to pint.
+    """
+
+    raw_interval = pint.Quantity(config[model_name]["model_time_step"]).to("minutes")
+    # Round raw time interval to nearest minute
+    update_interval = timedelta64(int(round(raw_interval.magnitude)), "m")
+
+    start_date = datetime64(config["core"]["timing"]["start_date"])
+
+    return start_date, update_interval

--- a/virtual_rainforest/core/utility_functions.py
+++ b/virtual_rainforest/core/utility_functions.py
@@ -27,7 +27,7 @@ def extract_model_time_details(
 
     Raises:
         pint.errors.DimensionalityError: If the desired conversion between units isn't
-        possible, e.g. kg to s.
+            possible, e.g. kg to s.
         pint.errors.UndefinedUnitError: If the unit is not known to pint.
     """
 

--- a/virtual_rainforest/core/utility_functions.py
+++ b/virtual_rainforest/core/utility_functions.py
@@ -11,8 +11,6 @@ import pint
 from numpy import datetime64, timedelta64
 
 
-# TODO - WRITE TEST FOR THIS
-# TODO - IMPROVE MODEL SETUP DOCUMENTATION TO REFLECT THIS
 def extract_model_time_details(
     config: dict[str, Any], model_name: str
 ) -> tuple[datetime64, timedelta64]:

--- a/virtual_rainforest/models/abiotic/abiotic_model.py
+++ b/virtual_rainforest/models/abiotic/abiotic_model.py
@@ -13,6 +13,7 @@ from numpy import datetime64, timedelta64
 from virtual_rainforest.core.base_model import BaseModel, InitialisationError
 from virtual_rainforest.core.data import Data
 from virtual_rainforest.core.logger import LOGGER
+from virtual_rainforest.core.utility_functions import extract_model_time_details
 
 
 class AbioticModel(BaseModel):
@@ -113,12 +114,9 @@ class AbioticModel(BaseModel):
         # Assume input is valid until we learn otherwise
         valid_input = True
         try:
-            raw_interval = pint.Quantity(config["abiotic"]["model_time_step"]).to(
-                "minutes"
+            start_time, update_interval = extract_model_time_details(
+                config, cls.model_name
             )
-            # Round raw time interval to nearest minute
-            update_interval = timedelta64(int(round(raw_interval.magnitude)), "m")
-            start_time = datetime64(config["core"]["timing"]["start_time"])
             soil_layers = config["abiotic"]["soil_layers"]
             canopy_layers = config["abiotic"]["canopy_layers"]
         except (

--- a/virtual_rainforest/models/animals/animal_model.py
+++ b/virtual_rainforest/models/animals/animal_model.py
@@ -27,6 +27,7 @@ from numpy import datetime64, timedelta64
 from virtual_rainforest.core.base_model import BaseModel, InitialisationError
 from virtual_rainforest.core.data import Data
 from virtual_rainforest.core.logger import LOGGER
+from virtual_rainforest.core.utility_functions import extract_model_time_details
 
 
 class AnimalModel(BaseModel):
@@ -74,12 +75,9 @@ class AnimalModel(BaseModel):
         # Assume input is valid until we learn otherwise
         valid_input = True
         try:
-            raw_interval = pint.Quantity(config["animal"]["model_time_step"]).to(
-                "minutes"
+            start_time, update_interval = extract_model_time_details(
+                config, cls.model_name
             )
-            # Round raw time interval to nearest minute
-            update_interval = timedelta64(int(round(raw_interval.magnitude)), "m")
-            start_time = datetime64(config["core"]["timing"]["start_time"])
         except (
             ValueError,
             pint.errors.DimensionalityError,

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -26,6 +26,7 @@ from numpy import datetime64, timedelta64
 from virtual_rainforest.core.base_model import BaseModel, InitialisationError
 from virtual_rainforest.core.data import Data
 from virtual_rainforest.core.logger import LOGGER
+from virtual_rainforest.core.utility_functions import extract_model_time_details
 
 
 class SoilModel(BaseModel):
@@ -106,12 +107,9 @@ class SoilModel(BaseModel):
         # Assume input is valid until we learn otherwise
         valid_input = True
         try:
-            raw_interval = pint.Quantity(config["soil"]["model_time_step"]).to(
-                "minutes"
+            start_date, update_interval = extract_model_time_details(
+                config, cls.model_name
             )
-            # Round raw time interval to nearest minute
-            update_interval = timedelta64(int(round(raw_interval.magnitude)), "m")
-            start_time = datetime64(config["core"]["timing"]["start_time"])
             no_layers = config["soil"]["no_layers"]
         except (
             ValueError,
@@ -130,7 +128,7 @@ class SoilModel(BaseModel):
                 "Information required to initialise the soil model successfully "
                 "extracted."
             )
-            return cls(data, update_interval, start_time, no_layers)
+            return cls(data, update_interval, start_date, no_layers)
         else:
             raise InitialisationError()
 


### PR DESCRIPTION
# Description

This pull request adds a utility function to extract the timing details based on @davidorme's suggestion. This utility function then gets used by each model class, instead of each class having nearly identical boiler plate code to extract the timing.

This pull request also addresses @alexdewar's comment about time units used by the Model classes not being SI by switching from using minutes to using seconds.

Fixes #180 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
