### PR TITLE
Basic data output functionality

### DIFF
--- a/docs/source/api/core/exceptions.md
+++ b/docs/source/api/core/exceptions.md
@@ -1,0 +1,23 @@
+---
+jupytext:
+  cell_metadata_filter: -all
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.8
+kernelspec:
+  display_name: vr_python3
+  language: python
+  name: vr_python3
+---
+
+# API documentation for the {mod}`~virtual_rainforest.core.exceptions` module
+
+```{eval-rst}
+.. automodule:: virtual_rainforest.core.exceptions
+    :autosummary:
+    :members:
+```

--- a/docs/source/development/defining_new_models.md
+++ b/docs/source/development/defining_new_models.md
@@ -80,9 +80,11 @@ from virtual_rainforest.core.data import Data
 from virtual_rainforest.core.logger import LOGGER
 
 # New model class will inherit from BaseModel.
+from virtual_rainforest.core.base_model import BaseModel
+
 # InitialisationError is a custom exception, for case where a `Model` class cannot be
 # properly initialised based on the data contained in the configuration
-from virtual_rainforest.core.base_model import BaseModel, InitialisationError
+from virtual_rainforest.core.exceptions import InitialisationError
 
 # A utility function to unpack the model specific timing details from the config
 from virtual_rainforest.core.utils import extract_model_time_details

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -87,6 +87,7 @@ team.
   Core axes <api/core/axes.md>
   Base Model <api/core/base_model.md>
   Utility functions <api/core/utils.md>
+  Custom exceptions <api/core/exceptions.md>
   Soil Overview <api/soil.md>
   Soil Model <api/soil/soil_model.md>
   Soil Carbon <api/soil/carbon.md>

--- a/docs/source/virtual_rainforest/core/data.md
+++ b/docs/source/virtual_rainforest/core/data.md
@@ -222,3 +222,15 @@ data.load_data_config(data_config["core"]["data"])
 ```{code-cell}
 data
 ```
+
+## Data output
+
+The contents of the `Data` object can be output using the
+{meth}`~virtual_rainforest.core.data.Data.save_to_netcdf` method:
+
+```python
+data.save_to_netcdf(output_file_path)
+```
+
+At present this outputs the entire contents of the `Data` object as a single NetCDF, but
+this will likely be reworked in future.

--- a/tests/core/data/all_config.toml
+++ b/tests/core/data/all_config.toml
@@ -13,6 +13,8 @@ run_length = "50 years"
 [core.data_output_options]
 save_initial_state = true
 save_final_state = true
+out_path_initial = "./model_at_start.nc"
+out_path_final = "./model_at_end.nc"
 
 [plants]
 a_plant_integer = 12

--- a/tests/core/data/all_config.toml
+++ b/tests/core/data/all_config.toml
@@ -10,6 +10,10 @@ start_date = "2020-01-01"
 update_interval = "10 minutes"
 run_length = "50 years"
 
+[core.data_output_options]
+save_initial_state = true
+save_final_state = true
+
 [plants]
 a_plant_integer = 12
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -41,57 +41,6 @@ def test_check_dict_leaves(d_a: dict, d_b: dict, overlap: list) -> None:
 
 
 @pytest.mark.parametrize(
-    "out_path,expected_log_entries",
-    [
-        (
-            "./complete_config.toml",
-            (
-                (
-                    CRITICAL,
-                    "A file in the user specified output folder (.) already makes use "
-                    "of the specified output file name (complete_config.toml), this "
-                    "file should either be renamed or deleted!",
-                ),
-            ),
-        ),
-        (
-            "bad_folder/complete_config.toml",
-            (
-                (
-                    CRITICAL,
-                    "The user specified output directory (bad_folder) doesn't exist!",
-                ),
-            ),
-        ),
-        (
-            "pyproject.toml/complete_config.toml",
-            (
-                (
-                    CRITICAL,
-                    "The user specified output folder (pyproject.toml) isn't a "
-                    "directory!",
-                ),
-            ),
-        ),
-    ],
-)
-def test_check_outfile(caplog, mocker, out_path, expected_log_entries):
-    """Check that an error is logged if an output file is already saved."""
-    from virtual_rainforest.core.config import check_outfile
-
-    # Configure the mock to return a specific list of files
-    if out_path == "./complete_config.toml":
-        mock_content = mocker.patch("virtual_rainforest.core.config.Path.exists")
-        mock_content.return_value = True
-
-    # Check that check_outfile fails as expected
-    with pytest.raises(ConfigurationError):
-        check_outfile(Path(out_path))
-
-    log_check(caplog, expected_log_entries)
-
-
-@pytest.mark.parametrize(
     "cfg_paths,contents,expected_exception,expected_log_entries",
     [
         (

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -47,9 +47,9 @@ def test_check_dict_leaves(d_a: dict, d_b: dict, overlap: list) -> None:
             (
                 (
                     CRITICAL,
-                    "A config file in the user specified output folder (.) already "
-                    "makes use of the specified output file name (complete_config.toml)"
-                    ", this file should either be renamed or deleted!",
+                    "A file in the user specified output folder (.) already makes use "
+                    "of the specified output file name (complete_config.toml), this "
+                    "file should either be renamed or deleted!",
                 ),
             ),
         ),

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -76,11 +76,11 @@ def test_check_dict_leaves(d_a: dict, d_b: dict, overlap: list) -> None:
 )
 def test_check_outfile(caplog, mocker, out_path, expected_log_entries):
     """Check that an error is logged if an output file is already saved."""
-    file_name = "complete_config"
 
     # Configure the mock to return a specific list of files
-    mock_content = mocker.patch("virtual_rainforest.core.config.Path.iterdir")
-    mock_content.return_value = [Path(f"{file_name}.toml")]
+    if out_path == "./complete_config.toml":
+        mock_content = mocker.patch("virtual_rainforest.core.config.Path.exists")
+        mock_content.return_value = True
 
     # Check that check_outfile fails as expected
     with pytest.raises(config.ConfigurationError):

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -9,7 +9,7 @@ import pytest
 from xarray import DataArray, Dataset
 
 from tests.conftest import log_check
-from virtual_rainforest.core.config import ConfigurationError
+from virtual_rainforest.core.exceptions import ConfigurationError
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -692,8 +692,9 @@ def test_save_to_netcdf(mocker, caplog, fixture_data, out_path, raises, exp_log)
     """Test that data object can save as NetCDF."""
 
     # Configure the mock to return a specific list of files
-    mock_content = mocker.patch("virtual_rainforest.core.config.Path.iterdir")
-    mock_content.return_value = [Path("final.nc")]
+    if out_path == "./final.nc":
+        mock_content = mocker.patch("virtual_rainforest.core.config.Path.exists")
+        mock_content.return_value = True
 
     with raises:
         fixture_data.save_to_netcdf(Path(out_path))

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -2,6 +2,7 @@
 
 from contextlib import nullcontext as does_not_raise
 from logging import CRITICAL, INFO
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -646,3 +647,58 @@ def test_on_core_axis(
 
     if err_message:
         assert str(err.value) == err_message
+
+
+@pytest.mark.parametrize(
+    argnames=["out_path", "raises", "exp_log"],
+    argvalues=[
+        ("./initial.nc", does_not_raise(), ()),
+        (
+            "bad_folder/initial.nc",
+            pytest.raises(ConfigurationError),
+            (
+                (
+                    CRITICAL,
+                    "The user specified output directory (bad_folder) doesn't exist!",
+                ),
+            ),
+        ),
+        (
+            "pyproject.toml/initial.nc",
+            pytest.raises(ConfigurationError),
+            (
+                (
+                    CRITICAL,
+                    "The user specified output folder (pyproject.toml) isn't a "
+                    "directory!",
+                ),
+            ),
+        ),
+        (
+            "./final.nc",
+            pytest.raises(ConfigurationError),
+            (
+                (
+                    CRITICAL,
+                    "A file in the user specified output folder (.) already makes use "
+                    "of the specified output file name (final.nc), this file should "
+                    "either be renamed or deleted!",
+                ),
+            ),
+        ),
+    ],
+)
+def test_save_to_netcdf(mocker, caplog, fixture_data, out_path, raises, exp_log):
+    """Test that data object can save as NetCDF."""
+
+    # Configure the mock to return a specific list of files
+    mock_content = mocker.patch("virtual_rainforest.core.config.Path.iterdir")
+    mock_content.return_value = [Path("final.nc")]
+
+    with raises:
+        fixture_data.save_to_netcdf(Path(out_path))
+        # Remove generated output file, as a bonus this  tests that output file was
+        # generated correctly + to the right location
+        Path(out_path).unlink()
+
+    log_check(caplog, exp_log)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,13 +1,14 @@
 """Testing the utility functions."""
 
 from contextlib import nullcontext as does_not_raise
-from logging import ERROR
+from logging import CRITICAL, ERROR
+from pathlib import Path
 
 import pytest
 from numpy import datetime64, timedelta64
 
 from tests.conftest import log_check
-from virtual_rainforest.core.exceptions import InitialisationError
+from virtual_rainforest.core.exceptions import ConfigurationError, InitialisationError
 
 
 @pytest.mark.parametrize(
@@ -70,3 +71,54 @@ def test_extract_model_time_details(
         assert update_interval == timestep
 
     log_check(caplog, expected_log)
+
+
+@pytest.mark.parametrize(
+    "out_path,expected_log_entries",
+    [
+        (
+            "./complete_config.toml",
+            (
+                (
+                    CRITICAL,
+                    "A file in the user specified output folder (.) already makes use "
+                    "of the specified output file name (complete_config.toml), this "
+                    "file should either be renamed or deleted!",
+                ),
+            ),
+        ),
+        (
+            "bad_folder/complete_config.toml",
+            (
+                (
+                    CRITICAL,
+                    "The user specified output directory (bad_folder) doesn't exist!",
+                ),
+            ),
+        ),
+        (
+            "pyproject.toml/complete_config.toml",
+            (
+                (
+                    CRITICAL,
+                    "The user specified output folder (pyproject.toml) isn't a "
+                    "directory!",
+                ),
+            ),
+        ),
+    ],
+)
+def test_check_outfile(caplog, mocker, out_path, expected_log_entries):
+    """Check that an error is logged if an output file is already saved."""
+    from virtual_rainforest.core.utils import check_outfile
+
+    # Configure the mock to return a specific list of files
+    if out_path == "./complete_config.toml":
+        mock_content = mocker.patch("virtual_rainforest.core.config.Path.exists")
+        mock_content.return_value = True
+
+    # Check that check_outfile fails as expected
+    with pytest.raises(ConfigurationError):
+        check_outfile(Path(out_path))
+
+    log_check(caplog, expected_log_entries)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -7,7 +7,7 @@ import pytest
 from numpy import datetime64, timedelta64
 
 from tests.conftest import log_check
-from virtual_rainforest.core.base_model import InitialisationError
+from virtual_rainforest.core.exceptions import InitialisationError
 
 
 @pytest.mark.parametrize(

--- a/tests/models/abiotic/test_abiotic_model.py
+++ b/tests/models/abiotic/test_abiotic_model.py
@@ -7,7 +7,7 @@ import pytest
 from numpy import datetime64, timedelta64
 
 from tests.conftest import log_check
-from virtual_rainforest.core.base_model import InitialisationError
+from virtual_rainforest.core.exceptions import InitialisationError
 from virtual_rainforest.models.abiotic.abiotic_model import AbioticModel
 
 

--- a/tests/models/abiotic/test_radiation.py
+++ b/tests/models/abiotic/test_radiation.py
@@ -6,7 +6,7 @@ import pytest
 import xarray as xr
 from xarray import DataArray
 
-from virtual_rainforest.core.base_model import InitialisationError
+from virtual_rainforest.core.exceptions import InitialisationError
 
 
 @pytest.fixture

--- a/tests/models/animals/test_animal_model.py
+++ b/tests/models/animals/test_animal_model.py
@@ -7,7 +7,7 @@ import pytest
 from numpy import datetime64, timedelta64
 
 from tests.conftest import log_check
-from virtual_rainforest.core.base_model import InitialisationError
+from virtual_rainforest.core.exceptions import InitialisationError
 
 
 def test_animal_model_initialization(caplog, data_instance):

--- a/tests/models/soil/test_carbon.py
+++ b/tests/models/soil/test_carbon.py
@@ -11,7 +11,7 @@ import pytest
 from xarray import DataArray
 
 from tests.conftest import log_check
-from virtual_rainforest.core.base_model import InitialisationError
+from virtual_rainforest.core.exceptions import InitialisationError
 from virtual_rainforest.models.soil.carbon import SoilCarbonPools
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,7 +11,8 @@ from pathlib import Path
 import pytest
 from numpy import datetime64, timedelta64
 
-from virtual_rainforest.core.base_model import BaseModel, InitialisationError
+from virtual_rainforest.core.base_model import BaseModel
+from virtual_rainforest.core.exceptions import InitialisationError
 from virtual_rainforest.main import vr_run
 from virtual_rainforest.models.soil.soil_model import SoilModel
 

--- a/virtual_rainforest/core/__init__.py
+++ b/virtual_rainforest/core/__init__.py
@@ -4,24 +4,26 @@ and then to configure them, populate them with data and provide logging.
 
 Each of the core sub-modules has its own API reference page:
 
-* The :mod:`~virtual_rainforest.core.config` submodule covers the
-  definition of formal configuration schema for components and the parsing and
-  validation of TOML configuration documents against those schema.
-* The :mod:`~virtual_rainforest.core.grid` submodule covers the
-  definition of the spatial layout to be used in a simulation and provides an interface
-  to the spatial relationships between cells.
-* The :mod:`~virtual_rainforest.core.data` submodule provides the
-  central data object used to store data required by the simulation and methods to
-  populate that data object for use in simulations.
+* The :mod:`~virtual_rainforest.core.config` submodule covers the definition of formal
+  configuration schema for components and the parsing and validation of TOML
+  configuration documents against those schema.
+* The :mod:`~virtual_rainforest.core.grid` submodule covers the definition of the
+  spatial layout to be used in a simulation and provides an interface to the spatial
+  relationships between cells.
+* The :mod:`~virtual_rainforest.core.data` submodule provides the central data object
+  used to store data required by the simulation and methods to populate that data object
+  for use in simulations.
 * The :mod:`~virtual_rainforest.core.axes` submodule provides validation for data to
   ensure that it is congruent with the model configuration.
 * The :mod:`~virtual_rainforest.core.readers` submodule provides functionality to read
   external data files into a standard internal format.
-* The :mod:`~virtual_rainforest.core.base_model` submodule provides an Abstract
-  Base Class describing the shared API to be used by science models within the Virtual
+* The :mod:`~virtual_rainforest.core.base_model` submodule provides an Abstract Base
+  Class describing the shared API to be used by science models within the Virtual
   Rainforest.
 * The :mod:`~virtual_rainforest.core.logger` configures the :class:`~logging.Logger`
   instance used throughout the package.
+* The :mod:`~virtual_rainforest.core.exceptions` submodule defines custom exceptions
+  that are used either in the core module, or across multiple modules.
 
 The :mod:`~virtual_rainforest.core` module itself is only responsible for loading the
 configuration schema for the core submodules.

--- a/virtual_rainforest/core/base_model.py
+++ b/virtual_rainforest/core/base_model.py
@@ -83,10 +83,6 @@ MODEL_REGISTRY: dict[str, Type[BaseModel]] = {}
 """A registry for different models."""
 
 
-class InitialisationError(Exception):
-    """Custom exception class for model initialisation failures."""
-
-
 class BaseModel(ABC):
     """A superclass for all Virtual Rainforest models.
 

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -247,7 +247,9 @@ def check_outfile(merge_file_path: Path) -> None:
     """Check that final output file is not already in the output folder.
 
     Args:
-        merge_file_path: Path that merged config file is meant to be saved to
+        merge_file_path: Path to save merged config file to (i.e. folder location + file
+            name)
+
     Raises:
         ConfigurationError: If the final output directory doesn't exist, isn't a
             directory, or the final output file already exists.
@@ -584,7 +586,8 @@ def validate_config(
     Args:
         cfg_paths: A path or a set of paths that point to either configuration files, or
             folders containing configuration files
-        merge_file_path: Path to save merged config file to
+        merge_file_path: Path to save merged config file to (i.e. folder location + file
+            name)
     """
 
     # Check that there isn't a final output file saved in the final output folder

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -40,6 +40,7 @@ from jsonschema import Draft202012Validator, FormatChecker, exceptions, validato
 
 from virtual_rainforest.core.exceptions import ConfigurationError
 from virtual_rainforest.core.logger import LOGGER
+from virtual_rainforest.core.utils import check_outfile
 
 if sys.version_info[:2] >= (3, 11):
     import tomllib
@@ -235,54 +236,6 @@ def check_dict_leaves(
                 conflicts.append("%s" % ".".join(path + [str(key)]))
 
     return conflicts
-
-
-def check_outfile(merge_file_path: Path) -> None:
-    """Check that final output file is not already in the output folder.
-
-    Args:
-        merge_file_path: Path to save merged config file to (i.e. folder location + file
-            name)
-
-    Raises:
-        ConfigurationError: If the final output directory doesn't exist, isn't a
-            directory, or the final output file already exists.
-    """
-
-    # Extract parent folder name and output file name. If this is a relative path, it is
-    # expected to be relative to where the command is being run.
-    if not merge_file_path.is_absolute():
-        parent_fold = merge_file_path.parent.relative_to(".")
-    else:
-        parent_fold = merge_file_path.parent
-    out_file_name = merge_file_path.name
-
-    # Throw critical error if the output folder doesn't exist
-    if not Path(parent_fold).exists():
-        to_raise = ConfigurationError(
-            f"The user specified output directory ({parent_fold}) doesn't exist!"
-        )
-        LOGGER.critical(to_raise)
-        raise to_raise
-
-    elif not Path(parent_fold).is_dir():
-        to_raise = ConfigurationError(
-            f"The user specified output folder ({parent_fold}) isn't a directory!"
-        )
-        LOGGER.critical(to_raise)
-        raise to_raise
-
-    # Throw critical error if combined output file already exists
-    if merge_file_path.exists():
-        to_raise = ConfigurationError(
-            f"A file in the user specified output folder ({parent_fold}) already "
-            f"makes use of the specified output file name ({out_file_name}), this "
-            f"file should either be renamed or deleted!"
-        )
-        LOGGER.critical(to_raise)
-        raise to_raise
-
-    return None
 
 
 def collect_files(cfg_paths: list[str]) -> list[Path]:

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -38,6 +38,7 @@ import dpath.util  # type: ignore
 import tomli_w
 from jsonschema import Draft202012Validator, FormatChecker, exceptions, validators
 
+from virtual_rainforest.core.exceptions import ConfigurationError
 from virtual_rainforest.core.logger import LOGGER
 
 if sys.version_info[:2] >= (3, 11):
@@ -50,12 +51,6 @@ SCHEMA_REGISTRY: dict = {}
 
 :meta hide-value:
 """
-
-
-class ConfigurationError(Exception):
-    """Custom exception class for configuration failures."""
-
-    pass
 
 
 def log_all_validation_errors(

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -277,15 +277,14 @@ def check_outfile(merge_file_path: Path) -> None:
         raise to_raise
 
     # Throw critical error if combined output file already exists
-    for file in Path(parent_fold).iterdir():
-        if file.name == f"{out_file_name}":
-            to_raise = ConfigurationError(
-                f"A file in the user specified output folder ({parent_fold}) already "
-                f"makes use of the specified output file name ({out_file_name}), this "
-                f"file should either be renamed or deleted!"
-            )
-            LOGGER.critical(to_raise)
-            raise to_raise
+    if merge_file_path.exists():
+        to_raise = ConfigurationError(
+            f"A file in the user specified output folder ({parent_fold}) already "
+            f"makes use of the specified output file name ({out_file_name}), this "
+            f"file should either be renamed or deleted!"
+        )
+        LOGGER.critical(to_raise)
+        raise to_raise
 
     return None
 

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -242,6 +242,7 @@ def check_dict_leaves(
     return conflicts
 
 
+# TODO - MOVE THIS TO UTILS MODULE (ONCE THAT IS MERGED)
 def check_outfile(merge_file_path: Path) -> None:
     """Check that final output file is not already in the output folder.
 

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -279,9 +279,9 @@ def check_outfile(merge_file_path: Path) -> None:
     for file in Path(parent_fold).iterdir():
         if file.name == f"{out_file_name}":
             to_raise = ConfigurationError(
-                f"A config file in the user specified output folder ({parent_fold}) "
-                f"already makes use of the specified output file name ({out_file_name})"
-                f", this file should either be renamed or deleted!"
+                f"A file in the user specified output folder ({parent_fold}) already "
+                f"makes use of the specified output file name ({out_file_name}), this "
+                f"file should either be renamed or deleted!"
             )
             LOGGER.critical(to_raise)
             raise to_raise

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -570,16 +570,17 @@ def validate_config(
 ) -> dict[str, Any]:
     """Validates the contents of user provided config files.
 
-    This function first reads in a set of configuration files in `.toml` format. This
-    either consists of all `.toml` files in a specified folder, or a set of user
-    specified files within this folder. Checks are carried out to ensure that these
+    This function first reads in a set of configuration files in ``.toml`` format. This
+    either consists of all ``.toml`` files in the specified folders, or a set of user
+    specified files within these folders. Checks are carried out to ensure that these
     files are correctly formatted. The module validation schemas are extracted from
-    `SCHEMA_REGISTRY` for the modules the user has specified to configure (in
-    `config.core.modules`). These schemas are then consolidated into a single combined
-    JSON schema. This combined schema is then used to validate the combined contents of
-    the configuration files. If this validation passes the combined configuration is
-    saved in toml format in the specified configuration file folder. This configuration
-    is then returned for use in downstream simulation setup.
+    :data:`~virtual_rainforest.core.config.SCHEMA_REGISTRY` for the modules the user has
+    specified to configure (in ``config.core.modules``). These schemas are then
+    consolidated into a single combined JSON schema. This combined schema is then used
+    to validate the combined contents of the configuration files. If this validation
+    passes the combined configuration is saved in toml format in the specified
+    configuration file folder. This configuration is then returned for use in downstream
+    simulation setup.
 
     Args:
         cfg_paths: A path or a set of paths that point to either configuration files, or

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -242,7 +242,6 @@ def check_dict_leaves(
     return conflicts
 
 
-# TODO - MOVE THIS TO UTILS MODULE (ONCE THAT IS MERGED)
 def check_outfile(merge_file_path: Path) -> None:
     """Check that final output file is not already in the output folder.
 

--- a/virtual_rainforest/core/core_schema.json
+++ b/virtual_rainforest/core/core_schema.json
@@ -95,11 +95,33 @@
                },
                "default": {},
                "required": []
+            },
+            "data_output_options": {
+               "description": "Options for output the virtual rainforest model state",
+               "type": "object",
+               "properties": {
+                  "save_initial_state": {
+                     "description": "Whether the initial state should be saved",
+                     "type": "boolean",
+                     "default": false
+                  },
+                  "save_final_state": {
+                     "description": "Whether the final state should be saved",
+                     "type": "boolean",
+                     "default": true
+                  }
+               },
+               "default": {},
+               "required": [
+                  "save_initial_state",
+                  "save_final_state"
+               ]
             }
          },
          "default": {},
          "required": [
             "data",
+            "data_output_options",
             "grid",
             "timing",
             "modules"

--- a/virtual_rainforest/core/core_schema.json
+++ b/virtual_rainforest/core/core_schema.json
@@ -109,12 +109,24 @@
                      "description": "Whether the final state should be saved",
                      "type": "boolean",
                      "default": true
+                  },
+                  "out_path_initial": {
+                     "description": "File path to save initial state to",
+                     "type": "string",
+                     "default": "./initial_state.nc"
+                  },
+                  "out_path_final": {
+                     "description": "File path to save final state to",
+                     "type": "string",
+                     "default": "./final_state.nc"
                   }
                },
                "default": {},
                "required": [
                   "save_initial_state",
-                  "save_final_state"
+                  "save_final_state",
+                  "out_path_initial",
+                  "out_path_final"
                ]
             }
          },

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -327,7 +327,6 @@ class Data:
         if not clean_load:
             raise ConfigurationError("Data configuration did not load cleanly")
 
-    # TODO - Write a test for this function
     # TODO - Think about where to document this
     def save_to_netcdf(self, output_file_path: Path) -> None:
         """Save the entire Virtual Rainforest model state as a NetCDF file.

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -123,7 +123,7 @@ import numpy as np
 from xarray import DataArray, Dataset
 
 from virtual_rainforest.core.axes import AXIS_VALIDATORS, validate_dataarray
-from virtual_rainforest.core.config import ConfigurationError
+from virtual_rainforest.core.config import ConfigurationError, check_outfile
 from virtual_rainforest.core.grid import Grid
 from virtual_rainforest.core.logger import LOGGER
 from virtual_rainforest.core.readers import load_to_dataarray
@@ -279,7 +279,7 @@ class Data:
         This is a method is used to validate a provided user data configuration and
         populate the Data instance object from the provided data sources. The
         data_config dictionary can contain a 'variable' key containing an array of
-        dictionaries provding the path to the file (``file``) and the
+        dictionaries providing the path to the file (``file``) and the
         name of the variable within the file (``var_name``).
 
         Args:
@@ -326,6 +326,21 @@ class Data:
 
         if not clean_load:
             raise ConfigurationError("Data configuration did not load cleanly")
+
+    # TODO - Write a test for this function
+    def save_to_netcdf(self, output_file_path: Path) -> None:
+        """Save the entire Virtual Rainforest model state as a NetCDF file.
+
+        Args:
+            output_file_path: Path location to save the Virtual Rainforest model state.
+        """
+
+        # Check that the folder to save to exists and that there isn't already a file
+        # saved there
+        check_outfile(output_file_path)
+
+        # If the file path is okay then write the model state out as a NetCDF
+        self.data.to_netcdf(output_file_path)
 
 
 class DataGenerator:

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -327,9 +327,8 @@ class Data:
         if not clean_load:
             raise ConfigurationError("Data configuration did not load cleanly")
 
-    # TODO - Think about where to document this
     def save_to_netcdf(self, output_file_path: Path) -> None:
-        """Save the entire Virtual Rainforest model state as a NetCDF file.
+        """Save the entire contents of the data object as a NetCDF file.
 
         Args:
             output_file_path: Path location to save the Virtual Rainforest model state.

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -328,6 +328,7 @@ class Data:
             raise ConfigurationError("Data configuration did not load cleanly")
 
     # TODO - Write a test for this function
+    # TODO - Think about where to document this
     def save_to_netcdf(self, output_file_path: Path) -> None:
         """Save the entire Virtual Rainforest model state as a NetCDF file.
 

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -123,7 +123,8 @@ import numpy as np
 from xarray import DataArray, Dataset
 
 from virtual_rainforest.core.axes import AXIS_VALIDATORS, validate_dataarray
-from virtual_rainforest.core.config import ConfigurationError, check_outfile
+from virtual_rainforest.core.config import check_outfile
+from virtual_rainforest.core.exceptions import ConfigurationError
 from virtual_rainforest.core.grid import Grid
 from virtual_rainforest.core.logger import LOGGER
 from virtual_rainforest.core.readers import load_to_dataarray

--- a/virtual_rainforest/core/exceptions.py
+++ b/virtual_rainforest/core/exceptions.py
@@ -1,0 +1,11 @@
+"""The ``core.exceptions`` module stores custom exceptions that are used within the core
+module or used across multiple modules.
+"""  # noqa: D205, D415
+
+
+class ConfigurationError(Exception):
+    """Custom exception class for configuration failures."""
+
+
+class InitialisationError(Exception):
+    """Custom exception class for model initialisation failures."""

--- a/virtual_rainforest/core/utils.py
+++ b/virtual_rainforest/core/utils.py
@@ -5,12 +5,13 @@ future. Adding functions here can be a good way to reduce the amount boiler plat
 generated for tasks that are repeated across modules.
 """  # noqa: D205, D415
 
+from pathlib import Path
 from typing import Any
 
 import pint
 from numpy import datetime64, timedelta64
 
-from virtual_rainforest.core.exceptions import InitialisationError
+from virtual_rainforest.core.exceptions import ConfigurationError, InitialisationError
 from virtual_rainforest.core.logger import LOGGER
 
 
@@ -43,3 +44,51 @@ def extract_model_time_details(
         raise InitialisationError() from excep
 
     return start_date, update_interval
+
+
+def check_outfile(merge_file_path: Path) -> None:
+    """Check that final output file is not already in the output folder.
+
+    Args:
+        merge_file_path: Path to save merged config file to (i.e. folder location + file
+            name)
+
+    Raises:
+        ConfigurationError: If the final output directory doesn't exist, isn't a
+            directory, or the final output file already exists.
+    """
+
+    # Extract parent folder name and output file name. If this is a relative path, it is
+    # expected to be relative to where the command is being run.
+    if not merge_file_path.is_absolute():
+        parent_fold = merge_file_path.parent.relative_to(".")
+    else:
+        parent_fold = merge_file_path.parent
+    out_file_name = merge_file_path.name
+
+    # Throw critical error if the output folder doesn't exist
+    if not Path(parent_fold).exists():
+        to_raise = ConfigurationError(
+            f"The user specified output directory ({parent_fold}) doesn't exist!"
+        )
+        LOGGER.critical(to_raise)
+        raise to_raise
+
+    elif not Path(parent_fold).is_dir():
+        to_raise = ConfigurationError(
+            f"The user specified output folder ({parent_fold}) isn't a directory!"
+        )
+        LOGGER.critical(to_raise)
+        raise to_raise
+
+    # Throw critical error if combined output file already exists
+    if merge_file_path.exists():
+        to_raise = ConfigurationError(
+            f"A file in the user specified output folder ({parent_fold}) already "
+            f"makes use of the specified output file name ({out_file_name}), this "
+            f"file should either be renamed or deleted!"
+        )
+        LOGGER.critical(to_raise)
+        raise to_raise
+
+    return None

--- a/virtual_rainforest/core/utils.py
+++ b/virtual_rainforest/core/utils.py
@@ -10,7 +10,7 @@ from typing import Any
 import pint
 from numpy import datetime64, timedelta64
 
-from virtual_rainforest.core.base_model import InitialisationError
+from virtual_rainforest.core.exceptions import InitialisationError
 from virtual_rainforest.core.logger import LOGGER
 
 

--- a/virtual_rainforest/entry_points.py
+++ b/virtual_rainforest/entry_points.py
@@ -9,7 +9,7 @@ import textwrap
 from pathlib import Path
 
 import virtual_rainforest as vr
-from virtual_rainforest.core.config import ConfigurationError
+from virtual_rainforest.core.exceptions import ConfigurationError
 from virtual_rainforest.core.logger import LOGGER
 from virtual_rainforest.main import vr_run
 

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -231,8 +231,11 @@ def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
 
     # TODO - A model spin up might be needed here in future
 
+    # Find parent folder for output for merge_file_path
+    parent_folder = merge_file_path.parent
+
     # Save the initial state of the model
-    # TODO - ERROR HANDLING WILL PROBABLY BE REQUIRED HERE
+    data.save_to_netcdf(Path(f"{parent_folder}/initial.nc"))
 
     # Get the list of date times of the next update.
     update_due = {mod.model_name: mod.next_update for mod in models_cfd.values()}
@@ -249,6 +252,7 @@ def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
             models_cfd[mod_nm].update()
             update_due[mod_nm] = models_cfd[mod_nm].next_update
 
-    # TODO - Save the final model state
+    # Save the final model state
+    data.save_to_netcdf(Path(f"{parent_folder}/final.nc"))
 
     LOGGER.info("Virtual rainforest model run completed!")

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -201,7 +201,8 @@ def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
 
     Args:
         cfg_paths: Set of paths to configuration files
-        merge_file_path: Path to save merged config file to
+        merge_file_path: Path to save merged config file to (i.e. folder location + file
+            name)
     """
 
     config = validate_config(cfg_paths, merge_file_path)

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -10,13 +10,10 @@ from typing import Any, Type, Union
 import pint
 from numpy import datetime64, timedelta64
 
-from virtual_rainforest.core.base_model import (
-    MODEL_REGISTRY,
-    BaseModel,
-    InitialisationError,
-)
+from virtual_rainforest.core.base_model import MODEL_REGISTRY, BaseModel
 from virtual_rainforest.core.config import validate_config
 from virtual_rainforest.core.data import Data
+from virtual_rainforest.core.exceptions import InitialisationError
 from virtual_rainforest.core.grid import Grid
 from virtual_rainforest.core.logger import LOGGER
 

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -191,10 +191,7 @@ def check_for_fast_models(
         )
 
 
-def vr_run(
-    cfg_paths: Union[str, list[str]],
-    merge_file_path: Path,
-) -> None:
+def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
     """Perform a virtual rainforest simulation.
 
     This is a high-level function that runs a virtual rainforest simulation. At the
@@ -235,6 +232,7 @@ def vr_run(
     # TODO - A model spin up might be needed here in future
 
     # Save the initial state of the model
+    # TODO - ERROR HANDLING WILL PROBABLY BE REQUIRED HERE
 
     # Get the list of date times of the next update.
     update_due = {mod.model_name: mod.next_update for mod in models_cfd.values()}

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -232,12 +232,11 @@ def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
 
     # TODO - A model spin up might be needed here in future
 
-    # Find parent folder for output for merge_file_path
-    parent_folder = merge_file_path.parent
-
     # Save the initial state of the model
     if config["core"]["data_output_options"]["save_initial_state"]:
-        data.save_to_netcdf(Path(f"{parent_folder}/initial.nc"))
+        data.save_to_netcdf(
+            Path(config["core"]["data_output_options"]["out_path_initial"])
+        )
 
     # Get the list of date times of the next update.
     update_due = {mod.model_name: mod.next_update for mod in models_cfd.values()}
@@ -256,6 +255,8 @@ def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
 
     # Save the final model state
     if config["core"]["data_output_options"]["save_final_state"]:
-        data.save_to_netcdf(Path(f"{parent_folder}/final.nc"))
+        data.save_to_netcdf(
+            Path(config["core"]["data_output_options"]["out_path_final"])
+        )
 
     LOGGER.info("Virtual rainforest model run completed!")

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -236,7 +236,8 @@ def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
     parent_folder = merge_file_path.parent
 
     # Save the initial state of the model
-    data.save_to_netcdf(Path(f"{parent_folder}/initial.nc"))
+    if config["core"]["data_output_options"]["save_initial_state"]:
+        data.save_to_netcdf(Path(f"{parent_folder}/initial.nc"))
 
     # Get the list of date times of the next update.
     update_due = {mod.model_name: mod.next_update for mod in models_cfd.values()}
@@ -254,6 +255,7 @@ def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
             update_due[mod_nm] = models_cfd[mod_nm].next_update
 
     # Save the final model state
-    data.save_to_netcdf(Path(f"{parent_folder}/final.nc"))
+    if config["core"]["data_output_options"]["save_final_state"]:
+        data.save_to_netcdf(Path(f"{parent_folder}/final.nc"))
 
     LOGGER.info("Virtual rainforest model run completed!")

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -232,13 +232,9 @@ def vr_run(
     # Identify models with shorter time steps than main loop and warn user about them
     check_for_fast_models(models_cfd, update_interval)
 
-    # TODO - Extract input data required to initialise the models
+    # TODO - A model spin up might be needed here in future
 
-    # TODO - Initialise the set of configured models
-
-    # TODO - Spin up the models
-
-    # TODO - Save model state
+    # Save the initial state of the model
 
     # Get the list of date times of the next update.
     update_due = {mod.model_name: mod.next_update for mod in models_cfd.values()}
@@ -255,6 +251,6 @@ def vr_run(
             models_cfd[mod_nm].update()
             update_due[mod_nm] = models_cfd[mod_nm].next_update
 
-        # TODO - Save model state
+    # TODO - Save the final model state
 
     LOGGER.info("Virtual rainforest model run completed!")

--- a/virtual_rainforest/models/abiotic/abiotic_model.py
+++ b/virtual_rainforest/models/abiotic/abiotic_model.py
@@ -9,8 +9,9 @@ from typing import Any
 
 from numpy import datetime64, timedelta64
 
-from virtual_rainforest.core.base_model import BaseModel, InitialisationError
+from virtual_rainforest.core.base_model import BaseModel
 from virtual_rainforest.core.data import Data
+from virtual_rainforest.core.exceptions import InitialisationError
 from virtual_rainforest.core.logger import LOGGER
 from virtual_rainforest.core.utils import extract_model_time_details
 

--- a/virtual_rainforest/models/abiotic/radiation.py
+++ b/virtual_rainforest/models/abiotic/radiation.py
@@ -29,8 +29,8 @@ from typing import Union
 import numpy as np
 from xarray import DataArray
 
-from virtual_rainforest.core.base_model import InitialisationError
 from virtual_rainforest.core.data import Data
+from virtual_rainforest.core.exceptions import InitialisationError
 from virtual_rainforest.core.logger import LOGGER
 from virtual_rainforest.models.abiotic.abiotic_tools import AbioticConstants
 

--- a/virtual_rainforest/models/soil/carbon.py
+++ b/virtual_rainforest/models/soil/carbon.py
@@ -7,8 +7,8 @@ interactions will be added at a later date.
 import numpy as np
 from xarray import DataArray, Dataset
 
-from virtual_rainforest.core.base_model import InitialisationError
 from virtual_rainforest.core.data import Data
+from virtual_rainforest.core.exceptions import InitialisationError
 from virtual_rainforest.core.logger import LOGGER
 from virtual_rainforest.models.soil.constants import (
     BindingWithPH,


### PR DESCRIPTION
# Description

This PR adds a method to output the full data object as a NetCDF file. It also adds this into the main simulation flow, which now outputs both the initial and final Virtual Rainforest model states.

The current implementation reflects how the `Data` object is currently being used, i.e. contains just `numpy` arrays, doesn't have a time axis. So, if you have any ideas of how to make it more extensible for the types of data you are currently working with let me know.

Fixes #102 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
