### PR TITLE
Remove usage of `pip install codecov` from CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,7 @@ jobs:
 
     - name: Run tests + codecov
       if: (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9')
-      run:
-        poetry run pytest --cov app
+      run: poetry run pytest --cov app
 
     - name: Upload coverage to Codecov
       if: (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
       run:
         poetry run pytest --cov app
 
+    - name: Upload coverage to Codecov
+      if: (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9')
+      uses: codecov/codecov-action@v3
+
   docs_build:
     needs: qa
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,14 @@ jobs:
     - name: Install dependencies
       run: poetry install
 
-    - name: Run tests
+    - name: Run tests (no codecov)
+      if: false == (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9')
       run: poetry run pytest
 
-    - name: Run codecov
-      if: success() && (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9')
-      run: |
-        pip install codecov
-        codecov
+    - name: Run tests + codecov
+      if: (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9')
+      run:
+        poetry run pytest --cov app
 
   docs_build:
     needs: qa

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Run tests + codecov
       if: (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9')
-      run: poetry run pytest --cov app
+      run: poetry run pytest --cov-report xml
 
     - name: Upload coverage to Codecov
       if: (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,7 @@ jobs:
     - name: Install dependencies
       run: poetry install
 
-    - name: Run tests (no codecov)
-      if: false == (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9')
-      run: poetry run pytest
-
-    - name: Run tests + codecov
-      if: (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9')
+    - name: Run tests
       run: poetry run pytest --cov-report xml
 
     - name: Upload coverage to Codecov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Welcome to the Virtual Rainforest
 
+[![codecov](https://codecov.io/gh/ImperialCollegeLondon/virtual_rainforest/branch/main/graph/badge.svg)](https://codecov.io/gh/ImperialCollegeLondon/virtual_rainforest)
+
 This repository is the home for the development of the Virtual Rainforest. The
 Virtual Rainforest is a project to develop a simulation of all of the major
 processes involved in a real rainforest including the:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome to the Virtual Rainforest
 
-[![codecov](https://codecov.io/gh/ImperialCollegeLondon/virtual_rainforest/branch/main/graph/badge.svg)](https://codecov.io/gh/ImperialCollegeLondon/virtual_rainforest)
+[![codecov](https://codecov.io/gh/ImperialCollegeLondon/virtual_rainforest/branch/develop/graph/badge.svg)](https://codecov.io/gh/ImperialCollegeLondon/virtual_rainforest)
 
 This repository is the home for the development of the Virtual Rainforest. The
 Virtual Rainforest is a project to develop a simulation of all of the major


### PR DESCRIPTION
# Description

This fixes the issue that arises from the removal of `codecov` from PyPi. I did this following the [template](https://github.com/codecov/example-python/blob/main/.github/workflows/ci.yml) provided by `codecov`. This involves calculating the coverage as part of the `pytest` run and then uploading the generated coverage using the `codecov` GitHub action. 

Fixes #199

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
