### PR TITLE
Introduce common update time step and timescale bounds for all models

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ The research is based at Imperial College London:
 ## Project Team
 
 * Professor Robert Ewers
-* Olivia Daniels
+* Olivia Daniel
 * Dr. Jaideep Joshi
 * Dr. David Orme
 * Dr. Vivienne Groner
 * Dr. Jacob Cook
-* Taran Rallings
+* Dr. Taran Rallings
 
 The research team are supported by the Imperial College London
 [Research Software

--- a/docs/source/api/core/base_model.md
+++ b/docs/source/api/core/base_model.md
@@ -21,5 +21,5 @@ kernelspec:
     :autosummary:
     :members:
     :special-members: __init_subclass__, __repr__, __str__, __init__
-    :private-members: _check_required_init_vars, _check_model_name
+    :private-members: _check_required_init_vars, _check_model_name, _check_time_bounds_units
 ```

--- a/docs/source/api/core/base_model.md
+++ b/docs/source/api/core/base_model.md
@@ -21,5 +21,6 @@ kernelspec:
     :autosummary:
     :members:
     :special-members: __init_subclass__, __repr__, __str__, __init__
-    :private-members: _check_required_init_vars, _check_model_name, _check_time_bounds_units
+    :private-members: _check_required_init_vars, _check_model_name,
+      _check_time_bounds_units, _check_time_bounds_values
 ```

--- a/docs/source/development/defining_new_models.md
+++ b/docs/source/development/defining_new_models.md
@@ -14,6 +14,8 @@ kernelspec:
 
 # Creating new Virtual Rainforest models
 
+TODO - UPDATE THIS TO DOCUMENT CHANGES TO TIMING SETUP.
+
 The Virtual Rainforest initially contains a set of models defining four core components
 of the rainforest: the `abiotic`, `animals`, `plants` and `soil` models. However, the
 simulation is designed to be modular:
@@ -87,7 +89,7 @@ from virtual_rainforest.core.base_model import BaseModel
 from virtual_rainforest.core.exceptions import InitialisationError
 
 # A utility function to unpack the model specific timing details from the config
-from virtual_rainforest.core.utils import extract_model_time_details
+from virtual_rainforest.core.utils import extract_update_interval
 ```
 
 ### Defining the new class and class attributes
@@ -305,7 +307,7 @@ def from_config(cls, config: dict[str, Any]) -> FreshWaterModel:
     """
 
     # Find timing details
-    start_time, update_interval = extract_model_time_details(config, cls.model_name)
+    update_interval = extract_update_interval(config)
     
     # Non-timing details now extracted
     no_of_pools = config["freshwater"]["no_of_pools"]

--- a/docs/source/development/defining_new_models.md
+++ b/docs/source/development/defining_new_models.md
@@ -307,7 +307,9 @@ def from_config(cls, config: dict[str, Any]) -> FreshWaterModel:
     """
 
     # Find timing details
-    update_interval = extract_update_interval(config)
+    update_interval = extract_update_interval(
+            config, cls.lower_bound_on_time_scale, cls.upper_bound_on_time_scale
+        )
     
     # Non-timing details now extracted
     no_of_pools = config["freshwater"]["no_of_pools"]

--- a/docs/source/development/defining_new_models.md
+++ b/docs/source/development/defining_new_models.md
@@ -14,8 +14,6 @@ kernelspec:
 
 # Creating new Virtual Rainforest models
 
-TODO - UPDATE THIS TO DOCUMENT CHANGES TO TIMING SETUP.
-
 The Virtual Rainforest initially contains a set of models defining four core components
 of the rainforest: the `abiotic`, `animals`, `plants` and `soil` models. However, the
 simulation is designed to be modular:
@@ -29,7 +27,8 @@ ensure that it can be accessed by the `core` processes in the simulation.
 
 ## Create a new submodule folder
 
-Start by creating  a new folder for your model, within the `virtual_rainforest/models/` directory.
+Start by creating  a new folder for your model, within the `virtual_rainforest/models/`
+directory.
 
 ```bash
 mkdir virtual_rainforest/models/freshwater
@@ -96,7 +95,7 @@ from virtual_rainforest.core.utils import extract_update_interval
 
 Now create a new class, that derives from the
 {mod}`~virtual_rainforest.core.base_model.BaseModel`. To begin with, choose a class name
-for the model and define the following two class attributes.
+for the model and define the following four class attributes.
 
 The {attr}`~virtual_rainforest.core.base_model.BaseModel.model_name` attribute
 : This is a string providing a shorter, lower case  name that is used to refer to this
@@ -114,6 +113,16 @@ tuple that sets any required axes for the variable. For example:
 (('temperature', ('spatial',)),) # temperature must be present and on the spatial axis
 ```
 
+The {attr}`~virtual_rainforest.core.base_model.BaseModel.lower_bound_on_time_scale`
+attribute: This give the shortest time scale for which the model can be said to be a
+reasonable model of reality for. This attribute is a string, which should include
+units that can be parsed using `pint`.
+
+The {attr}`~virtual_rainforest.core.base_model.BaseModel.upper_bound_on_time_scale`
+attribute: This give the longest time scale for which the model can be said to be a
+reasonable model of reality for. Again this attribute is a string, which should include
+units that can be parsed using `pint`.
+
 You will end up with something like the following:
 
 ```python
@@ -126,6 +135,10 @@ class FreshWaterModel(BaseModel):
 
     model_name = "freshwater"
     """The model name for use in registering the model and logging."""
+    lower_bound_on_time_scale = "1 day"
+    """Shortest time scale that freshwater model can sensibly capture."""
+    upper_bound_on_time_scale = "1 month"
+    """Longest time scale that freshwater model can sensibly capture."""
     required_init_vars = (('temperature', ('spatial', )), )
     """The required variables and axes for the Freshwater Model"""
 ```
@@ -324,31 +337,24 @@ def from_config(cls, config: dict[str, Any]) -> FreshWaterModel:
 
 ## Other model steps
 
-Every model class needs to include a function to update its model state. The exact
-details of what should be in this `update` function are yet to be decided, apart from
-how to update the internal model timing loop.
-
-```python
-def update(self) -> None:
-    """Function to update the freshwater model (only updates time currently)."""
-
-    # Update internal model timing loop
-    self.next_update += self.update_interval
-```
-
-In addition to the above, there are three other functions that must be included as part
-of the model class. The names and roles of these functions might well change as the
-Virtual Rainforest model develops, but that kind of API change is something that would
-require significant discussion. These functions are not actually used at present, so
-while they have to be included, there's no need to include any particular content within
-them (i.e. they can just be function definitions with docstrings).
+There are four functions that must be included as part of the model class. The names and
+roles of these functions might well change as the Virtual Rainforest model develops, but
+that kind of API change is something that would require significant discussion. Only the
+`update` function is used at present. The other functions need to be included, but
+there's no need to include any particular content within them (i.e. they can just be
+function definitions with docstrings).
 
 ```python
 def setup(self) -> None:
-    """Placeholder function to spin up the freshwater model."""
+    """Placeholder function to set up the freshwater model."""
 
 def spinup(self) -> None:
     """Placeholder function to spin up the freshwater model."""
+
+def update(self) -> None:
+    """Function to update the freshwater model."""
+
+    # Model simulation + update steps go in here.
 
 def cleanup(self) -> None:
     """Placeholder function for freshwater model cleanup."""

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -47,12 +47,12 @@ The research is based at [Imperial College London](https://imperial.ac.uk):
 ## Project Team
 
 - Professor Robert Ewers
-- Olivia Daniels
+- Olivia Daniel
 - Dr. Jaideep Joshi
 - Dr. David Orme
 - Dr. Vivienne Groner
 - Dr. Jacob Cook
-- Taran Rallings
+- Dr. Taran Rallings
 
 The research team are supported by the Imperial College London
 [Research Software Engineering](https://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/research-software-engineering/)

--- a/docs/source/virtual_rainforest/main_simulation.md
+++ b/docs/source/virtual_rainforest/main_simulation.md
@@ -48,7 +48,9 @@ the configuration, they are then all configured.
 The configuration contains a start time, an end time and an time interval for the update
 of every model. These details are extracted from configuration, with a check performed
 to ensure that the simulation will update at least once between the start and end time
-of the simulation.
+of the simulation. It is important to note that because months and years are of
+inconsistent length they are currently averaged over. This means that 1 month becomes
+30.4375 days, and 1 year becomes 365.25 days.
 
 ## Saving the initial state
 

--- a/docs/source/virtual_rainforest/main_simulation.md
+++ b/docs/source/virtual_rainforest/main_simulation.md
@@ -45,11 +45,10 @@ the configuration, they are then all configured.
 
 ## Extracting simulation timing details
 
-The configuration contains a start time, an end time and an time interval for checking
-whether models need to be updated. Once these details are extracted from the
-configuration, a check is performed to ensure that the simulation update interval works
-suitably with the time steps for individual models, i.e. that no model has a shorter
-time step than the overall simulation update interval.
+The configuration contains a start time, an end time and an time interval for the update
+of every model. These details are extracted from configuration, with a check performed
+to ensure that the simulation will update at least once between the start and end time
+of the simulation.
 
 ## Saving the initial state
 
@@ -61,8 +60,7 @@ a single data file of the initial model state.
 
 The previously extracted timing details are used to setup a timing loop, which runs from
 the start time to the end time with a time step set by the update interval. At each
-step a check is performed to determine if any models need to be updated. Any that do
-need to be updated are then updated.
+step all models are updated.
 
 ## Saving the final state
 

--- a/tests/core/data/all_config.toml
+++ b/tests/core/data/all_config.toml
@@ -26,6 +26,3 @@ maxh = 1.0
 [[plants.ftypes]]
 pft_name = "broadleaf"
 maxh = 50.0
-
-[soil]
-model_time_step = "2 weeks"

--- a/tests/core/data/all_config.toml
+++ b/tests/core/data/all_config.toml
@@ -7,7 +7,7 @@ ny = 10
 
 [core.timing]
 start_date = "2020-01-01"
-update_interval = "10 minutes"
+update_interval = "2 weeks"
 run_length = "50 years"
 
 [core.data_output_options]
@@ -28,4 +28,4 @@ pft_name = "broadleaf"
 maxh = 50.0
 
 [soil]
-model_time_step = "5 days"
+model_time_step = "2 weeks"

--- a/tests/core/test_base_model.py
+++ b/tests/core/test_base_model.py
@@ -83,6 +83,91 @@ def data_instance():
                 model_name = 'should_pass'
                 required_init_vars = tuple()
             """,
+            None,
+            "UnnamedModel",
+            pytest.raises(NotImplementedError),
+            "Property lower_bound_on_time_scale is not implemented in UnnamedModel",
+            [
+                (
+                    ERROR,
+                    "Property lower_bound_on_time_scale is not implemented in "
+                    "UnnamedModel",
+                ),
+                (CRITICAL, "Errors in UnnamedModel class properties: see log"),
+            ],
+            id="No lower_bound_on_time_scale",
+        ),
+        pytest.param(
+            """class UnnamedModel(BaseModel):
+                model_name = 'should_pass'
+                required_init_vars = tuple()
+                lower_bound_on_time_scale = "1 day"
+            """,
+            None,
+            "UnnamedModel",
+            pytest.raises(NotImplementedError),
+            "Property upper_bound_on_time_scale is not implemented in UnnamedModel",
+            [
+                (
+                    ERROR,
+                    "Property upper_bound_on_time_scale is not implemented in "
+                    "UnnamedModel",
+                ),
+                (CRITICAL, "Errors in UnnamedModel class properties: see log"),
+            ],
+            id="No upper_bound_on_time_scale",
+        ),
+        pytest.param(
+            """class UnnamedModel(BaseModel):
+                model_name = 'should_pass'
+                required_init_vars = tuple()
+                lower_bound_on_time_scale = "1 day"
+                upper_bound_on_time_scale = "1 time"
+            """,
+            None,
+            "UnnamedModel",
+            pytest.raises(ValueError),
+            "Invalid units for one or more model time bounds, see above errors.",
+            [
+                (ERROR, "Upper bound for UnnamedModel not given a valid unit."),
+                (
+                    ERROR,
+                    "Invalid units for one or more model time bounds, see above "
+                    "errors.",
+                ),
+                (CRITICAL, "Errors in UnnamedModel class properties: see log"),
+            ],
+            id="Bad unit for upper_bound_on_time_scale",
+        ),
+        pytest.param(
+            """class UnnamedModel(BaseModel):
+                model_name = 'should_pass'
+                required_init_vars = tuple()
+                lower_bound_on_time_scale = "1 meter"
+                upper_bound_on_time_scale = "1 month"
+            """,
+            None,
+            "UnnamedModel",
+            pytest.raises(ValueError),
+            "Invalid units for one or more model time bounds, see above errors.",
+            [
+                (ERROR, "Lower bound for UnnamedModel given a non-time unit."),
+                (
+                    ERROR,
+                    "Invalid units for one or more model time bounds, see above "
+                    "errors.",
+                ),
+                (CRITICAL, "Errors in UnnamedModel class properties: see log"),
+            ],
+            id="Distance unit for lower_bound_on_time_scale",
+        ),
+        pytest.param(
+            """class UnnamedModel(BaseModel):
+                model_name = 'should_pass'
+                required_init_vars = tuple()
+                lower_bound_on_time_scale = "1 day"
+                upper_bound_on_time_scale = "1 month"
+            """,
             "should_pass",
             "UnnamedModel",
             does_not_raise(),
@@ -94,6 +179,8 @@ def data_instance():
             """class UnnamedModel2(BaseModel):
                 model_name = 'should_pass'
                 required_init_vars = tuple()
+                lower_bound_on_time_scale = "1 day"
+                upper_bound_on_time_scale = "1 month"
             """,
             "should_pass",
             "UnnamedModel2",
@@ -112,6 +199,8 @@ def data_instance():
             """class UnnamedModel(BaseModel):
                 model_name = 'should_also_pass'
                 required_init_vars = (('temperature', ('spatial',),),)
+                lower_bound_on_time_scale = "1 day"
+                upper_bound_on_time_scale = "1 month"
             """,
             "should_also_pass",
             "UnnamedModel",
@@ -210,6 +299,8 @@ def test_check_required_init_var_structure(caplog, riv_value, exp_raise, exp_msg
     code = f"""class UM(BaseModel):
         model_name = 'should_also_pass'
         required_init_vars = {riv_value}
+        lower_bound_on_time_scale = "1 day"
+        upper_bound_on_time_scale = "1 month"
     """
 
     with exp_raise as err:

--- a/tests/core/test_base_model.py
+++ b/tests/core/test_base_model.py
@@ -231,6 +231,8 @@ def test_check_failure_on_missing_methods(data_instance):
 
     class InitVarModel(BaseModel):
         model_name = "init_var"
+        lower_bound_on_time_scale = "1 second"
+        upper_bound_on_time_scale = "1 year"
         required_init_vars = ()
 
     with pytest.raises(TypeError) as err:
@@ -306,6 +308,8 @@ def test_check_required_init_vars(
 
     class TestCaseModel(BaseModel):
         model_name = "init_var"
+        lower_bound_on_time_scale = "1 second"
+        upper_bound_on_time_scale = "1 year"
         required_init_vars = ()
 
         def setup(self) -> None:

--- a/tests/core/test_base_model.py
+++ b/tests/core/test_base_model.py
@@ -143,6 +143,48 @@ def data_instance():
             """class UnnamedModel(BaseModel):
                 model_name = 'should_pass'
                 required_init_vars = tuple()
+                lower_bound_on_time_scale = "1 day"
+                upper_bound_on_time_scale = "1 day"
+            """,
+            None,
+            "UnnamedModel",
+            pytest.raises(ValueError),
+            "Lower time bound for UnnamedModel is not less than the upper bound.",
+            [
+                (
+                    ERROR,
+                    "Lower time bound for UnnamedModel is not less than the upper "
+                    "bound.",
+                ),
+                (CRITICAL, "Errors in UnnamedModel class properties: see log"),
+            ],
+            id="Lower and upper bound equal",
+        ),
+        pytest.param(
+            """class UnnamedModel(BaseModel):
+                model_name = 'should_pass'
+                required_init_vars = tuple()
+                lower_bound_on_time_scale = "1 month"
+                upper_bound_on_time_scale = "1 day"
+            """,
+            None,
+            "UnnamedModel",
+            pytest.raises(ValueError),
+            "Lower time bound for UnnamedModel is not less than the upper bound.",
+            [
+                (
+                    ERROR,
+                    "Lower time bound for UnnamedModel is not less than the upper "
+                    "bound.",
+                ),
+                (CRITICAL, "Errors in UnnamedModel class properties: see log"),
+            ],
+            id="Lower bound greater",
+        ),
+        pytest.param(
+            """class UnnamedModel(BaseModel):
+                model_name = 'should_pass'
+                required_init_vars = tuple()
                 lower_bound_on_time_scale = "1 meter"
                 upper_bound_on_time_scale = "1 month"
             """,

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -409,18 +409,13 @@ def test_missing_core_schema(caplog, mocker):
             (),
         ),
         (
-            {"soil": {"no_layers": -1}},
+            {},
             None,
             pytest.raises(ConfigurationError),
             (
                 (
                     ERROR,
                     "[plants]: 'ftypes' is a required property",
-                ),
-                (
-                    ERROR,
-                    "[soil]: Additional properties are not allowed ('no_layers' was "
-                    "unexpected)",
                 ),
                 (
                     CRITICAL,

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -16,8 +16,12 @@ from virtual_rainforest.core.exceptions import ConfigurationError, Initialisatio
     argvalues=[
         (
             {
-                "core": {"timing": {"start_date": "2020-01-01"}},
-                "soil": {"model_time_step": "12 hours"},
+                "core": {
+                    "timing": {
+                        "start_date": "2020-01-01",
+                        "update_interval": "12 hours",
+                    }
+                },
             },
             does_not_raise(),
             timedelta64(720, "m"),
@@ -25,8 +29,12 @@ from virtual_rainforest.core.exceptions import ConfigurationError, Initialisatio
         ),
         (
             {
-                "core": {"timing": {"start_date": "2020-01-01"}},
-                "soil": {"model_time_step": "12 interminable hours"},
+                "core": {
+                    "timing": {
+                        "start_date": "2020-01-01",
+                        "update_interval": "12 interminable hours",
+                    }
+                },
             },
             pytest.raises(InitialisationError),
             None,
@@ -40,8 +48,12 @@ from virtual_rainforest.core.exceptions import ConfigurationError, Initialisatio
         ),
         (
             {
-                "core": {"timing": {"start_date": "2020-01-01"}},
-                "soil": {"model_time_step": "12 kilograms"},
+                "core": {
+                    "timing": {
+                        "start_date": "2020-01-01",
+                        "update_interval": "12 kilograms",
+                    }
+                },
             },
             pytest.raises(InitialisationError),
             None,
@@ -55,13 +67,13 @@ from virtual_rainforest.core.exceptions import ConfigurationError, Initialisatio
         ),
     ],
 )
-def test_extract_model_time_details(caplog, config, raises, timestep, expected_log):
+def test_extract_update_interval(caplog, config, raises, timestep, expected_log):
     """Tests timing details extraction utility."""
 
-    from virtual_rainforest.core.utils import extract_model_time_details
+    from virtual_rainforest.core.utils import extract_update_interval
 
     with raises:
-        update_interval = extract_model_time_details(config, "soil")
+        update_interval = extract_update_interval(config)
         assert update_interval == timestep
 
     log_check(caplog, expected_log)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -65,6 +65,42 @@ from virtual_rainforest.core.exceptions import ConfigurationError, Initialisatio
                 ),
             ),
         ),
+        (
+            {
+                "core": {
+                    "timing": {
+                        "start_date": "2020-01-01",
+                        "update_interval": "30 minutes",
+                    }
+                },
+            },
+            pytest.raises(ConfigurationError),
+            None,
+            (
+                (
+                    ERROR,
+                    "The update interval is shorter than the model's lower bound",
+                ),
+            ),
+        ),
+        (
+            {
+                "core": {
+                    "timing": {
+                        "start_date": "2020-01-01",
+                        "update_interval": "3 months",
+                    }
+                },
+            },
+            pytest.raises(ConfigurationError),
+            None,
+            (
+                (
+                    ERROR,
+                    "The update interval is longer than the model's upper bound",
+                ),
+            ),
+        ),
     ],
 )
 def test_extract_update_interval(caplog, config, raises, timestep, expected_log):
@@ -73,7 +109,7 @@ def test_extract_update_interval(caplog, config, raises, timestep, expected_log)
     from virtual_rainforest.core.utils import extract_update_interval
 
     with raises:
-        update_interval = extract_update_interval(config)
+        update_interval = extract_update_interval(config, "1 hour", "1 month")
         assert update_interval == timestep
 
     log_check(caplog, expected_log)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -5,14 +5,14 @@ from logging import CRITICAL, ERROR
 from pathlib import Path
 
 import pytest
-from numpy import datetime64, timedelta64
+from numpy import timedelta64
 
 from tests.conftest import log_check
 from virtual_rainforest.core.exceptions import ConfigurationError, InitialisationError
 
 
 @pytest.mark.parametrize(
-    argnames=["config", "raises", "timestep", "initial_time", "expected_log"],
+    argnames=["config", "raises", "timestep", "expected_log"],
     argvalues=[
         (
             {
@@ -21,7 +21,6 @@ from virtual_rainforest.core.exceptions import ConfigurationError, Initialisatio
             },
             does_not_raise(),
             timedelta64(720, "m"),
-            datetime64("2020-01-01"),
             (),
         ),
         (
@@ -30,7 +29,6 @@ from virtual_rainforest.core.exceptions import ConfigurationError, Initialisatio
                 "soil": {"model_time_step": "12 interminable hours"},
             },
             pytest.raises(InitialisationError),
-            None,
             None,
             (
                 (
@@ -47,7 +45,6 @@ from virtual_rainforest.core.exceptions import ConfigurationError, Initialisatio
             },
             pytest.raises(InitialisationError),
             None,
-            None,
             (
                 (
                     ERROR,
@@ -58,16 +55,13 @@ from virtual_rainforest.core.exceptions import ConfigurationError, Initialisatio
         ),
     ],
 )
-def test_extract_model_time_details(
-    caplog, config, raises, timestep, initial_time, expected_log
-):
+def test_extract_model_time_details(caplog, config, raises, timestep, expected_log):
     """Tests timing details extraction utility."""
 
     from virtual_rainforest.core.utils import extract_model_time_details
 
     with raises:
-        start_time, update_interval = extract_model_time_details(config, "soil")
-        assert start_time == initial_time
+        update_interval = extract_model_time_details(config, "soil")
         assert update_interval == timestep
 
     log_check(caplog, expected_log)

--- a/tests/models/abiotic/test_abiotic_model.py
+++ b/tests/models/abiotic/test_abiotic_model.py
@@ -4,7 +4,7 @@ from contextlib import nullcontext as does_not_raise
 from logging import ERROR, INFO
 
 import pytest
-from numpy import datetime64, timedelta64
+from numpy import timedelta64
 
 from tests.conftest import log_check
 from virtual_rainforest.core.exceptions import InitialisationError
@@ -76,7 +76,6 @@ def test_abiotic_model_initialization(
         model = AbioticModel(
             data_instance,
             timedelta64(1, "W"),
-            datetime64("2022-11-01"),
             soil_layers,
             canopy_layers,
         )
@@ -85,8 +84,7 @@ def test_abiotic_model_initialization(
         assert set(["setup", "spinup", "update", "cleanup"]).issubset(dir(model))
         assert model.model_name == "abiotic"
         assert (
-            repr(model)
-            == f"AbioticModel(update_interval = 1 weeks, next_update = 2022-11-08, "
+            repr(model) == f"AbioticModel(update_interval = 1 weeks, "
             f"soil_layers = {int(soil_layers)}, "
             f"canopy_layers = {int(canopy_layers)})"
         )
@@ -138,16 +136,9 @@ def test_generate_abiotic_model(
         assert model.soil_layers == config["abiotic"]["soil_layers"]
         assert model.canopy_layers == config["abiotic"]["canopy_layers"]
         assert model.update_interval == time_interval
-        assert (
-            model.next_update
-            == datetime64(config["core"]["timing"]["start_date"]) + time_interval
-        )
-        # Run the update step and check that next_update has incremented properly
+
+        # Run the update step (once this does something should check output)
         model.update()
-        assert (
-            model.next_update
-            == datetime64(config["core"]["timing"]["start_date"]) + 2 * time_interval
-        )
 
     # Final check that expected logging entries are produced
     log_check(caplog, expected_log_entries)

--- a/tests/models/abiotic/test_abiotic_model.py
+++ b/tests/models/abiotic/test_abiotic_model.py
@@ -106,11 +106,15 @@ def test_abiotic_model_initialization(
         ),
         (
             {
-                "core": {"timing": {"start_date": "2020-01-01"}},
+                "core": {
+                    "timing": {
+                        "start_date": "2020-01-01",
+                        "update_interval": "12 hours",
+                    }
+                },
                 "abiotic": {
                     "soil_layers": 2,
                     "canopy_layers": 3,
-                    "model_time_step": "12 hours",
                 },
             },
             timedelta64(12, "h"),

--- a/tests/models/animals/test_animal_model.py
+++ b/tests/models/animals/test_animal_model.py
@@ -4,7 +4,7 @@ from contextlib import nullcontext as does_not_raise
 from logging import ERROR, INFO
 
 import pytest
-from numpy import datetime64, timedelta64
+from numpy import timedelta64
 
 from tests.conftest import log_check
 from virtual_rainforest.core.exceptions import InitialisationError
@@ -15,16 +15,13 @@ def test_animal_model_initialization(caplog, data_instance):
     from virtual_rainforest.models.animals.animal_model import AnimalModel
 
     # Initialize model
-    model = AnimalModel(data_instance, timedelta64(1, "W"), datetime64("2022-11-01"))
+    model = AnimalModel(data_instance, timedelta64(1, "W"))
 
     # In cases where it passes then checks that the object has the right properties
     assert set(["setup", "spinup", "update", "cleanup"]).issubset(dir(model))
     assert model.model_name == "animal"
     assert str(model) == "A animal model instance"
-    assert (
-        repr(model)
-        == "AnimalModel(update_interval = 1 weeks, next_update = 2022-11-08)"
-    )
+    assert repr(model) == "AnimalModel(update_interval = 1 weeks)"
 
 
 @pytest.mark.parametrize(
@@ -78,16 +75,8 @@ def test_generate_animal_model(
     with raises:
         model = AnimalModel.from_config(data_instance, config)
         assert model.update_interval == time_interval
-        assert (
-            model.next_update
-            == datetime64(config["core"]["timing"]["start_date"]) + time_interval
-        )
-        # Run the update step and check that next_update has incremented properly
+        # Run the update step (once this does something should check output)
         model.update()
-        assert (
-            model.next_update
-            == datetime64(config["core"]["timing"]["start_date"]) + 2 * time_interval
-        )
 
     # Final check that expected logging entries are produced
     log_check(caplog, expected_log_entries)

--- a/tests/models/animals/test_animal_model.py
+++ b/tests/models/animals/test_animal_model.py
@@ -35,8 +35,12 @@ def test_animal_model_initialization(caplog, data_instance):
         ),
         (
             {
-                "core": {"timing": {"start_date": "2020-01-01"}},
-                "animal": {"model_time_step": "12 hours"},
+                "core": {
+                    "timing": {
+                        "start_date": "2020-01-01",
+                        "update_interval": "12 hours",
+                    }
+                },
             },
             timedelta64(12, "h"),
             does_not_raise(),
@@ -50,8 +54,12 @@ def test_animal_model_initialization(caplog, data_instance):
         ),
         (
             {
-                "core": {"timing": {"start_date": "2020-01-01"}},
-                "animal": {"model_time_step": "20 interminable minutes"},
+                "core": {
+                    "timing": {
+                        "start_date": "2020-01-01",
+                        "update_interval": "20 interminable minutes",
+                    }
+                },
             },
             None,
             pytest.raises(InitialisationError),

--- a/tests/models/animals/test_animal_model.py
+++ b/tests/models/animals/test_animal_model.py
@@ -38,11 +38,11 @@ def test_animal_model_initialization(caplog, data_instance):
                 "core": {
                     "timing": {
                         "start_date": "2020-01-01",
-                        "update_interval": "12 hours",
+                        "update_interval": "7 days",
                     }
                 },
             },
-            timedelta64(12, "h"),
+            timedelta64(7, "D"),
             does_not_raise(),
             (
                 (

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -168,13 +168,9 @@ def test_soil_model_initialization(
                     [0.05, 0.02, 0.1, -0.005], dims=["cell_id"]
                 )
             # Initialise model with bad data object
-            model = SoilModel(
-                carbon_data, np.timedelta64(1, "W"), np.datetime64("2022-11-01")
-            )
+            model = SoilModel(carbon_data, np.timedelta64(1, "W"))
         else:
-            model = SoilModel(
-                dummy_carbon_data, np.timedelta64(1, "W"), np.datetime64("2022-11-01")
-            )
+            model = SoilModel(dummy_carbon_data, np.timedelta64(1, "W"))
 
         # In cases where it passes then checks that the object has the right properties
         assert set(
@@ -189,10 +185,7 @@ def test_soil_model_initialization(
         ).issubset(dir(model))
         assert model.model_name == "soil"
         assert str(model) == "A soil model instance"
-        assert (
-            repr(model)
-            == "SoilModel(update_interval = 1 weeks, next_update = 2022-11-08)"
-        )
+        assert repr(model) == "SoilModel(update_interval = 1 weeks)"
 
     # Final check that expected logging entries are produced
     log_check(caplog, expected_log_entries)
@@ -266,10 +259,6 @@ def test_generate_soil_model(
     with raises:
         model = SoilModel.from_config(dummy_carbon_data, config)
         assert model.update_interval == time_interval
-        assert (
-            model.next_update
-            == np.datetime64(config["core"]["timing"]["start_date"]) + time_interval
-        )
 
     # Final check that expected logging entries are produced
     log_check(caplog, expected_log_entries)
@@ -295,11 +284,6 @@ def test_update(mocker, soil_model_fixture, dummy_carbon_data):
 
     # Check that integrator is called once (and once only)
     mock_integrate.assert_called_once()
-
-    # Check that time has incremented correctly
-    assert soil_model_fixture.next_update == np.datetime64(
-        "2020-01-01"
-    ) + 2 * np.timedelta64(12, "h")
 
     # Check that data fixture has been updated correctly
     assert np.allclose(dummy_carbon_data["soil_c_pool_lmwc"], end_lmwc)

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -21,8 +21,7 @@ def soil_model_fixture(dummy_carbon_data):
     from virtual_rainforest.models.soil.soil_model import SoilModel
 
     config = {
-        "core": {"timing": {"start_date": "2020-01-01"}},
-        "soil": {"model_time_step": "12 hours"},
+        "core": {"timing": {"start_date": "2020-01-01", "update_interval": "12 hours"}},
     }
     return SoilModel.from_config(dummy_carbon_data, config)
 
@@ -202,8 +201,12 @@ def test_soil_model_initialization(
         ),
         (
             {
-                "core": {"timing": {"start_date": "2020-01-01"}},
-                "soil": {"model_time_step": "12 hours"},
+                "core": {
+                    "timing": {
+                        "start_date": "2020-01-01",
+                        "update_interval": "12 hours",
+                    }
+                },
             },
             np.timedelta64(12, "h"),
             does_not_raise(),
@@ -406,8 +409,7 @@ def test_order_independance(dummy_carbon_data, soil_model_fixture):
 
     # Use this new data to make a new soil model object
     config = {
-        "core": {"timing": {"start_date": "2020-01-01"}},
-        "soil": {"model_time_step": "12 hours"},
+        "core": {"timing": {"start_date": "2020-01-01", "update_interval": "12 hours"}},
     }
     new_soil_model = SoilModel.from_config(new_data, config)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -82,8 +82,9 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
     [
         pytest.param(
             {  # valid config
-                "soil": {"model_time_step": "7 days"},
-                "core": {"timing": {"start_date": "2020-01-01"}},
+                "core": {
+                    "timing": {"start_date": "2020-01-01", "update_interval": "7 days"}
+                },
             },
             "SoilModel(update_interval = 604800 seconds)",
             does_not_raise(),
@@ -126,9 +127,8 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
             id="valid config",
         ),
         pytest.param(
-            {  # model_time_step missing units
-                "soil": {"model_time_step": "7"},
-                "core": {"timing": {}},
+            {  # update_interval missing units
+                "core": {"timing": {"update_interval": "7"}},
             },
             None,
             pytest.raises(InitialisationError),
@@ -202,11 +202,9 @@ def test_vr_run_bad_model(mocker, caplog):
             "timing": {
                 "start_date": "2020-01-01",
                 "end_date": "2120-01-01",
+                "update_interval": "0.5 martian days",
             },
             "data": [],
-        },
-        "soil": {
-            "model_time_step": "0.5 martian days",
         },
     }
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -151,6 +151,46 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
             ),
             id="model_time_step missing units",
         ),
+        pytest.param(
+            {  # update_interval missing units
+                "core": {"timing": {"update_interval": "1 minute"}},
+            },
+            None,
+            pytest.raises(InitialisationError),
+            (
+                (INFO, "Attempting to configure the following models: ['soil']"),
+                (
+                    ERROR,
+                    "The update interval is shorter than the model's lower bound",
+                ),
+                (
+                    CRITICAL,
+                    "Could not configure all the desired models, ending the "
+                    "simulation.",
+                ),
+            ),
+            id="update interval too short",
+        ),
+        pytest.param(
+            {  # update_interval missing units
+                "core": {"timing": {"update_interval": "1 year"}},
+            },
+            None,
+            pytest.raises(InitialisationError),
+            (
+                (INFO, "Attempting to configure the following models: ['soil']"),
+                (
+                    ERROR,
+                    "The update interval is longer than the model's upper bound",
+                ),
+                (
+                    CRITICAL,
+                    "Could not configure all the desired models, ending the "
+                    "simulation.",
+                ),
+            ),
+            id="update interval too long",
+        ),
     ],
 )
 def test_configure_models(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -85,8 +85,7 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
                 "soil": {"model_time_step": "7 days"},
                 "core": {"timing": {"start_date": "2020-01-01"}},
             },
-            "SoilModel(update_interval = 604800 seconds, next_update = "
-            "2020-01-08T00:00:00)",
+            "SoilModel(update_interval = 604800 seconds)",
             does_not_raise(),
             (
                 (INFO, "Attempting to configure the following models: ['soil']"),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ defined in main.py that it calls.
 """
 
 from contextlib import nullcontext as does_not_raise
-from logging import CRITICAL, DEBUG, ERROR, INFO, WARNING
+from logging import CRITICAL, DEBUG, ERROR, INFO
 from pathlib import Path
 
 import pytest
@@ -14,7 +14,6 @@ from numpy import datetime64, timedelta64
 from virtual_rainforest.core.base_model import BaseModel
 from virtual_rainforest.core.exceptions import InitialisationError
 from virtual_rainforest.main import vr_run
-from virtual_rainforest.models.soil.soil_model import SoilModel
 
 from .conftest import log_check
 
@@ -341,36 +340,5 @@ def test_extract_timing_details(caplog, config, output, raises, expected_log_ent
         assert end_time == output["end_time"]
         assert update_interval == output["update_interval"]
         assert current_time == output["start_time"]
-
-    log_check(caplog, expected_log_entries)
-
-
-@pytest.mark.parametrize(
-    "update_interval,expected_log_entries",
-    [
-        pytest.param(timedelta64(2, "W"), (), id="valid"),
-        pytest.param(
-            timedelta64(5, "W"),
-            (
-                (
-                    WARNING,
-                    "The following models have shorter time steps than the main model: "
-                    "['soil']",
-                ),
-            ),
-            id="fast model",
-        ),
-    ],
-)
-def test_check_for_fast_models(caplog, update_interval, expected_log_entries):
-    """Test that function to warn user about short module time steps works."""
-    from virtual_rainforest.main import check_for_fast_models
-
-    # Create SoilModel instance and then populate the update_interval
-    model = SoilModel.__new__(SoilModel)
-    model.update_interval = timedelta64(3, "W")
-    models_cfd = {"soil": model}
-
-    check_for_fast_models(models_cfd, update_interval)
 
     log_check(caplog, expected_log_entries)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -260,9 +260,9 @@ def test_vr_run_bad_model(mocker, caplog):
             (
                 (
                     INFO,
-                    "Virtual Rainforest simulation will run from 2020-01-01 until 2049-"
-                    "12-31T12:00. This is a run length of 15778800 minutes, the user "
-                    "requested 15778800 minutes",
+                    "Virtual Rainforest simulation will run from 2020-01-01 until "
+                    "2049-12-31T12:00:00. This is a run length of 946728000 seconds, "
+                    "the user requested 946728000 seconds",
                 ),
             ),
             id="timing correct",
@@ -282,8 +282,8 @@ def test_vr_run_bad_model(mocker, caplog):
             (
                 (
                     CRITICAL,
-                    "Models will never update as the update interval (10 minutes) is "
-                    "larger than the run length (1 minutes)",
+                    "Models will never update as the update interval (600 seconds) is "
+                    "larger than the run length (60 seconds)",
                 ),
             ),
             id="run length < update interval",

--- a/virtual_rainforest/core/base_model.py
+++ b/virtual_rainforest/core/base_model.py
@@ -31,12 +31,12 @@ that must be defined in subclasses:
 * The :attr:`~virtual_rainforest.core.base_model.BaseModel.upper_bound_on_time_scale`
   attribute
 
-TODO - Add in fourth method once I've defined it.
 The usage of these four attributes is described in their docstrings and four private
 methods are provided to validate that the properties are set and valid in subclasses
 (:meth:`~virtual_rainforest.core.base_model.BaseModel._check_model_name`,
 :meth:`~virtual_rainforest.core.base_model.BaseModel._check_required_init_vars`,
-:meth:`~virtual_rainforest.core.base_model.BaseModel._check_time_bounds_units`,).
+:meth:`~virtual_rainforest.core.base_model.BaseModel._check_time_bounds_units` and
+:meth:`~virtual_rainforest.core.base_model.BaseModel._check_time_bounds_values`).
 
 Model registration
 ------------------
@@ -347,6 +347,25 @@ class BaseModel(ABC):
             raise to_raise
 
     @classmethod
+    def _check_time_bounds_values(cls) -> None:
+        """Check that the lower time bound is less than the upper bound.
+
+        Raises:
+            ValueError: If the lower bound is not less than the upper bound
+        """
+
+        # Find upper and lower bound
+        upper_bound = pint.Quantity(cls.upper_bound_on_time_scale)
+        lower_bound = pint.Quantity(cls.lower_bound_on_time_scale)
+
+        if upper_bound <= lower_bound:
+            to_raise = ValueError(
+                f"Lower time bound for {cls.__name__} is not less than the upper bound."
+            )
+            LOGGER.error(to_raise)
+            raise to_raise
+
+    @classmethod
     def __init_subclass__(cls) -> None:
         """Initialise subclasses deriving from BaseModel.
 
@@ -364,6 +383,7 @@ class BaseModel(ABC):
             cls._check_model_name()
             cls._check_required_init_vars()
             cls._check_time_bounds_units()
+            cls._check_time_bounds_values()
         except (NotImplementedError, TypeError, ValueError) as excep:
             LOGGER.critical(f"Errors in {cls.__name__} class properties: see log")
             raise excep

--- a/virtual_rainforest/core/base_model.py
+++ b/virtual_rainforest/core/base_model.py
@@ -137,8 +137,7 @@ class BaseModel(ABC):
         performs the following core steps:
 
         * It populates the shared instance attributes
-          :attr:`~virtual_rainforest.core.base_model.BaseModel.data`,
-          :attr:`~virtual_rainforest.core.base_model.BaseModel.next_update` and
+          :attr:`~virtual_rainforest.core.base_model.BaseModel.data` and
           :attr:`~virtual_rainforest.core.base_model.BaseModel.update_interval`.
         * It uses the
           :meth:`~virtual_rainforest.core.base_model.BaseModel.check_init_data`

--- a/virtual_rainforest/core/base_model.py
+++ b/virtual_rainforest/core/base_model.py
@@ -73,7 +73,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Type
 
-from numpy import datetime64, timedelta64
+from numpy import timedelta64
 
 from virtual_rainforest.core.axes import AXIS_VALIDATORS
 from virtual_rainforest.core.data import Data
@@ -129,7 +129,6 @@ class BaseModel(ABC):
         self,
         data: Data,
         update_interval: timedelta64,
-        start_time: datetime64,
         **kwargs: Any,
     ):
         """Performs core initialisation for BaseModel subclasses.
@@ -150,9 +149,7 @@ class BaseModel(ABC):
         """A Data instance providing access to the shared simulation data."""
         self.update_interval = update_interval
         """The time interval between model updates."""
-        self.next_update = start_time + update_interval
-        """The simulation time at which the model should next run the update method"""
-        self._repr = ["update_interval", "next_update"]
+        self._repr = ["update_interval"]
         """A list of attributes to be included in the class __repr__ output"""
 
         # Check the required init variables

--- a/virtual_rainforest/core/base_model.py
+++ b/virtual_rainforest/core/base_model.py
@@ -113,6 +113,31 @@ class BaseModel(ABC):
 
     @property
     @abstractmethod
+    def lower_bound_on_time_scale(cls) -> str:
+        """The shortest time scale for which the model is reasonable to use.
+
+        Whether or not a model is an acceptable representation of reality depends on the
+        time scale of interest. At large time scales some processes can be treated as
+        transient (and therefore ignored), but at shorter time scales these processes
+        can be vital to capture. We thus require each model to define a lower bound on
+        the time scale for which it is thought to be a reasonable approximation.
+        """
+
+    @property
+    @abstractmethod
+    def upper_bound_on_time_scale(cls) -> str:
+        """The longest time scale for which the model is reasonable to use.
+
+        Whether or not a model is an acceptable representation of reality depends on the
+        time scale of interest. Processes that can be sensibly simulated in detail at
+        shorter time scales often need to approximated as time scales get longer (e.g.
+        impacts of diurnal or seasonal cycles). We thus require each model to define an
+        upper bound on the time scale for which it is thought to be a reasonable
+        approximation.
+        """
+
+    @property
+    @abstractmethod
     def required_init_vars(cls) -> tuple[tuple[str, tuple[str, ...]], ...]:
         """Required variables for model initialisation.
 

--- a/virtual_rainforest/core/core_schema.json
+++ b/virtual_rainforest/core/core_schema.json
@@ -39,11 +39,9 @@
                      "default": "2015-01-01"
                   },
                   "update_interval": {
-                     "description": "Model update interval. This should either be significantly",
-                     "desc_cont": "shorter than the model time steps, or all model time steps",
-                     "desc_cont2": "should be directly divisible by it.",
+                     "description": "Interval at which all models are updated",
                      "type": "string",
-                     "default": "10 minutes"
+                     "default": "1 month"
                   },
                   "run_length": {
                      "description": "How long the simulation should be run for",

--- a/virtual_rainforest/core/utils.py
+++ b/virtual_rainforest/core/utils.py
@@ -15,12 +15,11 @@ from virtual_rainforest.core.exceptions import ConfigurationError, Initialisatio
 from virtual_rainforest.core.logger import LOGGER
 
 
-def extract_model_time_details(config: dict[str, Any], model_name: str) -> timedelta64:
+def extract_update_interval(config: dict[str, Any]) -> timedelta64:
     """Function to extract the timing details required to setup a specific model.
 
     Args:
         config: The configuration for the Virtual Rainforest simulation.
-        model_name: The name of the specific model of interest.
 
     Returns:
         The update interval for the overall model
@@ -30,7 +29,7 @@ def extract_model_time_details(config: dict[str, Any], model_name: str) -> timed
     """
 
     try:
-        raw_interval = pint.Quantity(config[model_name]["model_time_step"]).to(
+        raw_interval = pint.Quantity(config["core"]["timing"]["update_interval"]).to(
             "seconds"
         )
         # Round raw time interval to nearest second

--- a/virtual_rainforest/core/utils.py
+++ b/virtual_rainforest/core/utils.py
@@ -15,6 +15,7 @@ from virtual_rainforest.core.exceptions import ConfigurationError, Initialisatio
 from virtual_rainforest.core.logger import LOGGER
 
 
+# TODO - This should switch to extracting model time bounds
 def extract_model_time_details(
     config: dict[str, Any], model_name: str
 ) -> tuple[datetime64, timedelta64]:
@@ -35,7 +36,7 @@ def extract_model_time_details(
         raw_interval = pint.Quantity(config[model_name]["model_time_step"]).to(
             "seconds"
         )
-        # Round raw time interval to nearest minute
+        # Round raw time interval to nearest second
         update_interval = timedelta64(round(raw_interval.magnitude), "s")
 
         start_date = datetime64(config["core"]["timing"]["start_date"])

--- a/virtual_rainforest/core/utils.py
+++ b/virtual_rainforest/core/utils.py
@@ -9,16 +9,13 @@ from pathlib import Path
 from typing import Any
 
 import pint
-from numpy import datetime64, timedelta64
+from numpy import timedelta64
 
 from virtual_rainforest.core.exceptions import ConfigurationError, InitialisationError
 from virtual_rainforest.core.logger import LOGGER
 
 
-# TODO - This should switch to extracting model time bounds
-def extract_model_time_details(
-    config: dict[str, Any], model_name: str
-) -> tuple[datetime64, timedelta64]:
+def extract_model_time_details(config: dict[str, Any], model_name: str) -> timedelta64:
     """Function to extract the timing details required to setup a specific model.
 
     Args:
@@ -26,7 +23,7 @@ def extract_model_time_details(
         model_name: The name of the specific model of interest.
 
     Returns:
-        A tuple containing the start date and the update interval for the model
+        The update interval for the overall model
 
     Raises:
         InitialisationError: If the model timing cannot be properly extracted
@@ -38,13 +35,11 @@ def extract_model_time_details(
         )
         # Round raw time interval to nearest second
         update_interval = timedelta64(round(raw_interval.magnitude), "s")
-
-        start_date = datetime64(config["core"]["timing"]["start_date"])
     except (pint.errors.DimensionalityError, pint.errors.UndefinedUnitError) as excep:
         LOGGER.error("Model timing error: %s" % str(excep))
         raise InitialisationError() from excep
 
-    return start_date, update_interval
+    return update_interval
 
 
 def check_outfile(merge_file_path: Path) -> None:

--- a/virtual_rainforest/core/utils.py
+++ b/virtual_rainforest/core/utils.py
@@ -15,17 +15,26 @@ from virtual_rainforest.core.exceptions import ConfigurationError, Initialisatio
 from virtual_rainforest.core.logger import LOGGER
 
 
-def extract_update_interval(config: dict[str, Any]) -> timedelta64:
+def extract_update_interval(
+    config: dict[str, Any], lower_bound: str, upper_bound: str
+) -> timedelta64:
     """Function to extract the timing details required to setup a specific model.
+
+    This also checks that the update interval is extracted is compatible with the bounds
+    on the appropriate time scales for the model in question.
 
     Args:
         config: The configuration for the Virtual Rainforest simulation.
+        lower_bound: The lower bound on the appropriate model time scale
+        upper_bound: The upper bound on the appropriate model time scale
 
     Returns:
         The update interval for the overall model
 
     Raises:
         InitialisationError: If the model timing cannot be properly extracted
+        ConfigurationError: If the update interval does not fit with the model's time
+            bounds
     """
 
     try:
@@ -37,6 +46,20 @@ def extract_update_interval(config: dict[str, Any]) -> timedelta64:
     except (pint.errors.DimensionalityError, pint.errors.UndefinedUnitError) as excep:
         LOGGER.error("Model timing error: %s" % str(excep))
         raise InitialisationError() from excep
+
+    # Check if either bound is violated
+    if raw_interval < pint.Quantity(lower_bound):
+        to_raise = ConfigurationError(
+            "The update interval is shorter than the model's lower bound"
+        )
+        LOGGER.error(to_raise)
+        raise to_raise
+    elif raw_interval > pint.Quantity(upper_bound):
+        to_raise = ConfigurationError(
+            "The update interval is longer than the model's upper bound"
+        )
+        LOGGER.error(to_raise)
+        raise to_raise
 
     return update_interval
 

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -130,7 +130,7 @@ def extract_timing_details(
 
     # Catch bad time dimensions
     try:
-        # TODO - Document what this unit transformation does (i.e. month = 30.4375 days)
+        # This averages across months and years (i.e. 1 month => 30.4375 days)
         raw_interval = pint.Quantity(config["core"]["timing"]["update_interval"]).to(
             "seconds"
         )

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -167,27 +167,6 @@ def extract_timing_details(
     return start_time, update_interval, end_time
 
 
-def check_for_fast_models(
-    models_cfd: dict[str, BaseModel], update_interval: timedelta64
-) -> None:
-    """Warn user of any models using a faster time step than update interval.
-
-    Args:
-        models_cfd: Set of initialised models
-        update_interval: Time step of the main model loop
-    """
-    fast_models = [
-        model.model_name
-        for model in models_cfd.values()
-        if model.update_interval < update_interval
-    ]
-    if fast_models:
-        LOGGER.warning(
-            "The following models have shorter time steps than the main model: %s"
-            % fast_models
-        )
-
-
 def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
     """Perform a virtual rainforest simulation.
 
@@ -221,9 +200,7 @@ def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
     # Extract all the relevant timing details
     current_time, update_interval, end_time = extract_timing_details(config)
 
-    # Identify models with shorter time steps than main loop and warn user about them
-    # TODO - THIS SHOULD BECOME A STEP CHECKING MODEL BOUNDS
-    check_for_fast_models(models_cfd, update_interval)
+    # TODO - Add step checking model bounds match with time step
 
     # TODO - A model spin up might be needed here in future
 

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -130,6 +130,7 @@ def extract_timing_details(
 
     # Catch bad time dimensions
     try:
+        # TODO - Document what this unit transformation does (i.e. month = 30.4375 days)
         raw_interval = pint.Quantity(config["core"]["timing"]["update_interval"]).to(
             "minutes"
         )
@@ -140,7 +141,6 @@ def extract_timing_details(
         )
         LOGGER.critical(to_raise)
         raise to_raise
-
     else:
         # Round raw time interval to nearest minute
         update_interval = timedelta64(int(round(raw_interval.magnitude)), "m")
@@ -222,6 +222,7 @@ def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
     current_time, update_interval, end_time = extract_timing_details(config)
 
     # Identify models with shorter time steps than main loop and warn user about them
+    # TODO - THIS SHOULD BECOME A STEP CHECKING MODEL BOUNDS
     check_for_fast_models(models_cfd, update_interval)
 
     # TODO - A model spin up might be needed here in future

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -3,6 +3,8 @@ simulation of the model, along with helper functions to validate and configure t
 model.
 """  # noqa: D205, D415
 
+# TODO - Update documentation of main simulation flow to reflect changes
+
 from math import ceil
 from pathlib import Path
 from typing import Any, Type, Union
@@ -167,6 +169,28 @@ def extract_timing_details(
     return start_time, update_interval, end_time
 
 
+# TODO - Add tests for this function
+def check_time_bounds_appropriateness(
+    models_cfd: dict[str, BaseModel], update_interval: timedelta64
+) -> None:
+    """Check that update interval is within the time bounds of all configured models.
+
+    Args:
+        models_cfd: Set of models configured for a simulation run
+        update_interval: Time to wait between updates of the model state
+
+    Raises:
+        ConfigurationError: If the update interval is higher than one or more upper
+            bounds and/or lower than one or more lower bounds
+    """
+
+    # TODO - Implement the below
+    # CHECK IS HIGHER THAN ALL LOWER BOUNDS
+    # AND LOWER THAN ALL UPPER BOUNDS
+    # IF NOT REPORT EVERYTHING AND ERROR
+
+
+# TODO - Work out if any more tested is needed for this main flow
 def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
     """Perform a virtual rainforest simulation.
 
@@ -200,7 +224,8 @@ def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
     # Extract all the relevant timing details
     current_time, update_interval, end_time = extract_timing_details(config)
 
-    # TODO - Add step checking model bounds match with time step
+    # Check that update interval is appropriate for configured models
+    check_time_bounds_appropriateness(models_cfd, update_interval)
 
     # TODO - A model spin up might be needed here in future
 

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -3,8 +3,6 @@ simulation of the model, along with helper functions to validate and configure t
 model.
 """  # noqa: D205, D415
 
-# TODO - Update documentation of main simulation flow to reflect changes
-
 from math import ceil
 from pathlib import Path
 from typing import Any, Type, Union
@@ -145,7 +143,7 @@ def extract_timing_details(
         raise to_raise
     else:
         # Round raw time interval to nearest second
-        update_interval = timedelta64(int(round(raw_interval.magnitude)), "s")
+        update_interval = timedelta64(round(raw_interval.magnitude), "s")
 
     if run_length < update_interval:
         to_raise = InitialisationError(
@@ -169,7 +167,6 @@ def extract_timing_details(
     return start_time, update_interval, end_time
 
 
-# TODO - Work out if any more tested is needed for this main flow
 def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
     """Perform a virtual rainforest simulation.
 

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -233,20 +233,13 @@ def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
             Path(config["core"]["data_output_options"]["out_path_initial"])
         )
 
-    # Get the list of date times of the next update.
-    update_due = {mod.model_name: mod.next_update for mod in models_cfd.values()}
-
     # Setup the timing loop
     while current_time < end_time:
         current_time += update_interval
 
-        # Get the names of models that have expired due dates
-        update_needed = [nm for nm, upd in update_due.items() if upd <= current_time]
-
-        # Run their update() method and update due dates for all expired models
-        for mod_nm in update_needed:
+        # Run update() method for every model
+        for mod_nm in models_cfd:
             models_cfd[mod_nm].update()
-            update_due[mod_nm] = models_cfd[mod_nm].next_update
 
     # Save the final model state
     if config["core"]["data_output_options"]["save_final_state"]:

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -116,7 +116,7 @@ def extract_timing_details(
 
     # Catch bad time dimensions
     try:
-        raw_length = pint.Quantity(config["core"]["timing"]["run_length"]).to("minutes")
+        raw_length = pint.Quantity(config["core"]["timing"]["run_length"]).to("seconds")
     except (pint.errors.DimensionalityError, pint.errors.UndefinedUnitError):
         to_raise = InitialisationError(
             "Units for core.timing.run_length are not valid time units: %s"
@@ -125,14 +125,14 @@ def extract_timing_details(
         LOGGER.critical(to_raise)
         raise to_raise
     else:
-        # Round raw time interval to nearest minute
-        run_length = timedelta64(int(round(raw_length.magnitude)), "m")
+        # Round raw time interval to nearest second
+        run_length = timedelta64(int(round(raw_length.magnitude)), "s")
 
     # Catch bad time dimensions
     try:
         # TODO - Document what this unit transformation does (i.e. month = 30.4375 days)
         raw_interval = pint.Quantity(config["core"]["timing"]["update_interval"]).to(
-            "minutes"
+            "seconds"
         )
     except (pint.errors.DimensionalityError, pint.errors.UndefinedUnitError):
         to_raise = InitialisationError(
@@ -142,8 +142,8 @@ def extract_timing_details(
         LOGGER.critical(to_raise)
         raise to_raise
     else:
-        # Round raw time interval to nearest minute
-        update_interval = timedelta64(int(round(raw_interval.magnitude)), "m")
+        # Round raw time interval to nearest second
+        update_interval = timedelta64(int(round(raw_interval.magnitude)), "s")
 
     if run_length < update_interval:
         to_raise = InitialisationError(

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -57,7 +57,6 @@ def select_models(model_list: list[str]) -> list[Type[BaseModel]]:
     return modules
 
 
-# TODO - Think I need extra testing here
 def configure_models(
     config: dict[str, Any], data: Data, model_list: list[Type[BaseModel]]
 ) -> dict[str, BaseModel]:

--- a/virtual_rainforest/models/abiotic/abiotic_model.py
+++ b/virtual_rainforest/models/abiotic/abiotic_model.py
@@ -34,10 +34,9 @@ class AbioticModel(BaseModel):
 
     model_name = "abiotic"
     """An internal name used to register the model and schema"""
-    # TODO - Check with Vivienne that these are sensible bounds
-    lower_bound_on_time_scale = "1 day"
+    lower_bound_on_time_scale = "30 minutes"
     """Shortest time scale that soil model can sensibly capture."""
-    upper_bound_on_time_scale = "3 months"
+    upper_bound_on_time_scale = "1 day"
     """Longest time scale that soil model can sensibly capture."""
     required_init_vars = ()
     """Required initialisation variables for the abiotic model.

--- a/virtual_rainforest/models/abiotic/abiotic_model.py
+++ b/virtual_rainforest/models/abiotic/abiotic_model.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from numpy import datetime64, timedelta64
+from numpy import timedelta64
 
 from virtual_rainforest.core.base_model import BaseModel
 from virtual_rainforest.core.data import Data
@@ -45,7 +45,6 @@ class AbioticModel(BaseModel):
         self,
         data: Data,
         update_interval: timedelta64,
-        start_time: datetime64,
         soil_layers: int,
         canopy_layers: int,
         **kwargs: Any,
@@ -78,7 +77,7 @@ class AbioticModel(BaseModel):
             LOGGER.error(to_raise)
             raise to_raise
 
-        super().__init__(data, update_interval, start_time, **kwargs)
+        super().__init__(data, update_interval, **kwargs)
         self.soil_layers = int(soil_layers)
         """The number of soil layers to be modelled."""
         self.canopy_layers = int(canopy_layers)
@@ -92,8 +91,6 @@ class AbioticModel(BaseModel):
         """A Data instance providing access to the shared simulation data."""
         self.update_interval
         """The time interval between model updates."""
-        self.next_update
-        """The simulation time at which the model should next run the update method"""
 
     @classmethod
     def from_config(cls, data: Data, config: dict[str, Any]) -> AbioticModel:
@@ -109,7 +106,7 @@ class AbioticModel(BaseModel):
         """
 
         # Find timing details
-        start_time, update_interval = extract_model_time_details(config, cls.model_name)
+        update_interval = extract_model_time_details(config, cls.model_name)
 
         soil_layers = config["abiotic"]["soil_layers"]
         canopy_layers = config["abiotic"]["canopy_layers"]
@@ -118,7 +115,7 @@ class AbioticModel(BaseModel):
             "Information required to initialise the abiotic model successfully "
             "extracted."
         )
-        return cls(data, update_interval, start_time, soil_layers, canopy_layers)
+        return cls(data, update_interval, soil_layers, canopy_layers)
 
     def setup(self) -> None:
         """Function to set up the abiotic model."""
@@ -128,9 +125,6 @@ class AbioticModel(BaseModel):
 
     def update(self) -> None:
         """Placeholder function to update the abiotic model."""
-
-        # Finally increment timing
-        self.next_update += self.update_interval
 
     def cleanup(self) -> None:
         """Placeholder function for abiotic model cleanup."""

--- a/virtual_rainforest/models/abiotic/abiotic_model.py
+++ b/virtual_rainforest/models/abiotic/abiotic_model.py
@@ -13,7 +13,7 @@ from virtual_rainforest.core.base_model import BaseModel
 from virtual_rainforest.core.data import Data
 from virtual_rainforest.core.exceptions import InitialisationError
 from virtual_rainforest.core.logger import LOGGER
-from virtual_rainforest.core.utils import extract_model_time_details
+from virtual_rainforest.core.utils import extract_update_interval
 
 
 class AbioticModel(BaseModel):
@@ -106,7 +106,7 @@ class AbioticModel(BaseModel):
         """
 
         # Find timing details
-        update_interval = extract_model_time_details(config, cls.model_name)
+        update_interval = extract_update_interval(config)
 
         soil_layers = config["abiotic"]["soil_layers"]
         canopy_layers = config["abiotic"]["canopy_layers"]

--- a/virtual_rainforest/models/abiotic/abiotic_model.py
+++ b/virtual_rainforest/models/abiotic/abiotic_model.py
@@ -110,7 +110,9 @@ class AbioticModel(BaseModel):
         """
 
         # Find timing details
-        update_interval = extract_update_interval(config)
+        update_interval = extract_update_interval(
+            config, cls.lower_bound_on_time_scale, cls.upper_bound_on_time_scale
+        )
 
         soil_layers = config["abiotic"]["soil_layers"]
         canopy_layers = config["abiotic"]["canopy_layers"]

--- a/virtual_rainforest/models/abiotic/abiotic_model.py
+++ b/virtual_rainforest/models/abiotic/abiotic_model.py
@@ -34,6 +34,11 @@ class AbioticModel(BaseModel):
 
     model_name = "abiotic"
     """An internal name used to register the model and schema"""
+    # TODO - Check with Vivienne that these are sensible bounds
+    lower_bound_on_time_scale = "1 day"
+    """Shortest time scale that soil model can sensibly capture."""
+    upper_bound_on_time_scale = "3 months"
+    """Longest time scale that soil model can sensibly capture."""
     required_init_vars = ()
     """Required initialisation variables for the abiotic model.
 

--- a/virtual_rainforest/models/abiotic/abiotic_schema.json
+++ b/virtual_rainforest/models/abiotic/abiotic_schema.json
@@ -16,20 +16,12 @@
                "type": "integer",
                "exclusiveMinimum": 0,
                "default": 3
-            },
-            "model_time_step": {
-               "description": "Time step for abiotic module, units must be provided!",
-               "desc_cont": "The time grain of the model is 10 minutes, so your choice",
-               "desc_cont2": "here should be divisible by 10 minutes.",
-               "type": "string",
-               "default": "7 days"
             }
          },
          "default": {},
          "required": [
             "soil_layers",
-            "canopy_layers",
-            "model_time_step"
+            "canopy_layers"
          ]
       }
    },

--- a/virtual_rainforest/models/animals/animal_model.py
+++ b/virtual_rainforest/models/animals/animal_model.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from numpy import datetime64, timedelta64
+from numpy import timedelta64
 
 from virtual_rainforest.core.base_model import BaseModel
 from virtual_rainforest.core.data import Data
@@ -51,10 +51,9 @@ class AnimalModel(BaseModel):
         self,
         data: Data,
         update_interval: timedelta64,
-        start_time: datetime64,
         **kwargs: Any,
     ):
-        super().__init__(data, update_interval, start_time, **kwargs)
+        super().__init__(data, update_interval, **kwargs)
 
     @classmethod
     def from_config(cls, data: Data, config: dict[str, Any]) -> AnimalModel:
@@ -70,13 +69,13 @@ class AnimalModel(BaseModel):
         """
 
         # Find timing details
-        start_time, update_interval = extract_model_time_details(config, cls.model_name)
+        update_interval = extract_model_time_details(config, cls.model_name)
 
         LOGGER.info(
             "Information required to initialise the animal model successfully "
             "extracted."
         )
-        return cls(data, update_interval, start_time)
+        return cls(data, update_interval)
 
     def setup(self) -> None:
         """Function to set up the animal model."""
@@ -86,9 +85,6 @@ class AnimalModel(BaseModel):
 
     def update(self) -> None:
         """Placeholder function to solve the animal model."""
-
-        # Finally increment timing
-        self.next_update += self.update_interval
 
     def cleanup(self) -> None:
         """Placeholder function for animal model cleanup."""

--- a/virtual_rainforest/models/animals/animal_model.py
+++ b/virtual_rainforest/models/animals/animal_model.py
@@ -44,6 +44,11 @@ class AnimalModel(BaseModel):
 
     model_name = "animal"
     """The model name for use in registering the model and logging."""
+    # TODO - Check with Taran that these are sensible bounds
+    lower_bound_on_time_scale = "1 day"
+    """Shortest time scale that soil model can sensibly capture."""
+    upper_bound_on_time_scale = "1 month"
+    """Longest time scale that soil model can sensibly capture."""
     required_init_vars = ()
     """Required initialisation variables for the animal model."""
 

--- a/virtual_rainforest/models/animals/animal_model.py
+++ b/virtual_rainforest/models/animals/animal_model.py
@@ -74,7 +74,9 @@ class AnimalModel(BaseModel):
         """
 
         # Find timing details
-        update_interval = extract_update_interval(config)
+        update_interval = extract_update_interval(
+            config, cls.lower_bound_on_time_scale, cls.upper_bound_on_time_scale
+        )
 
         LOGGER.info(
             "Information required to initialise the animal model successfully "

--- a/virtual_rainforest/models/animals/animal_model.py
+++ b/virtual_rainforest/models/animals/animal_model.py
@@ -26,7 +26,7 @@ from numpy import timedelta64
 from virtual_rainforest.core.base_model import BaseModel
 from virtual_rainforest.core.data import Data
 from virtual_rainforest.core.logger import LOGGER
-from virtual_rainforest.core.utils import extract_model_time_details
+from virtual_rainforest.core.utils import extract_update_interval
 
 
 class AnimalModel(BaseModel):
@@ -69,7 +69,7 @@ class AnimalModel(BaseModel):
         """
 
         # Find timing details
-        update_interval = extract_model_time_details(config, cls.model_name)
+        update_interval = extract_update_interval(config)
 
         LOGGER.info(
             "Information required to initialise the animal model successfully "

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -73,10 +73,9 @@ class SoilModel(BaseModel):
         self,
         data: Data,
         update_interval: np.timedelta64,
-        start_time: np.datetime64,
         **kwargs: Any,
     ):
-        super().__init__(data, update_interval, start_time, **kwargs)
+        super().__init__(data, update_interval, **kwargs)
 
         # Check that soil pool data is appropriately bounded
         if np.any(data["soil_c_pool_maom"] < 0.0) or np.any(
@@ -92,8 +91,6 @@ class SoilModel(BaseModel):
         """A Data instance providing access to the shared simulation data."""
         self.update_interval
         """The time interval between model updates."""
-        self.next_update
-        """The simulation time at which the model should next run the update method"""
 
     @classmethod
     def from_config(cls, data: Data, config: dict[str, Any]) -> SoilModel:
@@ -108,14 +105,14 @@ class SoilModel(BaseModel):
             config: The complete (and validated) Virtual Rainforest configuration.
         """
 
-        # Find timing details
-        start_time, update_interval = extract_model_time_details(config, cls.model_name)
+        # Find update interval
+        update_interval = extract_model_time_details(config, cls.model_name)
 
         LOGGER.info(
             "Information required to initialise the soil model successfully "
             "extracted."
         )
-        return cls(data, update_interval, start_time)
+        return cls(data, update_interval)
 
     def setup(self) -> None:
         """Placeholder function to setup up the soil model."""
@@ -132,9 +129,6 @@ class SoilModel(BaseModel):
         # Update carbon pools (attributes and data object)
         # n.b. this also updates the data object automatically
         self.replace_soil_pools(updated_carbon_pools)
-
-        # Finally increment timing
-        self.next_update += self.update_interval
 
     def cleanup(self) -> None:
         """Placeholder function for soil model cleanup."""

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -29,7 +29,7 @@ from virtual_rainforest.core.base_model import BaseModel
 from virtual_rainforest.core.data import Data
 from virtual_rainforest.core.exceptions import InitialisationError
 from virtual_rainforest.core.logger import LOGGER
-from virtual_rainforest.core.utils import extract_model_time_details
+from virtual_rainforest.core.utils import extract_update_interval
 from virtual_rainforest.models.soil.carbon import calculate_soil_carbon_updates
 
 
@@ -106,7 +106,7 @@ class SoilModel(BaseModel):
         """
 
         # Find update interval
-        update_interval = extract_model_time_details(config, cls.model_name)
+        update_interval = extract_update_interval(config)
 
         LOGGER.info(
             "Information required to initialise the soil model successfully "

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -54,6 +54,10 @@ class SoilModel(BaseModel):
 
     model_name = "soil"
     """An internal name used to register the model and schema"""
+    lower_bound_on_time_scale = "30 minutes"
+    """Shortest time scale that soil model can sensibly capture."""
+    upper_bound_on_time_scale = "3 months"
+    """Longest time scale that soil model can sensibly capture."""
     required_init_vars = (
         ("soil_c_pool_maom", ("spatial",)),
         ("soil_c_pool_lmwc", ("spatial",)),

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -110,7 +110,9 @@ class SoilModel(BaseModel):
         """
 
         # Find update interval
-        update_interval = extract_update_interval(config)
+        update_interval = extract_update_interval(
+            config, cls.lower_bound_on_time_scale, cls.upper_bound_on_time_scale
+        )
 
         LOGGER.info(
             "Information required to initialise the soil model successfully "

--- a/virtual_rainforest/models/soil/soil_schema.json
+++ b/virtual_rainforest/models/soil/soil_schema.json
@@ -4,19 +4,7 @@
       "soil": {
          "description": "Configuration settings for the soil module",
          "type": "object",
-         "properties": {
-            "model_time_step": {
-               "description": "Time step for soil module, units must be provided!",
-               "desc_cont": "The time grain of the model is 10 minutes, so your choice",
-               "desc_cont2": "here should be divisible by 10 minutes.",
-               "type": "string",
-               "default": "7 days"
-            }
-         },
-         "default": {},
-         "required": [
-            "model_time_step"
-         ]
+         "default": {}
       }
    },
    "required": [


### PR DESCRIPTION
# Description

This pull request removes all model specific time steps in favour of a common time step at which all models are updated.

In addition to this, it adds time bound attributes to `BaseModel`. These are required properties for all inheriting classes, and set the longest and shortest update frequency that the model makes sense to be run at. For example, it does not make sense to update a plant model which ignores sub-daily processes every hour. The intention here is to prevent the user from selecting a set of models with incompatible time scales.

@TaranRallings, I made my best guess on sensible bounds on the `AnimalModel`. Could you let me know what they should actually be, cheers.

Fixes #203, #204 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
