### PR TITLE
Update config module to use a class

### DIFF
--- a/tests/core/data/all_config_bad.toml
+++ b/tests/core/data/all_config_bad.toml
@@ -1,0 +1,31 @@
+[core]
+modules = [plants, soil]
+
+[core.grid]
+nx = 10
+ny = 10
+
+[core.timing]
+start_date = "2020-01-01"
+update_interval = "10 minutes"
+run_length = "50 years"
+
+[core.data_output_options]
+save_initial_state = true
+save_final_state = true
+out_path_initial = "./model_at_start.nc"
+out_path_final = "./model_at_end.nc"
+
+[plants]
+a_plant_integer = 12
+
+[[plants.ftypes]]
+pft_name = "shrub"
+maxh = 1.0
+
+[[plants.ftypes]]
+pft_name = "broadleaf"
+maxh = 50.0
+
+[soil]
+model_time_step = "5 days"

--- a/tests/core/data/bad_json_in_schema.json
+++ b/tests/core/data/bad_json_in_schema.json
@@ -1,0 +1,2 @@
+{this: is not valid JSON
+}

--- a/tests/core/data/bad_schema_in_schema.json
+++ b/tests/core/data/bad_schema_in_schema.json
@@ -1,0 +1,8 @@
+{
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Hello World!",
+    "type": "abject",
+    "praperties": {},
+    "description": "My first JSON Schema."
+}

--- a/tests/core/data/no_properties_in_schema.json
+++ b/tests/core/data/no_properties_in_schema.json
@@ -1,0 +1,13 @@
+{
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Hello World!",
+    "type": "object",
+    "properties": {
+        "module_name_missing": {}
+    },
+    "required": [
+        "module_name_missing"
+    ],
+    "description": "My first JSON Schema."
+}

--- a/tests/core/data/no_required_in_schema.json
+++ b/tests/core/data/no_required_in_schema.json
@@ -4,10 +4,7 @@
     "title": "Hello World!",
     "type": "object",
     "properties": {
-        "module_name_missing": {}
+        "failure_5": {}
     },
-    "required": [
-        "module_name_missing"
-    ],
     "description": "My first JSON Schema."
 }

--- a/tests/core/data/no_required_in_schema.json
+++ b/tests/core/data/no_required_in_schema.json
@@ -1,0 +1,13 @@
+{
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Hello World!",
+    "type": "object",
+    "properties": {
+        "module_name_missing": {}
+    },
+    "required": [
+        "module_name_missing"
+    ],
+    "description": "My first JSON Schema."
+}

--- a/tests/core/data/test.toml
+++ b/tests/core/data/test.toml
@@ -1,3 +1,5 @@
+[core]
+modules = []
 [[core.data.variable]]
 file = "cellid_coords.nc"
 var_name = "temp"

--- a/tests/core/data/test_dupes.toml
+++ b/tests/core/data/test_dupes.toml
@@ -1,3 +1,5 @@
+[core]
+modules = []
 [[core.data.variable]]
 file = "cellid_coords.nc"
 var_name = "temp"

--- a/tests/core/data/valid_schema.json
+++ b/tests/core/data/valid_schema.json
@@ -1,0 +1,13 @@
+{
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Hello World!",
+    "type": "object",
+    "properties": {
+        "test_module": {}
+    },
+    "required": [
+        "test_module"
+    ],
+    "description": "My first JSON Schema."
+}

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -415,22 +415,22 @@ def test_Config_build_config(
             ),
             id="minimum_value_violation",
         ),
-        # pytest.param(
-        #     {
-        #         "core": {"grid": {"nx": 10, "ny": 10}, "modules": ["soil"]},
-        #         "soil": {"no_layers": 123},
-        #     },
-        #     pytest.raises(ConfigurationError),
-        #     (
-        #         (
-        #             ERROR,
-        #             "Configuration error in ['soil']: Additional properties "
-        #             "are not allowed ('no_layers' was unexpected)",
-        #         ),
-        #         (CRITICAL, "Configuration contains schema violations: check log"),
-        #     ),
-        #     id="unexpected_property",
-        # ),
+        pytest.param(
+            {
+                "core": {"grid": {"nx": 10, "ny": 10}, "modules": ["soil"]},
+                "soil": {"no_layers": 123},
+            },
+            pytest.raises(ConfigurationError),
+            (
+                (
+                    ERROR,
+                    "Configuration error in ['soil']: Additional properties "
+                    "are not allowed ('no_layers' was unexpected)",
+                ),
+                (CRITICAL, "Configuration contains schema violations: check log"),
+            ),
+            id="unexpected_property",
+        ),
     ],
 )
 def test_Config_validate_config(

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -415,22 +415,22 @@ def test_Config_build_config(
             ),
             id="minimum_value_violation",
         ),
-        pytest.param(
-            {
-                "core": {"grid": {"nx": 10, "ny": 10}, "modules": ["soil"]},
-                "soil": {"no_layers": 123},
-            },
-            pytest.raises(ConfigurationError),
-            (
-                (
-                    ERROR,
-                    "Configuration error in ['soil']: Additional properties "
-                    "are not allowed ('no_layers' was unexpected)",
-                ),
-                (CRITICAL, "Configuration contains schema violations: check log"),
-            ),
-            id="unexpected_property",
-        ),
+        # pytest.param(
+        #     {
+        #         "core": {"grid": {"nx": 10, "ny": 10}, "modules": ["soil"]},
+        #         "soil": {"no_layers": 123},
+        #     },
+        #     pytest.raises(ConfigurationError),
+        #     (
+        #         (
+        #             ERROR,
+        #             "Configuration error in ['soil']: Additional properties "
+        #             "are not allowed ('no_layers' was unexpected)",
+        #         ),
+        #         (CRITICAL, "Configuration contains schema violations: check log"),
+        #     ),
+        #     id="unexpected_property",
+        # ),
     ],
 )
 def test_Config_validate_config(
@@ -446,7 +446,7 @@ def test_Config_validate_config(
 
     # Run the validation
     with expected_exception:
-        cfg.validate_config2()
+        cfg.validate_config()
 
     log_check(caplog, expected_log_entries)
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -480,3 +480,36 @@ def test_Config_init_auto(caplog, shared_datadir, file_path, expected_log_entrie
 
     Config(shared_datadir / file_path, auto=True)
     log_check(caplog, expected_log_entries)
+
+
+@pytest.mark.parametrize(
+    "auto,expected_log_entries",
+    [
+        pytest.param(
+            True,
+            ((INFO, "Saving config to: "),),
+            id="can_export",
+        ),
+        pytest.param(
+            False,
+            ((ERROR, "Cannot export unvalidated or invalid configuration"),),
+            id="cannot_export",
+        ),
+    ],
+)
+def test_Config_export_config(caplog, shared_datadir, auto, expected_log_entries):
+    """Checks that auto validation passes as expected."""
+    from virtual_rainforest.core.config import Config
+
+    cfg = Config(shared_datadir / "all_config.toml", auto=auto)
+    caplog.clear()
+
+    outpath = shared_datadir / "test_output.toml"
+    cfg.export_config(outfile=outpath)
+
+    log_check(caplog, expected_log_entries)
+
+    # Check file is created - maybe add a file hash check?
+    if auto:
+        assert outpath.exists()
+        assert outpath.is_file()

--- a/tests/core/test_config_schema.py
+++ b/tests/core/test_config_schema.py
@@ -1,0 +1,176 @@
+"""Check the configuration schema loading and validation routines."""
+
+import json
+from contextlib import nullcontext as does_not_raise
+from logging import CRITICAL, ERROR
+
+import jsonschema
+import pytest
+from jsonschema.exceptions import SchemaError
+
+from tests.conftest import log_check
+
+
+@pytest.mark.parametrize(
+    "module_name, schema_file_path, expected_exception, expected_log_entries",
+    [
+        pytest.param(
+            "failure_1",
+            "missing_file.json",
+            pytest.raises(FileNotFoundError),
+            [(ERROR, "Schema file not found")],
+            id="missing_schema_file",
+        ),
+        pytest.param(
+            "failure_2",
+            "bad_json_in_schema.json",
+            pytest.raises(json.JSONDecodeError),
+            [(ERROR, "JSON error in schema file")],
+            id="bad_json_in_schema_file",
+        ),
+        pytest.param(
+            "failure_3",
+            "bad_schema_in_schema.json",
+            pytest.raises(SchemaError),
+            [(ERROR, "Module schema invalid in")],
+            id="bad_schema_in_schema_file",
+        ),
+        pytest.param(
+            "failure_4",
+            "no_properties_in_schema.json",
+            pytest.raises(ValueError),
+            [(ERROR, "Missing key in module schema")],
+            id="no_properties_in_schema_file",
+        ),
+        pytest.param(
+            "failure_5",
+            "no_required_in_schema.json",
+            pytest.raises(ValueError),
+            [(ERROR, "Missing key in module schema")],
+            id="no_required_in_schema_file",
+        ),
+        pytest.param(
+            "test_module",
+            "valid_schema.json",
+            does_not_raise(),
+            [],
+            id="success",
+        ),
+    ],
+)
+def test_load_schema(
+    shared_datadir,
+    caplog,
+    module_name,
+    schema_file_path,
+    expected_exception,
+    expected_log_entries,
+):
+    """Tests schema loading and validation."""
+    from virtual_rainforest.core.config import load_schema
+
+    caplog.clear()
+
+    with expected_exception:
+        sfp = shared_datadir / schema_file_path
+        _ = load_schema(module_name=module_name, schema_file_path=sfp)
+
+    log_check(caplog, expected_log_entries)
+
+
+@pytest.mark.parametrize(
+    "schema_name,schema,expected_exception,expected_log_entries",
+    [
+        (
+            "core",
+            "",
+            ValueError,
+            (
+                (
+                    CRITICAL,
+                    "The module schema for core is already registered",
+                ),
+            ),
+        ),
+        (
+            "test",
+            "najsnjasnda",
+            json.JSONDecodeError,
+            (
+                (ERROR, "JSON error in schema file"),
+                (CRITICAL, "Schema registration for test failed: check log"),
+            ),
+        ),
+        (
+            "bad_module_1",
+            '{"type": "hobbit", "properties": {"bad_module_1": {}}}',
+            jsonschema.SchemaError,
+            (
+                (ERROR, "Module schema invalid in: "),
+                (CRITICAL, "Schema registration for bad_module_1 failed: check log"),
+            ),
+        ),
+        (
+            "bad_module_2",
+            '{"type": "object", "properties": {"bad_module_1": {}}}',
+            ValueError,
+            (
+                (ERROR, "Missing key in module schema bad_module_2:"),
+                (CRITICAL, "Schema registration for bad_module_2 failed: check log"),
+            ),
+        ),
+        (
+            "bad_module_3",
+            '{"type": "object", "properties": {"bad_module_3": {}}}',
+            ValueError,
+            (
+                (ERROR, "Missing key in module schema bad_module_3"),
+                (CRITICAL, "Schema registration for bad_module_3 failed: check log"),
+            ),
+        ),
+    ],
+)
+def test_register_schema_errors(
+    caplog, mocker, schema_name, schema, expected_exception, expected_log_entries
+):
+    """Test that the schema registering decorator throws the correct errors."""
+
+    from virtual_rainforest.core.config import register_schema
+
+    data = mocker.mock_open(read_data=schema)
+    mocker.patch("builtins.open", data)
+
+    # Check that construct_combined_schema fails as expected
+    with pytest.raises(expected_exception):
+        register_schema(schema_name, "file_path")
+
+    # Then check that the correct (critical error) log messages are emitted
+    log_check(caplog, expected_log_entries)
+
+
+def test_merge_schemas():
+    """Test that module schemas are properly merged."""
+    from virtual_rainforest.core.config import SCHEMA_REGISTRY, merge_schemas
+
+    merged_schemas = merge_schemas(
+        {
+            "core": SCHEMA_REGISTRY["core"],
+            "abiotic": SCHEMA_REGISTRY["abiotic"],
+            "animal": SCHEMA_REGISTRY["animal"],
+            "plants": SCHEMA_REGISTRY["plants"],
+            "soil": SCHEMA_REGISTRY["soil"],
+        }
+    )
+
+    assert set(merged_schemas["required"]) == set(
+        ["abiotic", "animal", "plants", "soil", "core"]
+    )
+
+
+def test_extend_with_default():
+    """Test that validator has been properly extended to allow addition of defaults."""
+    from virtual_rainforest.core.config import ValidatorWithDefaults
+
+    # Check that function adds a function with the right name in the right location
+    TestValidator = ValidatorWithDefaults({"str": {}})
+    assert TestValidator.VALIDATORS["properties"].__name__ == "set_defaults"

--- a/tests/core/test_config_schema.py
+++ b/tests/core/test_config_schema.py
@@ -39,14 +39,14 @@ from tests.conftest import log_check
             "failure_4",
             "no_properties_in_schema.json",
             pytest.raises(ValueError),
-            [(ERROR, "Missing key in module schema")],
+            [(ERROR, "Missing key in module schema failure_4: 'failure_4'")],
             id="no_properties_in_schema_file",
         ),
         pytest.param(
             "failure_5",
             "no_required_in_schema.json",
             pytest.raises(ValueError),
-            [(ERROR, "Missing key in module schema")],
+            [(ERROR, "Missing key in module schema failure_5: 'required'")],
             id="no_required_in_schema_file",
         ),
         pytest.param(

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -576,18 +576,22 @@ def test_Data_load_from_config(
 
     TODO - Could mock load_to_dataarray to avoid needing real files and just test the
            config loader part of the mechanism
+    TODO - The test TOML files here are _very_ minimal and are going to be fragile to
+           required fields being updated. They explicitly load no modules to moderate
+           this risk.
     """
 
     # Setup a Data instance to match the example files generated in tests/core/data
 
-    from virtual_rainforest.core.config import load_in_config_files
+    from virtual_rainforest.core.config import Config
     from virtual_rainforest.core.data import Data
 
     # Skip combinations where loader does not supported this grid
     data = Data(fixture_load_data_grids)
     file = [shared_datadir / file]
 
-    cfg = load_in_config_files(file)
+    cfg = Config(file)
+    caplog.clear()
 
     # Edit the paths loaded to point to copies in shared_datadir
     for each_var in cfg["core"]["data"]["variable"]:

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -268,6 +268,7 @@ class Config(dict):
         # Run the validation steps
         if auto:
             self.resolve_config_paths()
+            self.load_config_toml()
             self.build_config()
             self.build_schema()
             self.validate_config()
@@ -348,6 +349,8 @@ class Config(dict):
             except tomllib.TOMLDecodeError as err:
                 self.failed_inputs[this_file] = str(err)
                 LOGGER.error(f"Config TOML parsing error in {this_file}: {str(err)}")
+            else:
+                LOGGER.info(f"Config TOML loaded from {this_file}")
 
         if self.failed_inputs:
             to_raise = ConfigurationError("Errors parsing config files: check log")
@@ -389,6 +392,7 @@ class Config(dict):
 
         # Merge everything into a single dictionary and update the object
         self.update(dict(ChainMap(*self.toml_contents.values())))
+        LOGGER.info("Config files merged")
 
     def build_schema(self) -> None:
         """Build a schema to validate the model configuration.

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -275,18 +275,18 @@ class Config(dict):
       used to resolve the provided paths into the set of actual TOML files to be used to
       build the configuration.
 
-    * The :meth:`~virtual_rainforest.core.config.Config.load_config_toml` method is
-      then used to load the contents of each resolved file.
+    * The :meth:`~virtual_rainforest.core.config.Config.load_config_toml` method is then
+      used to load the contents of each resolved file.
 
-    * The :meth:`~virtual_rainforest.core.config.Config.build_config` method is
-      used to merge the loaded configuration across files and check that configuration
-      settings are uniquely defined.
+    * The :meth:`~virtual_rainforest.core.config.Config.build_config` method is used to
+      merge the loaded configuration across files and check that configuration settings
+      are uniquely defined.
 
     * The :meth:`~virtual_rainforest.core.config.Config.validate_config` method
       validates the compiled configuration against the appropriate configuration schema
-      for the :mod:`~virtual_rainforest.core` module and any
-      :mode:`~virtual_rainforest.models` included in the configuration. This validation
-      will also fill in any missing configuration settings with defined defaults.
+      for the :mod:`~virtual_rainforest.core` module and any models included in the
+      configuration. This validation will also fill in any missing configuration
+      settings with defined defaults.
 
     By default, creating a ``Config`` instance automatically runs these steps across the
     provided ``cfg_paths``, but the ``auto`` argument can be used to turn off automatic

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -316,8 +316,8 @@ class Config(dict):
         """A list of TOML file paths resolved from the initial config paths."""
         self.toml_contents: dict[Path, dict] = {}
         """A dictionary of the contents of config files, keyed by file path."""
-        self.merge_conflicts: set = set()
-        """Paths of configuration keys duplicated across configuration files."""
+        self.merge_conflicts: list = []
+        """A list of configuration keys duplicated across configuration files."""
         self.config_errors: list[tuple[str, Any]] = []
         """Configuration errors, as a list of tuples of key path and error details."""
         self.validated: bool = False
@@ -452,7 +452,7 @@ class Config(dict):
 
         # Check if any tags are repeated across files
         if conflicts:
-            self.merge_conflicts = set(conflicts)
+            self.merge_conflicts = sorted(set(conflicts))
             to_raise = ConfigurationError(
                 f"Duplicated entries in config files: {', '.join(self.merge_conflicts)}"
             )

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -592,10 +592,18 @@ class Config(dict):
         self.validated = True
 
     def export_config(self, outfile: Path) -> None:
-        """Exports a validated and merged configuration as a single file."""
+        """Exports a validated and merged configuration as a single file.
+
+        This method will only export a configuration file if the
+        :class:`~virtual_rainforest.core.config.Config` instance has been successfully
+        validated.
+
+        Args:
+            outfile: An output path for the TOML configuration file.
+        """
 
         if not self.validated:
-            LOGGER.error("Configuration not validated or failed validation")
+            LOGGER.error("Cannot export unvalidated or invalid configuration")
             return
 
         # Output combined toml file

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -269,7 +269,7 @@ class Config(dict):
     def __init__(
         self, cfg_paths: Union[str, Path, list[str], list[Path]], auto: bool = True
     ) -> None:
-        # Standardise cfg_paths
+        # Standardise cfg_paths to list of Paths
         if isinstance(cfg_paths, (str, Path)):
             self.cfg_paths = [Path(cfg_paths)]
         else:
@@ -304,8 +304,8 @@ class Config(dict):
 
         Raises:
             ConfigurationError: this is raised if any of the paths: do not exist, are
-            directories that do not contain TOML files, are not TOML files or if the
-            resolved files contain duplicate entries.
+                directories that do not contain TOML files, are not TOML files or if the
+                resolved files contain duplicate entries.
         """
 
         all_valid = True
@@ -393,11 +393,13 @@ class Config(dict):
 
         if len(input_dicts) == 0:
             # No input dicts, Config dict is empty
+            LOGGER.warn("No config files set")
             return
 
         if len(input_dicts) == 1:
             # One input dict, which becomes the content of the Config dict
             self.update(**input_dicts[0])
+            LOGGER.info("Config set from single file")
             return
 
         # Otherwise, merge other dicts into first
@@ -412,14 +414,14 @@ class Config(dict):
         if conflicts:
             self.merge_conflicts = set(conflicts)
             to_raise = ConfigurationError(
-                f"Duplicated entries in config files: {','.join(self.merge_conflicts)}"
+                f"Duplicated entries in config files: {', '.join(self.merge_conflicts)}"
             )
             LOGGER.critical(to_raise)
             raise to_raise
 
         # Merge everything into a single dictionary and update the object
         self.update(master)
-        LOGGER.info("Config files merged")
+        LOGGER.info("Config set from merged files")
 
     def build_schema(self) -> None:
         """Build a schema to validate the model configuration.

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -214,15 +214,15 @@ def config_merge(
 ) -> tuple[dict, tuple]:
     """Recursively merge two dictionaries detecting duplicated key definitions.
 
-    This function returns a copy of the dest dictionary that has been extended
-    recursively with the entries from the source dictionary. No key path should be
-    repeated between the two dictionaries. When duplicated key paths are found, the
-    value from the source dictionary is used and the function extends the returned
-    ``conflicts`` tuple with the conflicting key path.
+    This function returns a copy of the input ``dest`` dictionary that has been extended
+    recursively with the entries from the input ``source`` dictionary. The two input
+    dictionaries must not share any key paths and when duplicated key paths are
+    found, the value from the source dictionary is used and the function extends the
+    returned ``conflicts`` tuple with the duplicated key path.
 
     Args:
         dest: A dictionary to extend
-        source: A dictionary of key value pairs to extend dest
+        source: A dictionary of key value pairs to extend ``dest``
         conflicts: A tuple of duplicated key paths between the two dictionaries
         path: A string giving the current key path.
 

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -459,7 +459,7 @@ class Config(dict):
             LOGGER.critical(to_raise)
             raise to_raise
 
-        # Merge everything into a single dictionary and update the object
+        # Update the object
         self.update(master)
         LOGGER.info("Config set from merged files")
 
@@ -471,6 +471,10 @@ class Config(dict):
         modules are then loaded and combined to generate a single validation schema for
         model configuration.
         """
+
+        # NOTE: This is probably to be redacted - the merged schema was used to apply
+        # validation to the whole config in one go and this is not needed as each
+        # applicable schema can be applied separately to the config dictionary.
 
         # Get the core schema and then use it to validate the 'core' element of the
         # configuration dictionary
@@ -501,6 +505,10 @@ class Config(dict):
 
     def validate_config_old(self) -> None:
         """Validates the loaded config."""
+
+        # NOTE: This is probably to be redacted - it uses the merged schema, and there
+        # is no real need to actual merge schemas - just apply each applicable schema
+        # separately to the config dictionary.
 
         # Check to see if the instance is in a validatable state
         if not self.merged_schema:

--- a/virtual_rainforest/core/core_schema.json
+++ b/virtual_rainforest/core/core_schema.json
@@ -67,7 +67,8 @@
                "default": [
                   "plants",
                   "soil"
-               ]
+               ],
+               "uniqueItems": true
             },
             "data": {
                "description": "Configuration settings for the core data module",

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -123,11 +123,11 @@ import numpy as np
 from xarray import DataArray, Dataset
 
 from virtual_rainforest.core.axes import AXIS_VALIDATORS, validate_dataarray
-from virtual_rainforest.core.config import check_outfile
 from virtual_rainforest.core.exceptions import ConfigurationError
 from virtual_rainforest.core.grid import Grid
 from virtual_rainforest.core.logger import LOGGER
 from virtual_rainforest.core.readers import load_to_dataarray
+from virtual_rainforest.core.utils import check_outfile
 
 
 class Data:

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -11,7 +11,7 @@ import pint
 from numpy import datetime64, timedelta64
 
 from virtual_rainforest.core.base_model import MODEL_REGISTRY, BaseModel
-from virtual_rainforest.core.config import validate_config
+from virtual_rainforest.core.config import Config
 from virtual_rainforest.core.data import Data
 from virtual_rainforest.core.exceptions import InitialisationError
 from virtual_rainforest.core.grid import Grid
@@ -202,7 +202,7 @@ def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
             name)
     """
 
-    config = validate_config(cfg_paths, merge_file_path)
+    config = Config(cfg_paths)
 
     grid = Grid()  # TODO - this needs a Grid.from_config factory function
     data = Data(grid)

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -188,7 +188,9 @@ def check_for_fast_models(
         )
 
 
-def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
+def vr_run(
+    cfg_paths: Union[str, Path, list[Union[str, Path]]], merge_file_path: Path
+) -> None:
     """Perform a virtual rainforest simulation.
 
     This is a high-level function that runs a virtual rainforest simulation. At the
@@ -203,6 +205,7 @@ def vr_run(cfg_paths: Union[str, list[str]], merge_file_path: Path) -> None:
     """
 
     config = Config(cfg_paths)
+    config.export_config(merge_file_path)
 
     grid = Grid()  # TODO - this needs a Grid.from_config factory function
     data = Data(grid)


### PR DESCRIPTION
# Description

This PR is an update of the `config` module. The previous code defined a suite of functions that were used as a chain to:

* resolve inputs file paths to individual files
* load TOML content from individual files
* combine content into a single config
* validate the config (and write a validated config file).

The chain of functions means that the config process is stateless - you only get the validated dictionary at the end. This PR introduces the `Config` class, which encapsulates the same steps into a class instance. This is a `dict` subclass, so `Config` instances behave in exactly the same way as the previous dictionary outputs from `validate_config`, but the instance also retains information about config sources and validation. It adds an `export_config` method to separate that functionality from validation.

Mostly this is just rearranging the existing function code into methods, but there are two things that need a closer look:

1. There is a bug fix 🐛 . The previous version used `dict(ChainMap(...)` to merge config contents across files. This works if the inputs all have different first level keys but does not recursively resolve contents:

    ```python
    In [27]: from collections import ChainMap
    
    In [28]: dict(ChainMap({'core': 'stuff'}, {'plant': 'stuff'}))
    Out[28]: {'plant': 'stuff', 'core': 'stuff'}
    
    In [29]: dict(ChainMap({'core': {'grid': 'stuff'}}, {'core': {'data': 'stuff'}}, {'plant': 'stuff'}))
    Out[29]: {'plant': 'stuff', 'core': {'grid': 'stuff'}}
    ```
    The existing implementation already included the `check_dict_leaves` function, which was a recursive search for duplicated dictionary paths across those inputs. This PR extends that as the `config_merge` function which piggybacks exactly the same recursion to resolve the recursive dictionary content at the same time as detection duplicates.

2. ~~The previous implementation explicitly built a merged schema for all of the models in a configuration that was then applied to the entire merged config. This doesn't seem necessary - the appropriate individual schemas can be applied to the merged config dictionary to validate each section in turn. I'm not quite so sure about this one - I've deliberately some functions that may be un-needed in place for the moment to make it easier to compare what is being dropped.~~ 
    This has now been reverted to using the merged schema approach.

Fixes #207

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
