### PR TITLE
Fixs for `pint` problem in docs build action

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,7 +115,10 @@ intersphinx_mapping = {
     "xarray": ("https://docs.xarray.dev/en/stable/", None),
     "shapely": ("https://shapely.readthedocs.io/en/stable/", None),
     "jsonschema": ("https://python-jsonschema.readthedocs.io/en/stable/", None),
-    "pint": ("https://pint.readthedocs.io/en/stable/", None),
+    # TODO - This is pinned to a particular pint version as the package is making
+    # changes to how it handles typing, at some point it should be unpinned, i.e. set to
+    # stable
+    "pint": ("https://pint.readthedocs.io/en/0.21/", None),
 }
 
 


### PR DESCRIPTION
# Description

It seems like `pint` have changed how they do typing, which caused documentation build failures. I have set `intersphinx` to read from an earlier version of the `pint` documentation to avoid this problem.

This will have to change in future if we update `pint`, but at the moment it seems like they are still trying to pin down their typing, so doesn't seem sensible to refactor the code at the moment.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
