### PR TITLE
Use abiotic soil layers correctly in soil model

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def data_instance():
 
 
 @pytest.fixture
-def dummy_carbon_data():
+def dummy_carbon_data(layer_roles_fixture):
     """Creates a dummy carbon data object for use in tests."""
 
     from virtual_rainforest.core.data import Data
@@ -113,10 +113,10 @@ def dummy_carbon_data():
     grid = Grid(cell_nx=4, cell_ny=1)
     data = Data(grid)
 
-    # The required data is now added. This includes the two carbon pools: mineral
-    # associated organic matter and low molecular weight carbon. It also includes
-    # various factors of the physical environment: pH, bulk density, soil moisture, soil
-    # temperature, percentage clay in soil.
+    # The required data is now added. This includes the three carbon pools: mineral
+    # associated organic matter, low molecular weight carbon, and microbial carbon. It
+    # also includes various factors of the physical environment: pH, bulk density, soil
+    # moisture, soil temperature, percentage clay in soil.
     data["soil_c_pool_lmwc"] = DataArray([0.05, 0.02, 0.1, 0.005], dims=["cell_id"])
     """Low molecular weight carbon pool (kg C m^-3)"""
     data["soil_c_pool_maom"] = DataArray([2.5, 1.7, 4.5, 0.5], dims=["cell_id"])
@@ -125,9 +125,29 @@ def dummy_carbon_data():
     """Microbial biomass (carbon) pool (kg C m^-3)"""
     data["pH"] = DataArray([3.0, 7.5, 9.0, 5.7], dims=["cell_id"])
     data["bulk_density"] = DataArray([1350.0, 1800.0, 1000.0, 1500.0], dims=["cell_id"])
-    data["soil_moisture"] = DataArray([0.5, 0.7, 0.6, 0.2], dims=["cell_id"])
-    data["soil_temperature"] = DataArray([35.0, 37.5, 40.0, 25.0], dims=["cell_id"])
     data["percent_clay"] = DataArray([80.0, 30.0, 10.0, 90.0], dims=["cell_id"])
+
+    # The layer dependant data has to be handled separately
+    data["soil_moisture"] = xr.concat(
+        [
+            DataArray(np.full((13, 4), np.nan), dims=["layers", "cell_id"]),
+            # At present the soil model only uses the top soil layer, so this is the
+            # only one with real test values in
+            DataArray([0.5, 0.7, 0.6, 0.2], dims=["cell_id"]),
+            DataArray(np.full((1, 4), 0.1), dims=["layers", "cell_id"]),
+        ],
+        dim="layers",
+    )
+    data["soil_temperature"] = xr.concat(
+        [
+            DataArray(np.full((13, 4), np.nan), dims=["layers", "cell_id"]),
+            # At present the soil model only uses the top soil layer, so this is the
+            # only one with real test values in
+            DataArray([35.0, 37.5, 40.0, 25.0], dims=["cell_id"]),
+            DataArray(np.full((1, 4), 22.5), dims=["layers", "cell_id"]),
+        ],
+        dim="layers",
+    )
 
     return data
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,13 +140,24 @@ def dummy_carbon_data(layer_roles_fixture):
     )
     data["soil_temperature"] = xr.concat(
         [
-            DataArray(np.full((13, 4), np.nan), dims=["layers", "cell_id"]),
+            DataArray(np.full((13, 4), np.nan), dims=["dim_0", "cell_id"]),
             # At present the soil model only uses the top soil layer, so this is the
             # only one with real test values in
             DataArray([35.0, 37.5, 40.0, 25.0], dims=["cell_id"]),
-            DataArray(np.full((1, 4), 22.5), dims=["layers", "cell_id"]),
+            DataArray(np.full((1, 4), 22.5), dims=["dim_0", "cell_id"]),
         ],
-        dim="layers",
+        dim="dim_0",
+    )
+    data["soil_temperature"] = (
+        data["soil_temperature"]
+        .rename({"dim_0": "layers"})
+        .assign_coords(
+            {
+                "layers": np.arange(0, 15),
+                "layer_roles": ("layers", layer_roles_fixture),
+                "cell_id": data.grid.cell_id,
+            }
+        )
     )
 
     return data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,6 +138,13 @@ def dummy_carbon_data(layer_roles_fixture):
         ],
         dim="layers",
     )
+    data["soil_moisture"] = data["soil_moisture"].assign_coords(
+        {
+            "layers": np.arange(0, 15),
+            "layer_roles": ("layers", layer_roles_fixture),
+            "cell_id": data.grid.cell_id,
+        }
+    )
     data["soil_temperature"] = xr.concat(
         [
             DataArray(np.full((13, 4), np.nan), dims=["dim_0", "cell_id"]),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,7 @@ def dummy_carbon_data(layer_roles_fixture):
             DataArray(np.full((13, 4), np.nan), dims=["layers", "cell_id"]),
             # At present the soil model only uses the top soil layer, so this is the
             # only one with real test values in
-            DataArray([0.5, 0.7, 0.6, 0.2], dims=["cell_id"]),
+            DataArray([[0.5, 0.7, 0.6, 0.2]], dims=["layers", "cell_id"]),
             DataArray(np.full((1, 4), 0.1), dims=["layers", "cell_id"]),
         ],
         dim="layers",
@@ -143,7 +143,7 @@ def dummy_carbon_data(layer_roles_fixture):
             DataArray(np.full((13, 4), np.nan), dims=["dim_0", "cell_id"]),
             # At present the soil model only uses the top soil layer, so this is the
             # only one with real test values in
-            DataArray([35.0, 37.5, 40.0, 25.0], dims=["cell_id"]),
+            DataArray([[35.0, 37.5, 40.0, 25.0]], dims=["dim_0", "cell_id"]),
             DataArray(np.full((1, 4), 22.5), dims=["dim_0", "cell_id"]),
         ],
         dim="dim_0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,6 +152,14 @@ def dummy_carbon_data(layer_roles_fixture):
     return data
 
 
+# TODO - At the moment this returns a constant but this should be calculated from the
+# data object in future
+@pytest.fixture
+def top_soil_layer_index():
+    """The index of the top soil layer in the data object."""
+    return 13
+
+
 @pytest.fixture
 def new_axis_validators():
     """Create new axis validators to test methods and registration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,12 +152,10 @@ def dummy_carbon_data(layer_roles_fixture):
     return data
 
 
-# TODO - At the moment this returns a constant but this should be calculated from the
-# data object in future
 @pytest.fixture
-def top_soil_layer_index():
-    """The index of the top soil layer in the data object."""
-    return 13
+def top_soil_layer_index(layer_roles_fixture):
+    """The index of the top soil layer in the data fixtures."""
+    return next(i for i, v in enumerate(layer_roles_fixture) if v == "soil")
 
 
 @pytest.fixture

--- a/tests/models/soil/test_carbon.py
+++ b/tests/models/soil/test_carbon.py
@@ -30,6 +30,20 @@ def moist_temp_scalars(dummy_carbon_data, top_soil_layer_index):
     return moist_scalars * temp_scalars
 
 
+def test_top_soil_data_extraction(dummy_carbon_data, top_soil_layer_index):
+    """Test that top soil data can be extracted from the data object correctly."""
+
+    top_soil_temps = [35.0, 37.5, 40.0, 25.0]
+    top_soil_moistures = [0.5, 0.7, 0.6, 0.2]
+
+    assert np.allclose(
+        dummy_carbon_data["soil_temperature"][top_soil_layer_index], top_soil_temps
+    )
+    assert np.allclose(
+        dummy_carbon_data["soil_moisture"][top_soil_layer_index], top_soil_moistures
+    )
+
+
 def test_calculate_soil_carbon_updates(dummy_carbon_data, top_soil_layer_index):
     """Test that the two pool update functions work correctly."""
 

--- a/tests/models/soil/test_carbon.py
+++ b/tests/models/soil/test_carbon.py
@@ -13,20 +13,24 @@ from tests.conftest import log_check
 
 
 @pytest.fixture
-def moist_temp_scalars(dummy_carbon_data):
+def moist_temp_scalars(dummy_carbon_data, top_soil_layer_index):
     """Combined moisture and temperature scalars based on dummy carbon data."""
     from virtual_rainforest.models.soil.carbon import (
         convert_moisture_to_scalar,
         convert_temperature_to_scalar,
     )
 
-    moist_scalars = convert_moisture_to_scalar(dummy_carbon_data["soil_moisture"])
-    temp_scalars = convert_temperature_to_scalar(dummy_carbon_data["soil_temperature"])
+    moist_scalars = convert_moisture_to_scalar(
+        dummy_carbon_data["soil_moisture"][top_soil_layer_index]
+    )
+    temp_scalars = convert_temperature_to_scalar(
+        dummy_carbon_data["soil_temperature"][top_soil_layer_index]
+    )
 
     return moist_scalars * temp_scalars
 
 
-def test_calculate_soil_carbon_updates(dummy_carbon_data):
+def test_calculate_soil_carbon_updates(dummy_carbon_data, top_soil_layer_index):
     """Test that the two pool update functions work correctly."""
 
     from virtual_rainforest.models.soil.carbon import calculate_soil_carbon_updates
@@ -43,8 +47,8 @@ def test_calculate_soil_carbon_updates(dummy_carbon_data):
         dummy_carbon_data["soil_c_pool_microbe"].to_numpy(),
         dummy_carbon_data["pH"],
         dummy_carbon_data["bulk_density"],
-        dummy_carbon_data["soil_moisture"],
-        dummy_carbon_data["soil_temperature"],
+        dummy_carbon_data["soil_moisture"][top_soil_layer_index],
+        dummy_carbon_data["soil_temperature"][top_soil_layer_index],
         dummy_carbon_data["percent_clay"],
         {"soil_c_pool_lmwc": np.array([]), "soil_c_pool_maom": np.array([])},
     )
@@ -151,13 +155,15 @@ def test_calculate_binding_coefficient(dummy_carbon_data):
     assert np.allclose(binding_coefs, output_coefs)
 
 
-def test_convert_temperature_to_scalar(dummy_carbon_data):
+def test_convert_temperature_to_scalar(dummy_carbon_data, top_soil_layer_index):
     """Test that scalar_temperature runs and generates the correct value."""
     from virtual_rainforest.models.soil.carbon import convert_temperature_to_scalar
 
     output_scalars = [1.27113, 1.27196, 1.27263, 1.26344]
 
-    temp_scalar = convert_temperature_to_scalar(dummy_carbon_data["soil_temperature"])
+    temp_scalar = convert_temperature_to_scalar(
+        dummy_carbon_data["soil_temperature"][top_soil_layer_index]
+    )
 
     assert np.allclose(temp_scalar, output_scalars)
 
@@ -181,7 +187,13 @@ def test_convert_temperature_to_scalar(dummy_carbon_data):
     ],
 )
 def test_convert_moisture_to_scalar(
-    caplog, dummy_carbon_data, alternative, output_scalars, raises, expected_log_entries
+    caplog,
+    dummy_carbon_data,
+    alternative,
+    output_scalars,
+    raises,
+    expected_log_entries,
+    top_soil_layer_index,
 ):
     """Test that scalar_moisture runs and generates the correct value."""
     from virtual_rainforest.models.soil.carbon import convert_moisture_to_scalar
@@ -194,7 +206,7 @@ def test_convert_moisture_to_scalar(
             )
         else:
             moist_scalar = convert_moisture_to_scalar(
-                dummy_carbon_data["soil_moisture"]
+                dummy_carbon_data["soil_moisture"][top_soil_layer_index]
             )
 
         assert np.allclose(moist_scalar, output_scalars)
@@ -228,13 +240,15 @@ def test_calculate_necromass_adsorption(dummy_carbon_data, moist_temp_scalars):
     assert np.allclose(actual_adsorps, expected_adsorps)
 
 
-def test_calculate_carbon_use_efficiency(dummy_carbon_data):
+def test_calculate_carbon_use_efficiency(dummy_carbon_data, top_soil_layer_index):
     """Check carbon use efficiency calculates correctly."""
     from virtual_rainforest.models.soil.carbon import calculate_carbon_use_efficiency
 
     expected_cues = [0.36, 0.33, 0.3, 0.48]
 
-    actual_cues = calculate_carbon_use_efficiency(dummy_carbon_data["soil_temperature"])
+    actual_cues = calculate_carbon_use_efficiency(
+        dummy_carbon_data["soil_temperature"][top_soil_layer_index]
+    )
 
     assert np.allclose(actual_cues, expected_cues)
 
@@ -252,7 +266,9 @@ def test_calculate_microbial_saturation(dummy_carbon_data):
     assert np.allclose(actual_saturated, expected_saturated)
 
 
-def test_calculate_microbial_carbon_uptake(dummy_carbon_data, moist_temp_scalars):
+def test_calculate_microbial_carbon_uptake(
+    dummy_carbon_data, top_soil_layer_index, moist_temp_scalars
+):
     """Check microbial carbon uptake calculates correctly."""
     from virtual_rainforest.models.soil.carbon import calculate_microbial_carbon_uptake
 
@@ -262,7 +278,7 @@ def test_calculate_microbial_carbon_uptake(dummy_carbon_data, moist_temp_scalars
         dummy_carbon_data["soil_c_pool_lmwc"],
         dummy_carbon_data["soil_c_pool_microbe"],
         moist_temp_scalars,
-        dummy_carbon_data["soil_temperature"],
+        dummy_carbon_data["soil_temperature"][top_soil_layer_index],
     )
 
     assert np.allclose(actual_uptake, expected_uptake)

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -453,7 +453,7 @@ def test_order_independance(dummy_carbon_data, soil_model_fixture):
         assert np.allclose(output[pool_name], output_reversed[pool_name])
 
 
-def test_construct_full_soil_model(dummy_carbon_data):
+def test_construct_full_soil_model(dummy_carbon_data, top_soil_layer_index):
     """Test that the function that creates the object to integrate exists and works."""
 
     from virtual_rainforest.models.soil.soil_model import construct_full_soil_model
@@ -490,7 +490,7 @@ def test_construct_full_soil_model(dummy_carbon_data):
     }
 
     rate_of_change = construct_full_soil_model(
-        0.0, pools, dummy_carbon_data, 4, delta_pools_ordered
+        0.0, pools, dummy_carbon_data, 4, top_soil_layer_index, delta_pools_ordered
     )
 
     assert np.allclose(delta_pools, rate_of_change)

--- a/virtual_rainforest/models/abiotic_simple/abiotic_simple_model.py
+++ b/virtual_rainforest/models/abiotic_simple/abiotic_simple_model.py
@@ -119,7 +119,7 @@ class AbioticSimpleModel(BaseModel):
         self.data
         """A Data instance providing access to the shared simulation data."""
         self.layer_roles = layer_roles
-        "A list of vertical layer roles."
+        """A list of vertical layer roles."""
         self.update_interval
         """The time interval between model updates."""
         self.initial_soil_moisture = initial_soil_moisture

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -101,7 +101,7 @@ class SoilModel(BaseModel):
         # Find first soil layer from the soil temperature in data object
         self.top_soil_layer_index = next(
             i
-            for i, v in enumerate(data["soil_temperature"].coords["layer_roles"])
+            for i, v in enumerate(data["soil_moisture"].coords["layer_roles"])
             if v == "soil"
         )
         """The layer in the data object representing the first soil layer."""

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -204,8 +204,8 @@ class SoilModel(BaseModel):
             construct_full_soil_model,
             t_span,
             y0,
-            args=(self.data, no_cells, delta_pools_ordered),
-        )
+            args=(self.data, no_cells, 13, delta_pools_ordered),
+        )  # TODO - This should not be hardcoded in here
 
         # Check if integration failed
         if not output.success:
@@ -232,6 +232,7 @@ def construct_full_soil_model(
     pools: NDArray[np.float32],
     data: Data,
     no_cells: int,
+    top_soil_layer_index: int,
     delta_pools_ordered: dict[str, NDArray[np.float32]],
 ) -> NDArray[np.float32]:
     """Function that constructs the full soil model in a solve_ivp friendly form.
@@ -243,6 +244,7 @@ def construct_full_soil_model(
         pools: An array containing all soil pools in a single vector
         data: The data object, used to populate the arguments i.e. pH and bulk density
         no_cells: Number of grid cells the integration is being performed over
+        top_soil_layer_index: Index for layer in data object representing top soil layer
         delta_pools_ordered: Dictionary to store pool changes in the order that pools
             are stored in the initial condition vector.
 
@@ -257,10 +259,6 @@ def construct_full_soil_model(
     soil_pools = {
         str(pool): pools[slc] for slc, pool in zip(slices, delta_pools_ordered.keys())
     }
-
-    # TODO - THIS SHOULD BE CALCULATED DIRECTLY FROM THE DATA OBJECT
-    # AND ALSO PASSED INTO THE FUNCTION
-    top_soil_layer_index = 13
 
     # Supply soil pools by unpacking dictionary
     return calculate_soil_carbon_updates(

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -98,12 +98,15 @@ class SoilModel(BaseModel):
         """A Data instance providing access to the shared simulation data."""
         self.update_interval
         """The time interval between model updates."""
+        # Find first soil layer from the soil temperature in data object
+        self.top_soil_layer_index = next(
+            i
+            for i, v in enumerate(data["soil_temperature"].coords["layer_roles"])
+            if v == "soil"
+        )
+        """The layer in the data object representing the first soil layer."""
         # TODO - At the moment the soil model only cares about the very top layer. As
         # both the soil and abiotic models get more complex this might well change.
-        # TODO - This should not be hardcoded in here
-        # Ideally this can be calculated from the data object
-        self.top_soil_layer_index = 13
-        """The layer in the data object representing the first soil layer."""
 
     @classmethod
     def from_config(

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -98,6 +98,12 @@ class SoilModel(BaseModel):
         """A Data instance providing access to the shared simulation data."""
         self.update_interval
         """The time interval between model updates."""
+        # TODO - At the moment the soil model only cares about the very top layer. As
+        # both the soil and abiotic models get more complex this might well change.
+        # TODO - This should not be hardcoded in here
+        # Ideally this can be calculated from the data object
+        self.top_soil_layer_index = 13
+        """The layer in the data object representing the first soil layer."""
 
     @classmethod
     def from_config(
@@ -204,8 +210,8 @@ class SoilModel(BaseModel):
             construct_full_soil_model,
             t_span,
             y0,
-            args=(self.data, no_cells, 13, delta_pools_ordered),
-        )  # TODO - This should not be hardcoded in here
+            args=(self.data, no_cells, self.top_soil_layer_index, delta_pools_ordered),
+        )
 
         # Check if integration failed
         if not output.success:

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -258,12 +258,16 @@ def construct_full_soil_model(
         str(pool): pools[slc] for slc, pool in zip(slices, delta_pools_ordered.keys())
     }
 
+    # TODO - THIS SHOULD BE CALCULATED DIRECTLY FROM THE DATA OBJECT
+    # AND ALSO PASSED INTO THE FUNCTION
+    top_soil_layer_index = 13
+
     # Supply soil pools by unpacking dictionary
     return calculate_soil_carbon_updates(
         pH=data["pH"].to_numpy(),
         bulk_density=data["bulk_density"].to_numpy(),
-        soil_moisture=data["soil_moisture"].to_numpy(),
-        soil_temp=data["soil_temperature"].to_numpy(),
+        soil_moisture=data["soil_moisture"][top_soil_layer_index].to_numpy(),
+        soil_temp=data["soil_temperature"][top_soil_layer_index].to_numpy(),
         percent_clay=data["percent_clay"].to_numpy(),
         delta_pools_ordered=delta_pools_ordered,
         **soil_pools,


### PR DESCRIPTION
# Description

I've changed the soil model so that it uses the soil layers defined by the abiotic model correctly (well at all 🙂). This involves giving the `SoilModel` class a `top_soil_layer_index` attribute which is calculated using the `data` object used to init the overall class. This attribute is then used as an index to extract the top soil layer from `data` when required.

@vgro, there's no rush to review this. I just wanted to get the pull request in before I clock off for the long weekend.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
