### PR TITLE
Forced module order to be fixed based on config input

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ defined in main.py that it calls.
 """
 
 from contextlib import nullcontext as does_not_raise
-from logging import CRITICAL, DEBUG, ERROR, INFO
+from logging import CRITICAL, DEBUG, ERROR, INFO, WARNING
 from pathlib import Path
 
 import pint
@@ -47,7 +47,7 @@ from .conftest import log_check
             id="ignores core",
         ),
         pytest.param(
-            ["soil", "freshwater"],  # Model that hasn't been defined
+            ["freshwater", "soil"],  # Model that hasn't been defined
             0,
             pytest.raises(InitialisationError),
             (
@@ -63,6 +63,23 @@ from .conftest import log_check
                 ),
             ),
             id="undefined model",
+        ),
+        pytest.param(
+            ["soil", "abiotic_simple", "abiotic_simple"],
+            2,
+            does_not_raise(),
+            (
+                (
+                    WARNING,
+                    "Duplicate model names were provided, these have been ignored.",
+                ),
+                (
+                    INFO,
+                    "Attempting to configure the following models: ['soil', "
+                    "'abiotic_simple']",
+                ),
+            ),
+            id="repeated model",
         ),
     ],
 )


### PR DESCRIPTION
# Description

This pull request changes `select_models` to use a list rather than a set to find the non-duplicated model names. This means that the inputted order of models is preserved, so that models are always called in the order the user specifies them.

This doesn't fix the broader issue of how we should handle model ordering, where the information should be stored, etc. It does fix the issue of `vr_run` sometimes randomly stalling when a valid model order is entered.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
