### PR TITLE
Remove soil model specific function to update data object

### DIFF
--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -165,16 +165,9 @@ def test_soil_model_initialization(
             model = SoilModel(dummy_carbon_data, pint.Quantity("1 week"), 2, 10)
 
         # In cases where it passes then checks that the object has the right properties
-        assert set(
-            [
-                "setup",
-                "spinup",
-                "update",
-                "cleanup",
-                "replace_soil_pools",
-                "integrate",
-            ]
-        ).issubset(dir(model))
+        assert set(["setup", "spinup", "update", "cleanup", "integrate"]).issubset(
+            dir(model)
+        )
         assert model.model_name == "soil"
         assert str(model) == "A soil model instance"
         assert repr(model) == "SoilModel(update_interval = 1 week)"
@@ -287,30 +280,6 @@ def test_update(mocker, soil_model_fixture, dummy_carbon_data):
     # Check that data fixture has been updated correctly
     assert np.allclose(dummy_carbon_data["soil_c_pool_lmwc"], end_lmwc)
     assert np.allclose(dummy_carbon_data["soil_c_pool_maom"], end_maom)
-
-
-def test_replace_soil_pools(dummy_carbon_data, soil_model_fixture):
-    """Test function to update soil pools."""
-
-    end_lmwc = [0.04980117, 0.01999411, 0.09992829, 0.00499986]
-    end_maom = [2.50019883, 1.70000589, 4.50007171, 0.50000014]
-    end_microbe = [5.8, 2.3, 11.3, 1.0]
-
-    new_pools = Dataset(
-        data_vars=dict(
-            soil_c_pool_lmwc=DataArray(end_lmwc, dims="cell_id"),
-            soil_c_pool_maom=DataArray(end_maom, dims="cell_id"),
-            soil_c_pool_microbe=DataArray(end_microbe, dims="cell_id"),
-        )
-    )
-
-    # Use this update to update the soil carbon pools
-    soil_model_fixture.replace_soil_pools(new_pools)
-
-    # Then check that pools are correctly incremented based on update
-    assert np.allclose(dummy_carbon_data["soil_c_pool_maom"], end_maom)
-    assert np.allclose(dummy_carbon_data["soil_c_pool_lmwc"], end_lmwc)
-    assert np.allclose(dummy_carbon_data["soil_c_pool_microbe"], end_microbe)
 
 
 @pytest.mark.parametrize(

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -123,7 +123,7 @@ file.
 """  # noqa: D205, D415
 
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import numpy as np
 from xarray import DataArray, Dataset
@@ -348,7 +348,7 @@ class Data:
         # If the file path is okay then write the model state out as a NetCDF
         self.data.to_netcdf(output_file_path)
 
-    def add_from_dict(self, output_dict: Dict[str, DataArray]) -> None:
+    def add_from_dict(self, output_dict: dict[str, DataArray]) -> None:
         """Update data object from dictionary of variables.
 
         This function takes a dictionary of updated variables to replace the

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -364,7 +364,7 @@ class Data:
         """
 
         for variable in output_dict:
-            self.data[variable] = output_dict[variable]
+            self[variable] = output_dict[variable]
 
 
 class DataGenerator:

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -24,7 +24,7 @@ import numpy as np
 from numpy.typing import NDArray
 from pint import Quantity
 from scipy.integrate import solve_ivp
-from xarray import DataArray, Dataset
+from xarray import DataArray
 
 from virtual_rainforest.core.base_model import BaseModel
 from virtual_rainforest.core.data import Data
@@ -149,30 +149,12 @@ class SoilModel(BaseModel):
 
         # Update carbon pools (attributes and data object)
         # n.b. this also updates the data object automatically
-        self.replace_soil_pools(updated_carbon_pools)
+        self.data.add_from_dict(updated_carbon_pools)
 
     def cleanup(self) -> None:
         """Placeholder function for soil model cleanup."""
 
-    def replace_soil_pools(self, new_pools: Dataset) -> None:
-        """Replace soil pools with previously calculated new pool values.
-
-        The state of particular soil pools will effect the rate of other processes in
-        the soil module. These processes in turn can effect the exchange rates between
-        the original soil pools. Thus, a separate update function is necessary so that
-        the new values for all soil module components can be calculated on a single
-        state, which is then updated (using this function) when all values have been
-        calculated.
-
-        Args:
-            new_pools: Array of new pool values to insert into the data object
-        """
-
-        self.data["soil_c_pool_lmwc"] = new_pools["soil_c_pool_lmwc"]
-        self.data["soil_c_pool_maom"] = new_pools["soil_c_pool_maom"]
-        self.data["soil_c_pool_microbe"] = new_pools["soil_c_pool_microbe"]
-
-    def integrate(self) -> Dataset:
+    def integrate(self) -> dict[str, DataArray]:
         """Integrate the soil model.
 
         For now a single integration will be used to advance the entire soil module.
@@ -238,7 +220,7 @@ class SoilModel(BaseModel):
             for slc, pool in zip(slices, delta_pools_ordered.keys())
         }
 
-        return Dataset(data_vars=new_c_pools)
+        return new_c_pools
 
 
 def construct_full_soil_model(


### PR DESCRIPTION
# Description

The `soil` model had defined a function to update the data object. However, @vgro recently added a function to the `Data` object to do this. So, it makes sense to remove the `soil` specific function in favour of a function defined within `core`.

I also changed the `add_from_dict` slightly so that the relevant `LOGGER.info` output gets generated when data is saved using it.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
