### PR TITLE
Fix dask warning about saving "layer_roles" as an object

### DIFF
--- a/docs/source/data_recipes/plant_dummy.md
+++ b/docs/source/data_recipes/plant_dummy.md
@@ -23,9 +23,8 @@ section provides a recipe to create such an input conform with the dummy data fo
 [climate](./ERA5_preprocessing_example.md) and soil (add link here).
 
 ```{code-cell} ipython3
-import xarray as xr
 import numpy as np
-from xarray import DataArray
+from xarray import DataArray, Dataset
 
 # set layer roles
 layer_roles = ["above"] + 10 * ["canopy"] + ["subcanopy"] + ["surface"] + 2 * ["soil"]
@@ -57,10 +56,14 @@ plant_dummy["leaf_area_index"] = DataArray(
         },
         name="leaf_area_index",
 )
-plant_dummy
+
+# Make dictionary of DataArrays into a Dataset
+plant_dummy_dataset = Dataset(plant_dummy)
+
+plant_dummy_dataset
 ```
 
 ```python
 # write to NetCDF
-xr.Dataset(plant_dummy).to_netcdf("./plants_dummy.nc")
+plant_dummy_dataset.to_netcdf("./plants_dummy.nc")
 ```

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -263,6 +263,9 @@ def merge_continuous_data_files(
     # Open all files as a single dataset
     all_data = open_mfdataset(continuous_data_files)
 
+    # Specify type of the layer roles object to allow for quicker saving by dask
+    all_data["layer_roles"] = all_data["layer_roles"].astype("S9")
+
     # Save and close complete dataset
     all_data.to_netcdf(out_path)
     all_data.close()


### PR DESCRIPTION
# Description

I took the simplest approach I could think of to fix this warning. I just converted the "layer_roles" from being objects to being string with 9 characters ("S9"), right before the combined data is saved. With this change everything works without warnings, so I think that's enough to fix the bug.

I also changed the dummy_plant data recipe slightly so that the data set will show up as part of the documentation (which was already the case for the other recipes)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
