### PR TITLE
Updated poetry to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Poetry
-      uses: abatilo/actions-poetry@v2.1.6
+      uses: abatilo/actions-poetry@v2.3.0
       with:
-        poetry-version: 1.2.2
+        poetry-version: 1.5.1
 
     - name: Install dependencies
       run: poetry install
@@ -53,9 +53,9 @@ jobs:
           python-version: "3.9"
 
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v2.1.6
+        uses: abatilo/actions-poetry@v2.3.0
         with:
-          poetry-version: 1.2.2
+          poetry-version: 1.5.1
 
       - name: Install dependencies
         run: poetry install


### PR DESCRIPTION
# Description

The CI GitHub Action has a problem where occasionally a run will fail during the install dependancies step (see [here](https://github.com/ImperialCollegeLondon/virtual_rainforest/actions/runs/5505115190/jobs/10032099985)). This generally seems to happen on Windows with python version 3.10.

This PR updates `poetry` to latest version in case this is a `poetry` bug which has already been patched out. If it isn't then we'll have to investigate further.

(Updating `poetry` from `1.2.2` to `1.5.1` seems to halve dependancy install times, so I think this change is worthwhile regardless of if it fixes the bug)


## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
