### PR TITLE
Adding a particulate organic matter pool

### DIFF
--- a/docs/source/data_recipes/soil_dummy.md
+++ b/docs/source/data_recipes/soil_dummy.md
@@ -73,6 +73,14 @@ def generate_microbial_C_values(x: float, y: float) -> float:
     """
     return 0.0015 + 0.0035 * (x * y) / (64)
 
+def generate_pom_values(x: float, y: float) -> float:
+    """Function to generate a reasonable range of pom values.
+    
+    A reasonable amount of carbon is stored as particulate organic matter (POM), so a
+    range of 0.1-1.0 kg C m^-3 is used.
+    """
+    return 0.1 + 0.9 * (x * y) / (64)
+
 
 # Generate range of cell numbers in the a x and y directions. Here we have a 9x9 grid,
 # so cells are numbered from 0 to 8 in each direction.
@@ -92,6 +100,7 @@ maom_values = [[generate_maom_values(x, y) for y in y_cell_ids] for x in x_cell_
 microbial_C_values = [
     [generate_microbial_C_values(x, y) for y in y_cell_ids] for x in x_cell_ids
 ]
+pom_values = [[generate_pom_values(x, y) for y in y_cell_ids] for x in x_cell_ids]
 
 # How far the center of each cell is from the origin. This applies to both the x and y
 # direction independently, so cell (0,0) is at the origin, whereas cell (2,3) is 180m
@@ -107,6 +116,7 @@ dummy_soil_data = Dataset(
         soil_c_pool_lmwc=(["x", "y"], lmwc_values),
         soil_c_pool_maom=(["x", "y"], maom_values),
         soil_c_pool_microbe=(["x", "y"], microbial_C_values),
+        soil_c_pool_pom=(["x", "y"], pom_values),
     ),
     coords=dict(
         x=(["x"], cell_displacements),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,8 @@ def dummy_carbon_data(layer_roles_fixture):
     """Mineral associated organic matter pool (kg C m^-3)"""
     data["soil_c_pool_microbe"] = DataArray([5.8, 2.3, 11.3, 1.0], dims=["cell_id"])
     """Microbial biomass (carbon) pool (kg C m^-3)"""
+    data["soil_c_pool_pom"] = DataArray([0.1, 1.0, 0.7, 0.35], dims=["cell_id"])
+    """Particulate organic matter pool (kg C m^-3)"""
     data["pH"] = DataArray([3.0, 7.5, 9.0, 5.7], dims=["cell_id"])
     data["bulk_density"] = DataArray([1350.0, 1800.0, 1000.0, 1500.0], dims=["cell_id"])
     data["percent_clay"] = DataArray([80.0, 30.0, 10.0, 90.0], dims=["cell_id"])

--- a/tests/models/soil/test_carbon.py
+++ b/tests/models/soil/test_carbon.py
@@ -50,9 +50,10 @@ def test_calculate_soil_carbon_updates(dummy_carbon_data, top_soil_layer_index):
     from virtual_rainforest.models.soil.carbon import calculate_soil_carbon_updates
 
     change_in_pools = [
-        [1.44475655e-03, 1.01162673e-02, 7.04474125e-01, -5.43915134e-05],
+        [0.00525045055, 0.0205448757, 0.7136941904, 0.00141217],
         [0.13088391, 0.05654771, -0.39962841, 0.00533357],
         [-0.33131188, -0.16636299, -0.76078599, -0.01275669],
+        [-0.00349175378, -0.01011466818, -0.00890612528, -0.00115262138],
     ]
 
     delta_pools = calculate_soil_carbon_updates(
@@ -71,7 +72,8 @@ def test_calculate_soil_carbon_updates(dummy_carbon_data, top_soil_layer_index):
     # Check that the updates are correctly calculated
     assert np.allclose(delta_pools[:4], change_in_pools[0])
     assert np.allclose(delta_pools[4:8], change_in_pools[1])
-    assert np.allclose(delta_pools[8:], change_in_pools[2])
+    assert np.allclose(delta_pools[8:12], change_in_pools[2])
+    assert np.allclose(delta_pools[12:], change_in_pools[3])
 
 
 def test_calculate_mineral_association(dummy_carbon_data, moist_temp_scalars):

--- a/tests/models/soil/test_carbon.py
+++ b/tests/models/soil/test_carbon.py
@@ -311,12 +311,15 @@ def test_calculate_labile_carbon_leaching(dummy_carbon_data, moist_temp_scalars)
     assert np.allclose(actual_leaching, expected_leaching)
 
 
-def test_calculate_direct_litter_input_to_lmwc():
+def test_calculate_direct_litter_input_to_pools():
     """Check direct litter input to lmwc is calculated correctly."""
     from virtual_rainforest.models.soil.carbon import (
-        calculate_direct_litter_input_to_lmwc,
+        calculate_direct_litter_input_to_pools,
     )
+    from virtual_rainforest.models.soil.constants import LITTER_INPUT_RATE
 
-    actual_input = calculate_direct_litter_input_to_lmwc()
+    actual_input_lmwc, actual_input_pom = calculate_direct_litter_input_to_pools()
 
-    assert np.isclose(actual_input, 0.00015697011)
+    assert np.isclose(actual_input_lmwc, 0.00015697011)
+    assert np.isclose(actual_input_pom, 0.00031394022)
+    assert np.isclose(actual_input_lmwc + actual_input_pom, LITTER_INPUT_RATE)

--- a/tests/models/soil/test_carbon.py
+++ b/tests/models/soil/test_carbon.py
@@ -342,6 +342,21 @@ def test_calculate_labile_carbon_leaching(dummy_carbon_data, moist_temp_scalars)
     assert np.allclose(actual_leaching, expected_leaching)
 
 
+def test_calculate_pom_decomposition(dummy_carbon_data, moist_temp_scalars):
+    """Check that particulate organic matter decomposition is calculated correctly."""
+    from virtual_rainforest.models.soil.carbon import calculate_pom_decomposition
+
+    expected_decomp = [0.0038056940, 0.0104286084, 0.0092200655, 0.0014665616]
+
+    actual_decomp = calculate_pom_decomposition(
+        dummy_carbon_data["soil_c_pool_pom"],
+        dummy_carbon_data["soil_c_pool_microbe"],
+        moist_temp_scalars,
+    )
+
+    assert np.allclose(actual_decomp, expected_decomp)
+
+
 def test_calculate_direct_litter_input_to_pools():
     """Check direct litter input to lmwc is calculated correctly."""
     from virtual_rainforest.models.soil.carbon import (

--- a/tests/models/soil/test_carbon.py
+++ b/tests/models/soil/test_carbon.py
@@ -280,6 +280,21 @@ def test_calculate_microbial_saturation(dummy_carbon_data):
     assert np.allclose(actual_saturated, expected_saturated)
 
 
+def test_calculate_microbial_pom_mineralisation_saturation(dummy_carbon_data):
+    """Check microbial mineralisation saturation calculates correctly."""
+    from virtual_rainforest.models.soil.carbon import (
+        calculate_microbial_pom_mineralisation_saturation,
+    )
+
+    expected_saturated = [0.99793530, 0.99480968, 0.99893917, 0.98814229]
+
+    actual_saturated = calculate_microbial_pom_mineralisation_saturation(
+        dummy_carbon_data["soil_c_pool_microbe"]
+    )
+
+    assert np.allclose(actual_saturated, expected_saturated)
+
+
 def test_calculate_microbial_carbon_uptake(
     dummy_carbon_data, top_soil_layer_index, moist_temp_scalars
 ):

--- a/tests/models/soil/test_carbon.py
+++ b/tests/models/soil/test_carbon.py
@@ -59,6 +59,7 @@ def test_calculate_soil_carbon_updates(dummy_carbon_data, top_soil_layer_index):
         dummy_carbon_data["soil_c_pool_lmwc"].to_numpy(),
         dummy_carbon_data["soil_c_pool_maom"].to_numpy(),
         dummy_carbon_data["soil_c_pool_microbe"].to_numpy(),
+        dummy_carbon_data["soil_c_pool_pom"].to_numpy(),
         dummy_carbon_data["pH"],
         dummy_carbon_data["bulk_density"],
         dummy_carbon_data["soil_moisture"][top_soil_layer_index],
@@ -290,6 +291,21 @@ def test_calculate_microbial_pom_mineralisation_saturation(dummy_carbon_data):
 
     actual_saturated = calculate_microbial_pom_mineralisation_saturation(
         dummy_carbon_data["soil_c_pool_microbe"]
+    )
+
+    assert np.allclose(actual_saturated, expected_saturated)
+
+
+def test_calculate_pom_decomposition_saturation(dummy_carbon_data):
+    """Check POM decomposition saturation calculates correctly."""
+    from virtual_rainforest.models.soil.carbon import (
+        calculate_pom_decomposition_saturation,
+    )
+
+    expected_saturated = [0.4, 0.86956521, 0.82352941, 0.7]
+
+    actual_saturated = calculate_pom_decomposition_saturation(
+        dummy_carbon_data["soil_c_pool_pom"]
     )
 
     assert np.allclose(actual_saturated, expected_saturated)

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -291,13 +291,17 @@ def test_update(mocker, soil_model_fixture, dummy_carbon_data):
             Dataset(
                 data_vars=dict(
                     lmwc=DataArray(
-                        [0.05103402, 0.02542457, 1.86156352, 0.00497357], dims="cell_id"
+                        [0.05290414, 0.03085044, 1.87779865, 0.00569224], dims="cell_id"
                     ),
                     maom=DataArray(
-                        [2.56412463, 1.7271028, 2.8534901, 0.50265782], dims="cell_id"
+                        [2.5640905, 1.72670122, 2.84147024, 0.50266578], dims="cell_id"
                     ),
                     microbe=DataArray(
-                        [5.63675701, 2.21851098, 10.9601024, 0.993642], dims="cell_id"
+                        [5.63681284, 2.21869505, 10.96048678, 0.99364838],
+                        dims="cell_id",
+                    ),
+                    pom=DataArray(
+                        [0.09826415, 0.99494486, 0.69554961, 0.34942389], dims="cell_id"
                     ),
                 )
             ),
@@ -336,6 +340,7 @@ def test_integrate_soil_model(
         assert np.allclose(new_pools["soil_c_pool_lmwc"], final_pools["lmwc"])
         assert np.allclose(new_pools["soil_c_pool_maom"], final_pools["maom"])
         assert np.allclose(new_pools["soil_c_pool_microbe"], final_pools["microbe"])
+        assert np.allclose(new_pools["soil_c_pool_pom"], final_pools["pom"])
 
     # Check that integrator is called once (and once only)
     if mock_output:
@@ -403,10 +408,10 @@ def test_construct_full_soil_model(dummy_carbon_data, top_soil_layer_index):
     from virtual_rainforest.models.soil.soil_model import construct_full_soil_model
 
     delta_pools = [
-        1.44475655e-03,
-        1.01162673e-02,
-        7.04474125e-01,
-        -5.43915134e-05,
+        0.00525045055,
+        0.0205448757,
+        0.7136941904,
+        0.00141217,
         0.13088391,
         0.05654771,
         -0.39962841,
@@ -415,6 +420,10 @@ def test_construct_full_soil_model(dummy_carbon_data, top_soil_layer_index):
         -0.16636299,
         -0.76078599,
         -0.01275669,
+        -0.00349175378,
+        -0.01011466818,
+        -0.00890612528,
+        -0.00115262138,
     ]
 
     # make pools

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -51,6 +51,10 @@ def soil_model_fixture(dummy_carbon_data):
                 ),
                 (
                     DEBUG,
+                    "soil model: required var 'soil_c_pool_pom' checked",
+                ),
+                (
+                    DEBUG,
                     "soil model: required var 'pH' checked",
                 ),
                 (
@@ -79,6 +83,10 @@ def soil_model_fixture(dummy_carbon_data):
                     ERROR,
                     "soil model: init data missing required var "
                     "'soil_c_pool_microbe'",
+                ),
+                (
+                    ERROR,
+                    "soil model: init data missing required var " "'soil_c_pool_pom'",
                 ),
                 (
                     ERROR,
@@ -117,6 +125,10 @@ def soil_model_fixture(dummy_carbon_data):
                 (
                     DEBUG,
                     "soil model: required var 'soil_c_pool_microbe' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'soil_c_pool_pom' checked",
                 ),
                 (
                     DEBUG,
@@ -214,6 +226,10 @@ def test_soil_model_initialization(
                 (
                     DEBUG,
                     "soil model: required var 'soil_c_pool_microbe' checked",
+                ),
+                (
+                    DEBUG,
+                    "soil model: required var 'soil_c_pool_pom' checked",
                 ),
                 (
                     DEBUG,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -125,6 +125,10 @@ def test_select_models(caplog, model_list, no_models, raises, expected_log_entri
                 ),
                 (
                     DEBUG,
+                    "soil model: required var 'soil_c_pool_pom' checked",
+                ),
+                (
+                    DEBUG,
                     "soil model: required var 'pH' checked",
                 ),
                 (
@@ -466,7 +470,12 @@ def test_output_current_state(mocker, dummy_carbon_data, time_index):
     assert mock_save.call_count == 1
     assert mock_save.call_args == mocker.call(
         Path(f"./continuous_state{time_index:05}.nc"),
-        ["soil_c_pool_maom", "soil_c_pool_lmwc", "soil_c_pool_microbe"],
+        [
+            "soil_c_pool_maom",
+            "soil_c_pool_lmwc",
+            "soil_c_pool_microbe",
+            "soil_c_pool_pom",
+        ],
         time_index,
     )
     assert outpath == Path(f"./continuous_state{time_index:05}.nc")

--- a/virtual_rainforest/data_variables.toml
+++ b/virtual_rainforest/data_variables.toml
@@ -415,6 +415,14 @@ updated_by = "soil"
 used_by = [ "soil"]
 
 [[variable]]
+name = "soil_c_pool_pom"
+description = "Size of microbial biomass pool"
+unit = "kg C m-3"
+initialised_by = "soil"
+updated_by = "soil"
+used_by = ["soil"]
+
+[[variable]]
 name = "bulk_density"
 description = "Bulk density of soil"
 unit = "kg m-3"

--- a/virtual_rainforest/models/soil/carbon.py
+++ b/virtual_rainforest/models/soil/carbon.py
@@ -11,6 +11,7 @@ from virtual_rainforest.core.logger import LOGGER
 from virtual_rainforest.models.soil.constants import (
     CARBON_INPUT_TO_POM,
     HALF_SAT_MICROBIAL_ACTIVITY,
+    HALF_SAT_MICROBIAL_POM_MINERALISATION,
     LEACHING_RATE_LABILE_CARBON,
     LITTER_INPUT_RATE,
     MAX_UPTAKE_RATE_LABILE_C,
@@ -347,6 +348,35 @@ def calculate_microbial_saturation(
     """
 
     return soil_c_pool_microbe / (soil_c_pool_microbe + half_sat_microbial_activity)
+
+
+def calculate_microbial_pom_mineralisation_saturation(
+    soil_c_pool_microbe: NDArray[np.float32],
+    half_sat_microbial_mineralisation: float = HALF_SAT_MICROBIAL_POM_MINERALISATION,
+) -> NDArray[np.float32]:
+    """Calculate microbial POM mineralisation saturation (with increasing biomass).
+
+    This ensures that microbial mineralisation of POM (per unit biomass) drops as
+    biomass density increases. This is adopted from Abramoff et al. This function is
+    very similar to the
+    :func:`~virtual_rainforest.models.soil.carbon.calculate_microbial_saturation`
+    function. They could in theory be reworked into a single function, but it doesn't
+    seem worth the effort as we do not anticipate using biomass saturation functions
+    beyond the first model draft.
+
+    Args:
+        soil_c_pool_microbe: Microbial biomass (carbon) pool [kg C m^-3]
+        half_sat_microbial_mineralisation: Half saturation constant for microbial
+            mineralisation of POM
+
+    Returns:
+        A rescaling of microbial biomass that takes into account POM mineralisation rate
+        saturation with increasing biomass density
+    """
+
+    return soil_c_pool_microbe / (
+        soil_c_pool_microbe + half_sat_microbial_mineralisation
+    )
 
 
 def calculate_microbial_carbon_uptake(

--- a/virtual_rainforest/models/soil/carbon.py
+++ b/virtual_rainforest/models/soil/carbon.py
@@ -84,7 +84,7 @@ def calculate_soil_carbon_updates(
     labile_carbon_leaching = calculate_labile_carbon_leaching(
         soil_c_pool_lmwc, moist_temp_scalar
     )
-    litter_input_to_lmwc = calculate_direct_litter_input_to_lmwc()
+    litter_input_to_lmwc, litter_input_to_pom = calculate_direct_litter_input_to_pools()
 
     # Determine net changes to the pools
     delta_pools_ordered["soil_c_pool_lmwc"] = (
@@ -411,11 +411,11 @@ def calculate_labile_carbon_leaching(
     return leaching_rate * moist_temp_scalar * soil_c_pool_lmwc
 
 
-def calculate_direct_litter_input_to_lmwc(
+def calculate_direct_litter_input_to_pools(
     carbon_input_to_pom: float = CARBON_INPUT_TO_POM,
     litter_input_rate: float = LITTER_INPUT_RATE,
-) -> float:
-    """Calculate direct input from litter to LMWC pool.
+) -> tuple[float, float]:
+    """Calculate direct input from litter to LMWC and POM pools.
 
     This process is very much specific to :cite:t:`abramoff_millennial_2018`, and I
     don't think we want to preserve it long term.
@@ -427,7 +427,10 @@ def calculate_direct_litter_input_to_lmwc(
             pools [kg C m^-2 day^-1].
 
     Returns:
-        Amount of carbon directly added to LMWC pool from litter.
+        Amount of carbon directly added to LMWC and POM pools from litter.
     """
 
-    return (1 - carbon_input_to_pom) * litter_input_rate
+    return (
+        litter_input_rate * (1 - carbon_input_to_pom),
+        litter_input_rate * carbon_input_to_pom,
+    )

--- a/virtual_rainforest/models/soil/carbon.py
+++ b/virtual_rainforest/models/soil/carbon.py
@@ -12,6 +12,7 @@ from virtual_rainforest.models.soil.constants import (
     CARBON_INPUT_TO_POM,
     HALF_SAT_MICROBIAL_ACTIVITY,
     HALF_SAT_MICROBIAL_POM_MINERALISATION,
+    HALF_SAT_POM_DECOMPOSITION,
     LEACHING_RATE_LABILE_CARBON,
     LITTER_INPUT_RATE,
     MAX_UPTAKE_RATE_LABILE_C,
@@ -29,6 +30,7 @@ def calculate_soil_carbon_updates(
     soil_c_pool_lmwc: NDArray[np.float32],
     soil_c_pool_maom: NDArray[np.float32],
     soil_c_pool_microbe: NDArray[np.float32],
+    soil_c_pool_pom: NDArray[np.float32],
     pH: NDArray[np.float32],
     bulk_density: NDArray[np.float32],
     soil_moisture: NDArray[np.float32],
@@ -46,6 +48,7 @@ def calculate_soil_carbon_updates(
         soil_c_pool_lmwc: Low molecular weight carbon pool [kg C m^-3]
         soil_c_pool_maom: Mineral associated organic matter pool [kg C m^-3]
         soil_c_pool_microbe: Microbial biomass (carbon) pool [kg C m^-3]
+        soil_c_pool_pom: Particulate organic matter pool [kg C m^-3]
         pH: pH values for each soil grid cell
         bulk_density: bulk density values for each soil grid cell [kg m^-3]
         soil_moisture: relative water content for each soil grid cell [unitless]
@@ -377,6 +380,27 @@ def calculate_microbial_pom_mineralisation_saturation(
     return soil_c_pool_microbe / (
         soil_c_pool_microbe + half_sat_microbial_mineralisation
     )
+
+
+def calculate_pom_decomposition_saturation(
+    soil_c_pool_pom: NDArray[np.float32],
+    half_sat_pom_decomposition: float = HALF_SAT_POM_DECOMPOSITION,
+) -> NDArray[np.float32]:
+    """Calculate particulate organic matter (POM) decomposition saturation.
+
+    This ensures that decomposition of POM to low molecular weight carbon (LMWC)
+    saturates with increasing POM. This effect arises from the saturation of enzymes
+    with increasing substrate.
+
+    Args:
+        soil_c_pool_pom: Particulate organic matter (carbon) pool [kg C m^-3]
+        half_sat_pom_decomposition: Half saturation constant for POM decomposition
+
+    Returns:
+        The saturation of the decomposition process
+    """
+
+    return soil_c_pool_pom / (soil_c_pool_pom + half_sat_pom_decomposition)
 
 
 def calculate_microbial_carbon_uptake(

--- a/virtual_rainforest/models/soil/carbon.py
+++ b/virtual_rainforest/models/soil/carbon.py
@@ -90,14 +90,24 @@ def calculate_soil_carbon_updates(
         soil_c_pool_lmwc, moist_temp_scalar
     )
     litter_input_to_lmwc, litter_input_to_pom = calculate_direct_litter_input_to_pools()
+    pom_decomposition_to_lmwc = calculate_pom_decomposition(
+        soil_c_pool_pom, soil_c_pool_microbe, moist_temp_scalar
+    )
 
     # Determine net changes to the pools
     delta_pools_ordered["soil_c_pool_lmwc"] = (
-        litter_input_to_lmwc - lmwc_to_maom - microbial_uptake - labile_carbon_leaching
+        litter_input_to_lmwc
+        + pom_decomposition_to_lmwc
+        - lmwc_to_maom
+        - microbial_uptake
+        - labile_carbon_leaching
     )
     delta_pools_ordered["soil_c_pool_maom"] = lmwc_to_maom + necromass_adsorption
     delta_pools_ordered["soil_c_pool_microbe"] = (
         microbial_uptake - microbial_respiration - necromass_adsorption
+    )
+    delta_pools_ordered["soil_c_pool_pom"] = (
+        litter_input_to_pom - pom_decomposition_to_lmwc
     )
 
     # Create output array of pools in desired order

--- a/virtual_rainforest/models/soil/constants.py
+++ b/virtual_rainforest/models/soil/constants.py
@@ -55,6 +55,21 @@ class TempScalar:
     """Reference temperature [degrees C]"""
 
 
+@dataclass(frozen=True)
+class CarbonUseEfficiency:
+    """Collection of carbon use efficiency parameters.
+
+    Taken from :cite:t:`abramoff_millennial_2018`, more investigation required in future
+    """
+
+    reference_cue = 0.6
+    """Carbon use efficiency of community at the reference temperature [no units]"""
+    reference_temp = 15.0
+    """Reference temperature [degrees C]"""
+    cue_with_temperature = 0.012
+    """Change in carbon use efficiency with increasing temperature [degree C^-1]."""
+
+
 MICROBIAL_TURNOVER_RATE: Final[float] = 0.036
 """Microbial turnover rate [day^-1], this isn't a constant but often treated as one."""
 
@@ -86,6 +101,10 @@ empirical work. However, this is something we will definitely completely alter d
 line so no need to worry too much about references.
 """
 
+HALF_SAT_POM_DECOMPOSITION: Final[float] = 0.150
+"""Half saturation constant for POM decomposition to LMWC [kg C m^-2].
+"""
+
 LITTER_INPUT_RATE: Final[float] = 0.172 / 365.25
 """Rate of litter input to the system [kg C m^-2 day^-1].
 
@@ -93,18 +112,3 @@ This definitely is not a constant for our purposes. However,
 :cite:t:`abramoff_millennial_2018` use a constant litter input rate, so we shall also
 use one initially.
 """
-
-
-@dataclass(frozen=True)
-class CarbonUseEfficiency:
-    """Collection of carbon use efficiency parameters.
-
-    Taken from :cite:t:`abramoff_millennial_2018`, more investigation required in future
-    """
-
-    reference_cue = 0.6
-    """Carbon use efficiency of community at the reference temperature [no units]"""
-    reference_temp = 15.0
-    """Reference temperature [degrees C]"""
-    cue_with_temperature = 0.012
-    """Change in carbon use efficiency with increasing temperature [degree C^-1]."""

--- a/virtual_rainforest/models/soil/constants.py
+++ b/virtual_rainforest/models/soil/constants.py
@@ -87,7 +87,13 @@ HALF_SAT_MICROBIAL_ACTIVITY: Final[float] = 0.0072
 """
 
 HALF_SAT_MICROBIAL_POM_MINERALISATION: Final[float] = 0.012
-"""Half saturation constant for microbial POM mineralisation [kg C m^-2].
+"""Half saturation constant for microbial POM mineralisation [kg C m^-2]."""
+
+MAX_DECOMP_RATE_POM: Final[float] = 0.01
+"""Maximum (theoretical) rate at which particulate organic matter can be broken down.
+
+Units of [kg C m^-2 day^-1]. Taken from :cite:t:`abramoff_millennial_2018`, where it was
+obtained by calibration.
 """
 
 LEACHING_RATE_LABILE_CARBON: Final[float] = 1.5e-3

--- a/virtual_rainforest/models/soil/constants.py
+++ b/virtual_rainforest/models/soil/constants.py
@@ -71,6 +71,10 @@ HALF_SAT_MICROBIAL_ACTIVITY: Final[float] = 0.0072
 """Half saturation constant for microbial activity (with increasing biomass)[kg C m^-2].
 """
 
+HALF_SAT_MICROBIAL_POM_MINERALISATION: Final[float] = 0.012
+"""Half saturation constant for microbial POM mineralisation [kg C m^-2].
+"""
+
 LEACHING_RATE_LABILE_CARBON: Final[float] = 1.5e-3
 """Leaching rate for labile carbon (lmwc) [day^-1]."""
 

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -63,6 +63,7 @@ class SoilModel(BaseModel):
         ("soil_c_pool_maom", ("spatial",)),
         ("soil_c_pool_lmwc", ("spatial",)),
         ("soil_c_pool_microbe", ("spatial",)),
+        ("soil_c_pool_pom", ("spatial",)),
         ("pH", ("spatial",)),
         ("bulk_density", ("spatial",)),
         ("percent_clay", ("spatial",)),
@@ -72,7 +73,12 @@ class SoilModel(BaseModel):
     This is a set of variables that must be present in the data object used to create a
     SoilModel , along with any core axes that those variables must map on
     to."""
-    vars_updated = ["soil_c_pool_maom", "soil_c_pool_lmwc", "soil_c_pool_microbe"]
+    vars_updated = [
+        "soil_c_pool_maom",
+        "soil_c_pool_lmwc",
+        "soil_c_pool_microbe",
+        "soil_c_pool_pom",
+    ]
     """Variables updated by the soil model."""
 
     def __init__(
@@ -90,6 +96,7 @@ class SoilModel(BaseModel):
             np.any(data["soil_c_pool_maom"] < 0.0)
             or np.any(data["soil_c_pool_lmwc"] < 0.0)
             or np.any(data["soil_c_pool_microbe"] < 0.0)
+            or np.any(data["soil_c_pool_pom"] < 0.0)
         ):
             to_raise = InitialisationError(
                 "Initial carbon pools contain at least one negative value!"


### PR DESCRIPTION
# Description

This pull request adds an extra carbon pool to the soil carbon model. The pool added is the particulate organic matter (POM) pool. This pool is for organic matter that is too complex to be immediately taken up by microbes but that isn't protected through mineral association. The motivation for adding this pool is that the carbon transfers from litter to soil go to this pool, so adding it is a prerequisite for setting up a `litter` model/module.

I've just added @vgro as a reviewer here, as this PR just extends existing functionality and doesn't really add anything novel, so I don't feel it needs a really thorough going over. If others want to add comments that's completely fine.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
