### PR TITLE
fix time_index

### DIFF
--- a/docs/source/data_recipes/ERA5_preprocessing_example.md
+++ b/docs/source/data_recipes/ERA5_preprocessing_example.md
@@ -182,7 +182,7 @@ The dummy model iterates over time indices rather than real datetime. Therefore,
 a `time_index` coordinate to the dataset:
 
 ```{code-cell} ipython3
-dataset_xy_timeindex = dataset_xy_dummy.assign_coords({'time_index':np.arange(0,24,1)})
+dataset_xy_timeindex = dataset_xy_dummy.rename_dims({'time':'time_index'}).assign_coords({'time_index':np.arange(0,24,1)})
 dataset_xy_timeindex.coords
 ```
 


### PR DESCRIPTION
There was an issue with the `time_index` as a coordinate only, we need it to be a dimension to be accessible by `isel`. I tried to add a 4th dimension but that caused problems, so as an intermediate solution I renamed the time dimension and create an issue.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
