### PR TITLE
Change soil constants to use new system

### DIFF
--- a/tests/models/soil/test_carbon.py
+++ b/tests/models/soil/test_carbon.py
@@ -23,16 +23,16 @@ def moist_temp_scalars(dummy_carbon_data, top_soil_layer_index):
 
     moist_scalars = convert_moisture_to_scalar(
         dummy_carbon_data["soil_moisture"][top_soil_layer_index],
-        SoilConsts().moisture_scalar_coefficient,
-        SoilConsts().moisture_scalar_exponent,
+        SoilConsts.moisture_scalar_coefficient,
+        SoilConsts.moisture_scalar_exponent,
     )
     temp_scalars = convert_temperature_to_scalar(
         dummy_carbon_data["soil_temperature"][top_soil_layer_index],
-        SoilConsts().temp_scalar_coefficient_1,
-        SoilConsts().temp_scalar_coefficient_2,
-        SoilConsts().temp_scalar_coefficient_3,
-        SoilConsts().temp_scalar_coefficient_4,
-        SoilConsts().temp_scalar_reference_temp,
+        SoilConsts.temp_scalar_coefficient_1,
+        SoilConsts.temp_scalar_coefficient_2,
+        SoilConsts.temp_scalar_coefficient_3,
+        SoilConsts.temp_scalar_coefficient_4,
+        SoilConsts.temp_scalar_reference_temp,
     )
 
     return moist_scalars * temp_scalars
@@ -85,7 +85,7 @@ def test_calculate_soil_carbon_updates(dummy_carbon_data, top_soil_layer_index):
         dummy_carbon_data["soil_temperature"][top_soil_layer_index],
         dummy_carbon_data["percent_clay"],
         pool_order,
-        constants=SoilConsts(),
+        constants=SoilConsts,
     )
 
     # Check that the updates are correctly calculated. Using a loop here implicitly
@@ -109,7 +109,7 @@ def test_calculate_mineral_association(dummy_carbon_data, moist_temp_scalars):
         dummy_carbon_data["bulk_density"],
         moist_temp_scalars,
         dummy_carbon_data["percent_clay"],
-        constants=SoilConsts(),
+        constants=SoilConsts,
     )
 
     # Check that expected values are generated
@@ -127,7 +127,7 @@ def test_calculate_equilibrium_maom(dummy_carbon_data):
         dummy_carbon_data["pH"],
         Q_max,
         dummy_carbon_data["soil_c_pool_lmwc"],
-        constants=SoilConsts(),
+        constants=SoilConsts,
     )
     assert np.allclose(equib_maoms, output_eqb_maoms)
 
@@ -172,15 +172,15 @@ def test_calculate_max_sorption_capacity(
             max_capacities = calculate_max_sorption_capacity(
                 dummy_carbon_data["bulk_density"],
                 np.array(alternative, dtype=np.float32),
-                SoilConsts().max_sorption_with_clay_slope,
-                SoilConsts().max_sorption_with_clay_intercept,
+                SoilConsts.max_sorption_with_clay_slope,
+                SoilConsts.max_sorption_with_clay_intercept,
             )
         else:
             max_capacities = calculate_max_sorption_capacity(
                 dummy_carbon_data["bulk_density"],
                 dummy_carbon_data["percent_clay"],
-                SoilConsts().max_sorption_with_clay_slope,
-                SoilConsts().max_sorption_with_clay_intercept,
+                SoilConsts.max_sorption_with_clay_slope,
+                SoilConsts.max_sorption_with_clay_intercept,
             )
 
         assert np.allclose(max_capacities, output_capacities)
@@ -196,8 +196,8 @@ def test_calculate_binding_coefficient(dummy_carbon_data):
 
     binding_coefs = calculate_binding_coefficient(
         dummy_carbon_data["pH"],
-        SoilConsts().binding_with_ph_slope,
-        SoilConsts().binding_with_ph_intercept,
+        SoilConsts.binding_with_ph_slope,
+        SoilConsts.binding_with_ph_intercept,
     )
 
     assert np.allclose(binding_coefs, output_coefs)
@@ -211,11 +211,11 @@ def test_convert_temperature_to_scalar(dummy_carbon_data, top_soil_layer_index):
 
     temp_scalar = convert_temperature_to_scalar(
         dummy_carbon_data["soil_temperature"][top_soil_layer_index],
-        SoilConsts().temp_scalar_coefficient_1,
-        SoilConsts().temp_scalar_coefficient_2,
-        SoilConsts().temp_scalar_coefficient_3,
-        SoilConsts().temp_scalar_coefficient_4,
-        SoilConsts().temp_scalar_reference_temp,
+        SoilConsts.temp_scalar_coefficient_1,
+        SoilConsts.temp_scalar_coefficient_2,
+        SoilConsts.temp_scalar_coefficient_3,
+        SoilConsts.temp_scalar_coefficient_4,
+        SoilConsts.temp_scalar_reference_temp,
     )
 
     assert np.allclose(temp_scalar, output_scalars)
@@ -256,14 +256,14 @@ def test_convert_moisture_to_scalar(
         if alternative:
             moist_scalar = convert_moisture_to_scalar(
                 np.array(alternative, dtype=np.float32),
-                SoilConsts().moisture_scalar_coefficient,
-                SoilConsts().moisture_scalar_exponent,
+                SoilConsts.moisture_scalar_coefficient,
+                SoilConsts.moisture_scalar_exponent,
             )
         else:
             moist_scalar = convert_moisture_to_scalar(
                 dummy_carbon_data["soil_moisture"][top_soil_layer_index],
-                SoilConsts().moisture_scalar_coefficient,
-                SoilConsts().moisture_scalar_exponent,
+                SoilConsts.moisture_scalar_coefficient,
+                SoilConsts.moisture_scalar_exponent,
             )
 
         assert np.allclose(moist_scalar, output_scalars)
@@ -280,7 +280,7 @@ def test_calculate_maintenance_respiration(dummy_carbon_data, moist_temp_scalars
     main_resps = calculate_maintenance_respiration(
         dummy_carbon_data["soil_c_pool_microbe"],
         moist_temp_scalars,
-        SoilConsts().microbial_turnover_rate,
+        SoilConsts.microbial_turnover_rate,
     )
 
     assert np.allclose(main_resps, expected_resps)
@@ -295,7 +295,7 @@ def test_calculate_necromass_adsorption(dummy_carbon_data, moist_temp_scalars):
     actual_adsorps = calculate_necromass_adsorption(
         dummy_carbon_data["soil_c_pool_microbe"],
         moist_temp_scalars,
-        SoilConsts().necromass_adsorption_rate,
+        SoilConsts.necromass_adsorption_rate,
     )
 
     assert np.allclose(actual_adsorps, expected_adsorps)
@@ -309,9 +309,9 @@ def test_calculate_carbon_use_efficiency(dummy_carbon_data, top_soil_layer_index
 
     actual_cues = calculate_carbon_use_efficiency(
         dummy_carbon_data["soil_temperature"][top_soil_layer_index],
-        SoilConsts().reference_cue,
-        SoilConsts().cue_reference_temp,
-        SoilConsts().cue_with_temperature,
+        SoilConsts.reference_cue,
+        SoilConsts.cue_reference_temp,
+        SoilConsts.cue_with_temperature,
     )
 
     assert np.allclose(actual_cues, expected_cues)
@@ -325,7 +325,7 @@ def test_calculate_microbial_saturation(dummy_carbon_data):
 
     actual_saturated = calculate_microbial_saturation(
         dummy_carbon_data["soil_c_pool_microbe"],
-        SoilConsts().half_sat_microbial_activity,
+        SoilConsts.half_sat_microbial_activity,
     )
 
     assert np.allclose(actual_saturated, expected_saturated)
@@ -341,7 +341,7 @@ def test_calculate_microbial_pom_mineralisation_saturation(dummy_carbon_data):
 
     actual_saturated = calculate_microbial_pom_mineralisation_saturation(
         dummy_carbon_data["soil_c_pool_microbe"],
-        SoilConsts().half_sat_microbial_pom_mineralisation,
+        SoilConsts.half_sat_microbial_pom_mineralisation,
     )
 
     assert np.allclose(actual_saturated, expected_saturated)
@@ -356,7 +356,7 @@ def test_calculate_pom_decomposition_saturation(dummy_carbon_data):
     expected_saturated = [0.4, 0.86956521, 0.82352941, 0.7]
 
     actual_saturated = calculate_pom_decomposition_saturation(
-        dummy_carbon_data["soil_c_pool_pom"], SoilConsts().half_sat_pom_decomposition
+        dummy_carbon_data["soil_c_pool_pom"], SoilConsts.half_sat_pom_decomposition
     )
 
     assert np.allclose(actual_saturated, expected_saturated)
@@ -375,7 +375,7 @@ def test_calculate_microbial_carbon_uptake(
         dummy_carbon_data["soil_c_pool_microbe"],
         moist_temp_scalars,
         dummy_carbon_data["soil_temperature"][top_soil_layer_index],
-        constants=SoilConsts(),
+        constants=SoilConsts,
     )
 
     assert np.allclose(actual_uptake, expected_uptake)
@@ -390,7 +390,7 @@ def test_calculate_labile_carbon_leaching(dummy_carbon_data, moist_temp_scalars)
     actual_leaching = calculate_labile_carbon_leaching(
         dummy_carbon_data["soil_c_pool_lmwc"],
         moist_temp_scalars,
-        SoilConsts().leaching_rate_labile_carbon,
+        SoilConsts.leaching_rate_labile_carbon,
     )
 
     assert np.allclose(actual_leaching, expected_leaching)
@@ -406,7 +406,7 @@ def test_calculate_pom_decomposition(dummy_carbon_data, moist_temp_scalars):
         dummy_carbon_data["soil_c_pool_pom"],
         dummy_carbon_data["soil_c_pool_microbe"],
         moist_temp_scalars,
-        constants=SoilConsts(),
+        constants=SoilConsts,
     )
 
     assert np.allclose(actual_decomp, expected_decomp)
@@ -419,11 +419,11 @@ def test_calculate_direct_litter_input_to_pools():
     )
 
     actual_input_lmwc, actual_input_pom = calculate_direct_litter_input_to_pools(
-        SoilConsts().carbon_input_to_pom, SoilConsts().litter_input_rate
+        SoilConsts.carbon_input_to_pom, SoilConsts.litter_input_rate
     )
 
     assert np.isclose(actual_input_lmwc, 0.00015697011)
     assert np.isclose(actual_input_pom, 0.00031394022)
     assert np.isclose(
-        actual_input_lmwc + actual_input_pom, SoilConsts().litter_input_rate
+        actual_input_lmwc + actual_input_pom, SoilConsts.litter_input_rate
     )

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -174,7 +174,7 @@ def test_soil_model_initialization(
                 )
             # Initialise model with bad data object
             model = SoilModel(
-                carbon_data, pint.Quantity("1 week"), 2, 10, constants=SoilConsts()
+                carbon_data, pint.Quantity("1 week"), 2, 10, constants=SoilConsts
             )
         else:
             model = SoilModel(
@@ -182,7 +182,7 @@ def test_soil_model_initialization(
                 pint.Quantity("1 week"),
                 2,
                 10,
-                constants=SoilConsts(),
+                constants=SoilConsts,
             )
 
         # In cases where it passes then checks that the object has the right properties
@@ -553,7 +553,7 @@ def test_construct_full_soil_model(dummy_carbon_data, top_soil_layer_index):
         4,
         top_soil_layer_index,
         delta_pools_ordered,
-        constants=SoilConsts(),
+        constants=SoilConsts,
     )
 
     assert np.allclose(delta_pools, rate_of_change)

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -12,6 +12,7 @@ from xarray import DataArray, Dataset
 
 from tests.conftest import log_check
 from virtual_rainforest.core.exceptions import InitialisationError
+from virtual_rainforest.models.soil.constants import SoilConsts
 from virtual_rainforest.models.soil.soil_model import IntegrationError, SoilModel
 
 
@@ -172,9 +173,17 @@ def test_soil_model_initialization(
                     [0.05, 0.02, 0.1, -0.005], dims=["cell_id"]
                 )
             # Initialise model with bad data object
-            model = SoilModel(carbon_data, pint.Quantity("1 week"), 2, 10)
+            model = SoilModel(
+                carbon_data, pint.Quantity("1 week"), 2, 10, constants=SoilConsts()
+            )
         else:
-            model = SoilModel(dummy_carbon_data, pint.Quantity("1 week"), 2, 10)
+            model = SoilModel(
+                dummy_carbon_data,
+                pint.Quantity("1 week"),
+                2,
+                10,
+                constants=SoilConsts(),
+            )
 
         # In cases where it passes then checks that the object has the right properties
         assert set(["setup", "spinup", "update", "cleanup", "integrate"]).issubset(
@@ -459,7 +468,13 @@ def test_construct_full_soil_model(dummy_carbon_data, top_soil_layer_index):
     }
 
     rate_of_change = construct_full_soil_model(
-        0.0, pools, dummy_carbon_data, 4, top_soil_layer_index, delta_pools_ordered
+        0.0,
+        pools,
+        dummy_carbon_data,
+        4,
+        top_soil_layer_index,
+        delta_pools_ordered,
+        constants=SoilConsts(),
     )
 
     assert np.allclose(delta_pools, rate_of_change)

--- a/virtual_rainforest/models/soil/carbon.py
+++ b/virtual_rainforest/models/soil/carbon.py
@@ -52,16 +52,16 @@ def calculate_soil_carbon_updates(
     # Find scalar factors that multiple rates
     temp_scalar = convert_temperature_to_scalar(
         soil_temp,
-        SoilConsts.temp_scalar_coefficient_1,
-        SoilConsts.temp_scalar_coefficient_2,
-        SoilConsts.temp_scalar_coefficient_3,
-        SoilConsts.temp_scalar_coefficient_4,
-        SoilConsts.temp_scalar_reference_temp,
+        constants.temp_scalar_coefficient_1,
+        constants.temp_scalar_coefficient_2,
+        constants.temp_scalar_coefficient_3,
+        constants.temp_scalar_coefficient_4,
+        constants.temp_scalar_reference_temp,
     )
     moist_scalar = convert_moisture_to_scalar(
         soil_moisture,
-        SoilConsts.moisture_scalar_coefficient,
-        SoilConsts.moisture_scalar_exponent,
+        constants.moisture_scalar_coefficient,
+        constants.moisture_scalar_exponent,
     )
     moist_temp_scalar = moist_scalar * temp_scalar
 
@@ -79,16 +79,16 @@ def calculate_soil_carbon_updates(
         soil_c_pool_lmwc, soil_c_pool_microbe, moist_temp_scalar, soil_temp, constants
     )
     microbial_respiration = calculate_maintenance_respiration(
-        soil_c_pool_microbe, moist_temp_scalar, SoilConsts.microbial_turnover_rate
+        soil_c_pool_microbe, moist_temp_scalar, constants.microbial_turnover_rate
     )
     necromass_adsorption = calculate_necromass_adsorption(
-        soil_c_pool_microbe, moist_temp_scalar, SoilConsts.necromass_adsorption_rate
+        soil_c_pool_microbe, moist_temp_scalar, constants.necromass_adsorption_rate
     )
     labile_carbon_leaching = calculate_labile_carbon_leaching(
-        soil_c_pool_lmwc, moist_temp_scalar, SoilConsts.leaching_rate_labile_carbon
+        soil_c_pool_lmwc, moist_temp_scalar, constants.leaching_rate_labile_carbon
     )
     litter_input_to_lmwc, litter_input_to_pom = calculate_direct_litter_input_to_pools(
-        SoilConsts.carbon_input_to_pom, SoilConsts.litter_input_rate
+        constants.carbon_input_to_pom, constants.litter_input_rate
     )
     pom_decomposition_to_lmwc = calculate_pom_decomposition(
         soil_c_pool_pom, soil_c_pool_microbe, moist_temp_scalar, constants

--- a/virtual_rainforest/models/soil/carbon.py
+++ b/virtual_rainforest/models/soil/carbon.py
@@ -8,23 +8,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from virtual_rainforest.core.logger import LOGGER
-from virtual_rainforest.models.soil.constants import (
-    CARBON_INPUT_TO_POM,
-    HALF_SAT_MICROBIAL_ACTIVITY,
-    HALF_SAT_MICROBIAL_POM_MINERALISATION,
-    HALF_SAT_POM_DECOMPOSITION,
-    LEACHING_RATE_LABILE_CARBON,
-    LITTER_INPUT_RATE,
-    MAX_DECOMP_RATE_POM,
-    MAX_UPTAKE_RATE_LABILE_C,
-    MICROBIAL_TURNOVER_RATE,
-    NECROMASS_ADSORPTION_RATE,
-    BindingWithPH,
-    CarbonUseEfficiency,
-    MaxSorptionWithClay,
-    MoistureScalar,
-    TempScalar,
-)
+from virtual_rainforest.models.soil.constants import SoilConsts
 
 
 def calculate_soil_carbon_updates(
@@ -38,6 +22,7 @@ def calculate_soil_carbon_updates(
     soil_temp: NDArray[np.float32],
     percent_clay: NDArray[np.float32],
     delta_pools_ordered: dict[str, NDArray[np.float32]],
+    constants: SoilConsts,
 ) -> NDArray[np.float32]:
     """Calculate net change for each carbon pool.
 
@@ -57,6 +42,7 @@ def calculate_soil_carbon_updates(
         percent_clay: Percentage clay for each soil grid cell
         delta_pools_ordered: Dictionary to store pool changes in the order that pools
             are stored in the initial condition vector.
+        constants: Set of constants for the soil model.
 
     Returns:
         A vector containing net changes to each pool. Order [lmwc, maom].
@@ -64,8 +50,19 @@ def calculate_soil_carbon_updates(
     # TODO - Add interactions which involve the three missing carbon pools
 
     # Find scalar factors that multiple rates
-    temp_scalar = convert_temperature_to_scalar(soil_temp)
-    moist_scalar = convert_moisture_to_scalar(soil_moisture)
+    temp_scalar = convert_temperature_to_scalar(
+        soil_temp,
+        SoilConsts.temp_scalar_coefficient_1,
+        SoilConsts.temp_scalar_coefficient_2,
+        SoilConsts.temp_scalar_coefficient_3,
+        SoilConsts.temp_scalar_coefficient_4,
+        SoilConsts.temp_scalar_reference_temp,
+    )
+    moist_scalar = convert_moisture_to_scalar(
+        soil_moisture,
+        SoilConsts.moisture_scalar_coefficient,
+        SoilConsts.moisture_scalar_exponent,
+    )
     moist_temp_scalar = moist_scalar * temp_scalar
 
     # Calculate transfers between pools
@@ -76,22 +73,25 @@ def calculate_soil_carbon_updates(
         bulk_density,
         moist_temp_scalar,
         percent_clay,
+        constants,
     )
     microbial_uptake = calculate_microbial_carbon_uptake(
-        soil_c_pool_lmwc, soil_c_pool_microbe, moist_temp_scalar, soil_temp
+        soil_c_pool_lmwc, soil_c_pool_microbe, moist_temp_scalar, soil_temp, constants
     )
     microbial_respiration = calculate_maintenance_respiration(
-        soil_c_pool_microbe, moist_temp_scalar
+        soil_c_pool_microbe, moist_temp_scalar, SoilConsts.microbial_turnover_rate
     )
     necromass_adsorption = calculate_necromass_adsorption(
-        soil_c_pool_microbe, moist_temp_scalar
+        soil_c_pool_microbe, moist_temp_scalar, SoilConsts.necromass_adsorption_rate
     )
     labile_carbon_leaching = calculate_labile_carbon_leaching(
-        soil_c_pool_lmwc, moist_temp_scalar
+        soil_c_pool_lmwc, moist_temp_scalar, SoilConsts.leaching_rate_labile_carbon
     )
-    litter_input_to_lmwc, litter_input_to_pom = calculate_direct_litter_input_to_pools()
+    litter_input_to_lmwc, litter_input_to_pom = calculate_direct_litter_input_to_pools(
+        SoilConsts.carbon_input_to_pom, SoilConsts.litter_input_rate
+    )
     pom_decomposition_to_lmwc = calculate_pom_decomposition(
-        soil_c_pool_pom, soil_c_pool_microbe, moist_temp_scalar
+        soil_c_pool_pom, soil_c_pool_microbe, moist_temp_scalar, constants
     )
 
     # Determine net changes to the pools
@@ -121,6 +121,7 @@ def calculate_mineral_association(
     bulk_density: NDArray[np.float32],
     moist_temp_scalar: NDArray[np.float32],
     percent_clay: NDArray[np.float32],
+    constants: SoilConsts,
 ) -> NDArray[np.float32]:
     """Calculates net rate of LMWC association with soil minerals.
 
@@ -139,14 +140,20 @@ def calculate_mineral_association(
         moist_temp_scalar: A scalar capturing the combined impact of soil moisture and
             temperature on process rates
         percent_clay: Percentage clay for each soil grid cell
+        constants: Set of constants for the soil model.
 
     Returns:
         The net flux from LMWC to MAOM [kg C m^-3 day^-1]
     """
 
-    # Calculate
-    Q_max = calculate_max_sorption_capacity(bulk_density, percent_clay)
-    equib_maom = calculate_equilibrium_maom(pH, Q_max, soil_c_pool_lmwc)
+    # Calculate maximum sorption
+    Q_max = calculate_max_sorption_capacity(
+        bulk_density,
+        percent_clay,
+        constants.max_sorption_with_clay_slope,
+        constants.max_sorption_with_clay_intercept,
+    )
+    equib_maom = calculate_equilibrium_maom(pH, Q_max, soil_c_pool_lmwc, constants)
 
     return (
         moist_temp_scalar * soil_c_pool_lmwc * (equib_maom - soil_c_pool_maom) / Q_max
@@ -156,7 +163,8 @@ def calculate_mineral_association(
 def calculate_max_sorption_capacity(
     bulk_density: NDArray[np.float32],
     percent_clay: NDArray[np.float32],
-    coef: MaxSorptionWithClay = MaxSorptionWithClay(),
+    max_sorption_with_clay_slope: float,
+    max_sorption_with_clay_intercept: float,
 ) -> NDArray[np.float32]:
     """Calculate maximum sorption capacity based on bulk density and clay content.
 
@@ -168,6 +176,10 @@ def calculate_max_sorption_capacity(
     Args:
         bulk_density: bulk density values for each soil grid cell [kg m^-3]
         percent_clay: Percentage clay for each soil grid cell
+        max_sorption_with_clay_slope: Slope of relationship between clay content and
+            maximum organic matter sorption [(% clay)^-1]
+        max_sorption_with_clay_intercept: Intercept of relationship between clay content
+            and maximum organic matter sorption [log(kg C kg soil ^-1)]
 
     Returns:
         Maximum sorption capacity [kg C m^-3]
@@ -181,7 +193,10 @@ def calculate_max_sorption_capacity(
         LOGGER.error(to_raise)
         raise to_raise
 
-    Q_max = bulk_density * 10 ** (coef.slope * np.log10(percent_clay) + coef.intercept)
+    Q_max = bulk_density * 10 ** (
+        max_sorption_with_clay_slope * np.log10(percent_clay)
+        + max_sorption_with_clay_intercept
+    )
     return Q_max
 
 
@@ -189,6 +204,7 @@ def calculate_equilibrium_maom(
     pH: NDArray[np.float32],
     Q_max: NDArray[np.float32],
     lmwc: NDArray[np.float32],
+    constants: SoilConsts,
 ) -> NDArray[np.float32]:
     """Calculate equilibrium MAOM concentration based on Langmuir coefficients.
 
@@ -200,17 +216,22 @@ def calculate_equilibrium_maom(
         pH: pH values for each soil grid cell
         Q_max: Maximum sorption capacities [kg C m^-3]
         lmwc: Low molecular weight carbon pool [kg C m^-3]
+        constants: Set of constants for the soil model.
 
     Returns:
         Equilibrium concentration of MAOM [kg C m^-3]
     """
 
-    binding_coefficient = calculate_binding_coefficient(pH)
+    binding_coefficient = calculate_binding_coefficient(
+        pH, constants.binding_with_ph_slope, constants.binding_with_ph_intercept
+    )
     return (binding_coefficient * Q_max * lmwc) / (1 + lmwc * binding_coefficient)
 
 
 def calculate_binding_coefficient(
-    pH: NDArray[np.float32], coef: BindingWithPH = BindingWithPH()
+    pH: NDArray[np.float32],
+    binding_with_ph_slope: float,
+    binding_with_ph_intercept: float,
 ) -> NDArray[np.float32]:
     """Calculate Langmuir binding coefficient based on pH.
 
@@ -219,17 +240,26 @@ def calculate_binding_coefficient(
 
     Args:
         pH: pH values for each soil grid cell
+        binding_with_ph_slope: Slope of relationship between pH and binding coefficient
+            [pH^-1]
+        binding_with_ph_intercept: Intercept of relationship between pH and binding
+            coefficient [log(m^3 kg^-1)]
 
     Returns:
         Langmuir binding coefficients for mineral association of labile carbon [m^3
         kg^-1]
     """
 
-    return 10.0 ** (coef.slope * pH + coef.intercept)
+    return 10.0 ** (binding_with_ph_slope * pH + binding_with_ph_intercept)
 
 
 def convert_temperature_to_scalar(
-    soil_temp: NDArray[np.float32], coef: TempScalar = TempScalar()
+    soil_temp: NDArray[np.float32],
+    temp_scalar_coefficient_1: float,
+    temp_scalar_coefficient_2: float,
+    temp_scalar_coefficient_3: float,
+    temp_scalar_coefficient_4: float,
+    temp_scalar_reference_temp: float,
 ) -> NDArray[np.float32]:
     """Convert soil temperature into a factor to multiply rates by.
 
@@ -239,18 +269,29 @@ def convert_temperature_to_scalar(
     needed.
 
     Args:
-       soil_temp: soil temperature for each soil grid cell [degrees C]
+        soil_temp: soil temperature for each soil grid cell [degrees C]
+        temp_scalar_coefficient_1: Unclear exactly what this parameter is [degrees C]
+        temp_scalar_coefficient_2: Unclear exactly what this parameter is [unclear]
+        temp_scalar_coefficient_3: Unclear exactly what this parameter is [unclear]
+        temp_scalar_coefficient_4: Unclear exactly what this parameter is [unclear]
+        temp_scalar_reference_temp: Reference temperature for temperature scalar
+            [degrees C]
 
     Returns:
         A scalar that captures the impact of soil temperature on process rates
     """
 
     # This expression is drawn from Abramoff et al. (2018)
-    numerator = coef.t_2 + (coef.t_3 / np.pi) * np.arctan(
-        np.pi * (soil_temp - coef.t_1)
-    )
-    denominator = coef.t_2 + (coef.t_3 / np.pi) * np.arctan(
-        np.pi * coef.t_4 * (coef.ref_temp - coef.t_1)
+    numerator = temp_scalar_coefficient_2 + (
+        temp_scalar_coefficient_3 / np.pi
+    ) * np.arctan(np.pi * (soil_temp - temp_scalar_coefficient_1))
+
+    denominator = temp_scalar_coefficient_2 + (
+        temp_scalar_coefficient_3 / np.pi
+    ) * np.arctan(
+        np.pi
+        * temp_scalar_coefficient_4
+        * (temp_scalar_reference_temp - temp_scalar_coefficient_1)
     )
 
     return np.divide(numerator, denominator)
@@ -258,7 +299,8 @@ def convert_temperature_to_scalar(
 
 def convert_moisture_to_scalar(
     soil_moisture: NDArray[np.float32],
-    coef: MoistureScalar = MoistureScalar(),
+    moisture_scalar_coefficient: float,
+    moisture_scalar_exponent: float,
 ) -> NDArray[np.float32]:
     """Convert soil moisture into a factor to multiply rates by.
 
@@ -268,7 +310,9 @@ def convert_moisture_to_scalar(
     needed.
 
     Args:
-        soil_moisture: relative water content for each soil grid cell (unitless)
+        soil_moisture: relative water content for each soil grid cell [unitless]
+        moisture_scalar_coefficient: [unit less]
+        moisture_scalar_exponent: [(Relative water content)^-1]
 
     Returns:
         A scalar that captures the impact of soil moisture on process rates
@@ -282,13 +326,17 @@ def convert_moisture_to_scalar(
         raise to_raise
 
     # This expression is drawn from Abramoff et al. (2018)
-    return 1 / (1 + coef.coefficient * np.exp(-coef.exponent * soil_moisture))
+    return 1 / (
+        1
+        + moisture_scalar_coefficient
+        * np.exp(-moisture_scalar_exponent * soil_moisture)
+    )
 
 
 def calculate_maintenance_respiration(
     soil_c_pool_microbe: NDArray[np.float32],
     moist_temp_scalar: NDArray[np.float32],
-    microbial_turnover_rate: float = MICROBIAL_TURNOVER_RATE,
+    microbial_turnover_rate: float,
 ) -> NDArray[np.float32]:
     """Calculate the maintenance respiration of the microbial pool.
 
@@ -308,7 +356,7 @@ def calculate_maintenance_respiration(
 def calculate_necromass_adsorption(
     soil_c_pool_microbe: NDArray[np.float32],
     moist_temp_scalar: NDArray[np.float32],
-    necromass_adsorption_rate: float = NECROMASS_ADSORPTION_RATE,
+    necromass_adsorption_rate: float,
 ) -> NDArray[np.float32]:
     """Calculate adsorption of microbial necromass to soil minerals.
 
@@ -326,25 +374,30 @@ def calculate_necromass_adsorption(
 
 
 def calculate_carbon_use_efficiency(
-    soil_temp: NDArray[np.float32], paras: CarbonUseEfficiency = CarbonUseEfficiency()
+    soil_temp: NDArray[np.float32],
+    reference_cue: float,
+    cue_reference_temp: float,
+    cue_with_temperature: float,
 ) -> NDArray[np.float32]:
     """Calculate the (temperature dependant) carbon use efficiency.
 
     Args:
-       soil_temp: soil temperature for each soil grid cell [degrees C]
+        soil_temp: soil temperature for each soil grid cell [degrees C]
+        reference_cue: Carbon use efficiency at reference temp [unitless]
+        cue_reference_temp: Reference temperature [degrees C]
+        cue_with_temperature: Rate of change in carbon use efficiency with increasing
+            temperature [degree C^-1]
 
     Returns:
         The carbon use efficiency (CUE) of the microbial community
     """
 
-    return paras.reference_cue - paras.cue_with_temperature * (
-        soil_temp - paras.reference_temp
-    )
+    return reference_cue - cue_with_temperature * (soil_temp - cue_reference_temp)
 
 
 def calculate_microbial_saturation(
     soil_c_pool_microbe: NDArray[np.float32],
-    half_sat_microbial_activity: float = HALF_SAT_MICROBIAL_ACTIVITY,
+    half_sat_microbial_activity: float,
 ) -> NDArray[np.float32]:
     """Calculate microbial activity saturation.
 
@@ -366,7 +419,7 @@ def calculate_microbial_saturation(
 
 def calculate_microbial_pom_mineralisation_saturation(
     soil_c_pool_microbe: NDArray[np.float32],
-    half_sat_microbial_mineralisation: float = HALF_SAT_MICROBIAL_POM_MINERALISATION,
+    half_sat_microbial_mineralisation: float,
 ) -> NDArray[np.float32]:
     """Calculate microbial POM mineralisation saturation (with increasing biomass).
 
@@ -395,7 +448,7 @@ def calculate_microbial_pom_mineralisation_saturation(
 
 def calculate_pom_decomposition_saturation(
     soil_c_pool_pom: NDArray[np.float32],
-    half_sat_pom_decomposition: float = HALF_SAT_POM_DECOMPOSITION,
+    half_sat_pom_decomposition: float,
 ) -> NDArray[np.float32]:
     """Calculate particulate organic matter (POM) decomposition saturation.
 
@@ -419,7 +472,7 @@ def calculate_microbial_carbon_uptake(
     soil_c_pool_microbe: NDArray[np.float32],
     moist_temp_scalar: NDArray[np.float32],
     soil_temp: NDArray[np.float32],
-    max_uptake_rate: float = MAX_UPTAKE_RATE_LABILE_C,
+    constants: SoilConsts,
 ) -> NDArray[np.float32]:
     """Calculate amount of labile carbon taken up by microbes.
 
@@ -429,23 +482,29 @@ def calculate_microbial_carbon_uptake(
         moist_temp_scalar: A scalar capturing the combined impact of soil moisture and
             temperature on process rates
         soil_temp: soil temperature for each soil grid cell [degrees C]
-        max_uptake_rate: Maximum rate at which microbes can uptake labile carbon
-            [day^-1]
+        constants: Set of constants for the soil model.
 
     Returns:
         Uptake of low molecular weight carbon (LMWC) by the soil microbial biomass.
     """
 
     # Calculate carbon use efficiency and microbial saturation
-    carbon_use_efficency = calculate_carbon_use_efficiency(soil_temp)
-    microbial_saturation = calculate_microbial_saturation(soil_c_pool_microbe)
+    carbon_use_efficency = calculate_carbon_use_efficiency(
+        soil_temp,
+        constants.reference_cue,
+        constants.cue_reference_temp,
+        constants.cue_with_temperature,
+    )
+    microbial_saturation = calculate_microbial_saturation(
+        soil_c_pool_microbe, constants.half_sat_microbial_activity
+    )
 
     # TODO - the quantities calculated above can be used to calculate the carbon
     # respired instead of being uptaken. This isn't currently of interest, but will be
     # in future
 
     return (
-        max_uptake_rate
+        constants.max_uptake_rate_labile_C
         * moist_temp_scalar
         * soil_c_pool_lmwc
         * microbial_saturation
@@ -456,7 +515,7 @@ def calculate_microbial_carbon_uptake(
 def calculate_labile_carbon_leaching(
     soil_c_pool_lmwc: NDArray[np.float32],
     moist_temp_scalar: NDArray[np.float32],
-    leaching_rate: float = LEACHING_RATE_LABILE_CARBON,
+    leaching_rate: float,
 ) -> NDArray[np.float32]:
     """Calculate rate at which labile carbon is leached.
 
@@ -480,7 +539,7 @@ def calculate_pom_decomposition(
     soil_c_pool_pom: NDArray[np.float32],
     soil_c_pool_microbe: NDArray[np.float32],
     moist_temp_scalar: NDArray[np.float32],
-    max_pom_decomp_rate: float = MAX_DECOMP_RATE_POM,
+    constants: SoilConsts,
 ) -> NDArray[np.float32]:
     """Calculate decomposition of particulate organic matter into labile carbon (LMWC).
 
@@ -492,6 +551,7 @@ def calculate_pom_decomposition(
         soil_c_pool_microbe: Microbial biomass (carbon) pool [kg C m^-3]
         moist_temp_scalar: A scalar capturing the combined impact of soil moisture and
             temperature on process rates
+        constants: Set of constants for the soil model.
 
     Returns:
         The amount of particulate organic matter (POM) decomposed into labile carbon
@@ -500,12 +560,14 @@ def calculate_pom_decomposition(
 
     # Calculate the two relevant saturations
     saturation_with_biomass = calculate_microbial_pom_mineralisation_saturation(
-        soil_c_pool_microbe
+        soil_c_pool_microbe, constants.half_sat_microbial_pom_mineralisation
     )
-    saturation_with_pom = calculate_pom_decomposition_saturation(soil_c_pool_pom)
+    saturation_with_pom = calculate_pom_decomposition_saturation(
+        soil_c_pool_pom, constants.half_sat_pom_decomposition
+    )
 
     return (
-        max_pom_decomp_rate
+        constants.max_decomp_rate_pom
         * saturation_with_pom
         * saturation_with_biomass
         * moist_temp_scalar
@@ -513,8 +575,8 @@ def calculate_pom_decomposition(
 
 
 def calculate_direct_litter_input_to_pools(
-    carbon_input_to_pom: float = CARBON_INPUT_TO_POM,
-    litter_input_rate: float = LITTER_INPUT_RATE,
+    carbon_input_to_pom: float,
+    litter_input_rate: float,
 ) -> tuple[float, float]:
     """Calculate direct input from litter to LMWC and POM pools.
 

--- a/virtual_rainforest/models/soil/constants.py
+++ b/virtual_rainforest/models/soil/constants.py
@@ -7,6 +7,9 @@ from dataclasses import dataclass
 
 # TODO - Need to figure out a sensible area to volume conversion
 
+# TODO - Need to either work out what the temp and moisture scalars are, or find an
+# alternative way of capturing temperature and moisture effects
+
 
 @dataclass(frozen=True)
 class SoilConsts:

--- a/virtual_rainforest/models/soil/constants.py
+++ b/virtual_rainforest/models/soil/constants.py
@@ -20,7 +20,6 @@ class SoilConsts:
 
     Unit of [log(m^3 kg^-1)]. n.b. +3 converts from mg^-1 to kg^-1 and L to m^3
     """
-    """From linear regression :cite:p:`mayes_relation_2012`."""
 
     max_sorption_with_clay_slope: float = 0.483
     """From linear regression :cite:p:`mayes_relation_2012`. Units of [(% clay)^-1]."""

--- a/virtual_rainforest/models/soil/constants.py
+++ b/virtual_rainforest/models/soil/constants.py
@@ -4,117 +4,141 @@ constants" (fitting relationships taken from the literature) required by the bro
 """  # noqa: D205, D415
 
 from dataclasses import dataclass
-from typing import Final
 
 # TODO - Need to figure out a sensible area to volume conversion
 
 
 @dataclass(frozen=True)
-class BindingWithPH:
+class SoilConsts:
+    """Dataclass to store all constants for the `abiotic_simple` model."""
+
+    binding_with_ph_slope: float = -0.186
+    """Units of [pH^-1]. From linear regression :cite:p:`mayes_relation_2012`."""
+
+    binding_with_ph_intercept: float = -0.216 + 3.0
+    """From linear regression :cite:p:`mayes_relation_2012`.
+
+    Unit of [log(m^3 kg^-1)]. n.b. +3 converts from mg^-1 to kg^-1 and L to m^3
+    """
     """From linear regression :cite:p:`mayes_relation_2012`."""
 
-    slope: float = -0.186
-    """Units of pH^-1."""
-    intercept: float = -0.216 + 3.0
-    """Unit of log(m^3 kg^-1). n.b. +3 converts from mg^-1 to kg^-1 and L to m^3"""
+    max_sorption_with_clay_slope: float = 0.483
+    """From linear regression :cite:p:`mayes_relation_2012`. Units of [(% clay)^-1]."""
 
+    max_sorption_with_clay_intercept: float = 2.328 - 6.0
+    """From linear regression :cite:p:`mayes_relation_2012`.
 
-@dataclass(frozen=True)
-class MaxSorptionWithClay:
-    """From linear regression :cite:p:`mayes_relation_2012`."""
-
-    slope: float = 0.483
-    """Units of (% clay)^-1."""
-    intercept: float = 2.328 - 6.0
-    """Unit of log(kg C kg soil ^-1). n.b. -6 converts from mg to kg"""
-
-
-@dataclass(frozen=True)
-class MoistureScalar:
-    """Used in :cite:t:`abramoff_millennial_2018`, can't find original source."""
-
-    coefficient: float = 30.0
-    """Value at zero relative water content (RWC) [unit less]."""
-    exponent: float = 9.0
-    """Units of (RWC)^-1"""
-
-
-@dataclass(frozen=True)
-class TempScalar:
-    """Used in :cite:t:`abramoff_millennial_2018`, can't find original source."""
-
-    t_1: float = 15.4
-    """Unclear exactly what this parameter is [degrees C]"""
-    t_2: float = 11.75
-    """Unclear exactly what this parameter is [units unclear]"""
-    t_3: float = 29.7
-    """Unclear exactly what this parameter is [units unclear]"""
-    t_4: float = 0.031
-    """Unclear exactly what this parameter is [units unclear]"""
-    ref_temp: float = 30.0
-    """Reference temperature [degrees C]"""
-
-
-@dataclass(frozen=True)
-class CarbonUseEfficiency:
-    """Collection of carbon use efficiency parameters.
-
-    Taken from :cite:t:`abramoff_millennial_2018`, more investigation required in future
+    Unit of [log(kg C kg soil ^-1)]. n.b. -6 converts from mg to kg
     """
 
-    reference_cue = 0.6
-    """Carbon use efficiency of community at the reference temperature [no units]"""
-    reference_temp = 15.0
-    """Reference temperature [degrees C]"""
-    cue_with_temperature = 0.012
-    """Change in carbon use efficiency with increasing temperature [degree C^-1]."""
+    moisture_scalar_coefficient: float = 30.0
+    """Used in :cite:t:`abramoff_millennial_2018`, can't find original source.
 
+    Value at zero relative water content (RWC) [unit less].
+    """
 
-MICROBIAL_TURNOVER_RATE: Final[float] = 0.036
-"""Microbial turnover rate [day^-1], this isn't a constant but often treated as one."""
+    moisture_scalar_exponent: float = 9.0
+    """Used in :cite:t:`abramoff_millennial_2018`, can't find original source.
 
-MAX_UPTAKE_RATE_LABILE_C: Final[float] = 0.35
-"""Maximum (theoretical) rate at which microbes can take up labile carbon [day^-1]."""
+    Units of [(RWC)^-1]
+    """
 
-NECROMASS_ADSORPTION_RATE: Final[float] = 0.025
-"""Rate at which necromass is adsorbed by soil minerals [day^-1].
+    temp_scalar_coefficient_1: float = 15.4
+    """Used in :cite:t:`abramoff_millennial_2018`, can't find original source.
 
-Taken from :cite:t:`abramoff_millennial_2018`, where it was obtained by calibration.
-"""
+    Unclear exactly what this parameter is [degrees C]
+    """
 
-HALF_SAT_MICROBIAL_ACTIVITY: Final[float] = 0.0072
-"""Half saturation constant for microbial activity (with increasing biomass)[kg C m^-2].
-"""
+    temp_scalar_coefficient_2: float = 11.75
+    """Used in :cite:t:`abramoff_millennial_2018`, can't find original source.
 
-HALF_SAT_MICROBIAL_POM_MINERALISATION: Final[float] = 0.012
-"""Half saturation constant for microbial POM mineralisation [kg C m^-2]."""
+    Unclear exactly what this parameter is [units unclear]
+    """
 
-MAX_DECOMP_RATE_POM: Final[float] = 0.01
-"""Maximum (theoretical) rate at which particulate organic matter can be broken down.
+    temp_scalar_coefficient_3: float = 29.7
+    """Used in :cite:t:`abramoff_millennial_2018`, can't find original source.
 
-Units of [kg C m^-2 day^-1]. Taken from :cite:t:`abramoff_millennial_2018`, where it was
-obtained by calibration.
-"""
+    Unclear exactly what this parameter is [units unclear]
+    """
 
-LEACHING_RATE_LABILE_CARBON: Final[float] = 1.5e-3
-"""Leaching rate for labile carbon (lmwc) [day^-1]."""
+    temp_scalar_coefficient_4: float = 0.031
+    """Used in :cite:t:`abramoff_millennial_2018`, can't find original source.
 
-CARBON_INPUT_TO_POM: Final[float] = 2.0 / 3.0
-"""Proportion of carbon input that becomes particulate organic matter (POM) [unitless].
+    Unclear exactly what this parameter is [units unclear]
+    """
 
-Taken from :cite:t:`abramoff_millennial_2018`, this is justified there based on previous
-empirical work. However, this is something we will definitely completely alter down the
-line so no need to worry too much about references.
-"""
+    temp_scalar_reference_temp: float = 30.0
+    """Used in :cite:t:`abramoff_millennial_2018`, can't find original source.
 
-HALF_SAT_POM_DECOMPOSITION: Final[float] = 0.150
-"""Half saturation constant for POM decomposition to LMWC [kg C m^-2].
-"""
+    Reference temperature [degrees C]
+    """
 
-LITTER_INPUT_RATE: Final[float] = 0.172 / 365.25
-"""Rate of litter input to the system [kg C m^-2 day^-1].
+    reference_cue: float = 0.6
+    """Carbon use efficiency of community at the reference temperature [no units].
 
-This definitely is not a constant for our purposes. However,
-:cite:t:`abramoff_millennial_2018` use a constant litter input rate, so we shall also
-use one initially.
-"""
+    Default value taken from :cite:t:`abramoff_millennial_2018`.
+    """
+
+    cue_reference_temp: float = 15.0
+    """Reference temperature for carbon use efficiency [degrees C].
+
+    Default value taken from :cite:t:`abramoff_millennial_2018`.
+    """
+
+    cue_with_temperature: float = 0.012
+    """Change in carbon use efficiency with increasing temperature [degree C^-1].
+
+    Default value taken from :cite:t:`abramoff_millennial_2018`.
+    """
+
+    microbial_turnover_rate: float = 0.036
+    """Microbial turnover rate [day^-1], this isn't a constant but often treated as one.
+    """
+
+    max_uptake_rate_labile_C: float = 0.35
+    """Maximum (theoretical) rate at which microbes can take up labile carbon [day^-1].
+    """
+
+    necromass_adsorption_rate: float = 0.025
+    """Rate at which necromass is adsorbed by soil minerals [day^-1].
+
+    Taken from :cite:t:`abramoff_millennial_2018`, where it was obtained by calibration.
+    """
+
+    half_sat_microbial_activity: float = 0.0072
+    """Half saturation constant for microbial activity (with increasing biomass).
+
+    Units of [kg C m^-2].
+    """
+
+    half_sat_microbial_pom_mineralisation: float = 0.012
+    """Half saturation constant for microbial POM mineralisation [kg C m^-2]."""
+
+    max_decomp_rate_pom: float = 0.01
+    """Maximum (theoretical) rate for particulate organic matter break down.
+
+    Units of [kg C m^-2 day^-1]. Taken from :cite:t:`abramoff_millennial_2018`, where it
+    was obtained by calibration.
+    """
+
+    leaching_rate_labile_carbon: float = 1.5e-3
+    """Leaching rate for labile carbon (lmwc) [day^-1]."""
+
+    carbon_input_to_pom: float = 2.0 / 3.0
+    """Proportion of carbon input that becomes particulate organic matter (POM).
+
+    [unitless]. Taken from :cite:t:`abramoff_millennial_2018`, this is justified there
+    based on previous empirical work. However, this is something we will definitely
+    completely alter down the line so no need to worry too much about references.
+    """
+
+    half_sat_pom_decomposition: float = 0.150
+    """Half saturation constant for POM decomposition to LMWC [kg C m^-2]."""
+
+    litter_input_rate: float = 0.172 / 365.25
+    """Rate of litter input to the system [kg C m^-2 day^-1].
+
+    This definitely is not a constant for our purposes. However,
+    :cite:t:`abramoff_millennial_2018` use a constant litter input rate, so we shall
+    also use one initially.
+    """

--- a/virtual_rainforest/models/soil/constants.py
+++ b/virtual_rainforest/models/soil/constants.py
@@ -10,24 +10,35 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class SoilConsts:
-    """Dataclass to store all constants for the `soil` model."""
+    """Dataclass to store all constants for the `soil` model.
+
+    All constants are taken from :cite:t:`abramoff_millennial_2018` unless otherwise
+    stated.
+    """
 
     binding_with_ph_slope: float = -0.186
-    """Units of [pH^-1]. From linear regression :cite:p:`mayes_relation_2012`."""
+    """Change in the binding affinity of soil mineral with pH.
+
+    Units of [pH^-1]. From linear regression :cite:p:`mayes_relation_2012`."""
 
     binding_with_ph_intercept: float = -0.216 + 3.0
-    """From linear regression :cite:p:`mayes_relation_2012`.
+    """Binding affinity of soil minerals at zero pH.
 
-    Unit of [log(m^3 kg^-1)]. n.b. +3 converts from mg^-1 to kg^-1 and L to m^3
+    Unit of [log(m^3 kg^-1)]. n.b. +3 converts from mg^-1 to kg^-1 and L to m^3. From
+    linear regression :cite:p:`mayes_relation_2012`.
     """
 
     max_sorption_with_clay_slope: float = 0.483
-    """From linear regression :cite:p:`mayes_relation_2012`. Units of [(% clay)^-1]."""
+    """Change in the maximum size of the MAOM pool with increasing clay content.
+
+    Units of [(% clay)^-1]. From linear regression :cite:p:`mayes_relation_2012`.
+    """
 
     max_sorption_with_clay_intercept: float = 2.328 - 6.0
-    """From linear regression :cite:p:`mayes_relation_2012`.
+    """Maximum size of the MAOM pool at zero clay content.
 
-    Unit of [log(kg C kg soil ^-1)]. n.b. -6 converts from mg to kg
+    Unit of [log(kg C kg soil ^-1)]. n.b. -6 converts from mg to kg. From linear
+    regression :cite:p:`mayes_relation_2012`.
     """
 
     moisture_scalar_coefficient: float = 30.0

--- a/virtual_rainforest/models/soil/constants.py
+++ b/virtual_rainforest/models/soil/constants.py
@@ -1,5 +1,5 @@
 """The ``models.soil.constants`` module contains a set of dataclasses containing
-constants" (fitting relationships taken from the literature) required by the broader
+constants (fitting relationships taken from the literature) required by the broader
 :mod:`~virtual_rainforest.models.soil` module
 """  # noqa: D205, D415
 

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -49,7 +49,6 @@ class SoilModel(BaseModel):
 
     Args:
         data: The data object to be used in the model.
-        start_time: A datetime64 value setting the start time of the model.
         update_interval: Time to wait between updates of the model state.
         soil_layers: The number of soil layers to be modelled.
         canopy_layers: The number of canopy layers to be modelled.

--- a/virtual_rainforest/models/soil/soil_schema.json
+++ b/virtual_rainforest/models/soil/soil_schema.json
@@ -4,7 +4,20 @@
       "soil": {
          "description": "Configuration settings for the soil module",
          "type": "object",
-         "properties": {},
+         "properties": {
+            "constants": {
+               "description": "Constants for the soil module",
+               "type": "object",
+               "properties": {
+                  "SoilConsts": {
+                     "type": "object"
+                  }
+               },
+               "required": [
+                  "SoilConsts"
+               ]
+            }
+         },
          "default": {},
          "required": []
       }


### PR DESCRIPTION
# Description

This PR changes puts all the soil constants into a single data class which is then stored as an attribute of the soil model. This follows the new system for constants, that has so far only be applied to the `abiotic_simple` and `hydrology` models.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
