### PR TITLE
Feature/add streamflow

### DIFF
--- a/docs/source/data_recipes/ERA5_preprocessing_example.md
+++ b/docs/source/data_recipes/ERA5_preprocessing_example.md
@@ -95,10 +95,12 @@ dataset["rh2m"] = (
 ### 4. Convert precipitation units
 
 The standard output unit for total precipitation in ERA5-Land is meters which we need to
-convert to millimeters.
+convert to millimeters. Further, the data represents mean daily accumulated
+precipitation for the 9x9km grid box, so the value has to be scaled to monthly (here 30
+days).
 
 ```{code-cell} ipython3
-dataset["tp_mm"] = dataset["tp"]*1000
+dataset["tp_mm"] = dataset["tp"]*1000*30
 ```
 
 ### 5. Convert surface pressure units

--- a/docs/source/data_recipes/plant_dummy.md
+++ b/docs/source/data_recipes/plant_dummy.md
@@ -57,6 +57,17 @@ plant_dummy["leaf_area_index"] = DataArray(
         name="leaf_area_index",
 )
 
+evapotranspiration = np.repeat(a=[np.nan, 20.0, np.nan], repeats=[1, 3, 11])
+plant_dummy["evapotranspiration"] = DataArray(
+        np.broadcast_to(evapotranspiration, (81, 15)).T,
+        dims=["layers", "cell_id"],
+        coords={
+            "layers": np.arange(15),
+            "layer_roles": ("layers", layer_roles),
+            "cell_id": np.arange(0,81),
+        },
+        name="evapotranspiration",
+)
 # Make dictionary of DataArrays into a Dataset
 plant_dummy_dataset = Dataset(plant_dummy)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,7 +263,10 @@ def dummy_climate_data(layer_roles_fixture):
         np.full((3, 3), 400),
         dims=["cell_id", "time_index"],
     )
-
+    data["evapotranspiration"] = DataArray(
+        np.full((3, 3), 20),
+        dims=["cell_id", "time_index"],
+    )
     leaf_area_index = np.repeat(a=[np.nan, 1.0, np.nan], repeats=[1, 3, 11])
     data["leaf_area_index"] = DataArray(
         np.broadcast_to(leaf_area_index, (3, 15)).T,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,9 +263,16 @@ def dummy_climate_data(layer_roles_fixture):
         np.full((3, 3), 400),
         dims=["cell_id", "time_index"],
     )
+    evapotranspiration = np.repeat(a=[np.nan, 20.0, np.nan], repeats=[1, 3, 11])
     data["evapotranspiration"] = DataArray(
-        np.full((3, 3), 20),
-        dims=["cell_id", "time_index"],
+        np.broadcast_to(evapotranspiration, (3, 15)).T,
+        dims=["layers", "cell_id"],
+        coords={
+            "layers": np.arange(15),
+            "layer_roles": ("layers", layer_roles_fixture),
+            "cell_id": data.grid.cell_id,
+        },
+        name="evapotranspiration",
     )
     leaf_area_index = np.repeat(a=[np.nan, 1.0, np.nan], repeats=[1, 3, 11])
     data["leaf_area_index"] = DataArray(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -302,7 +302,8 @@ def dummy_climate_data(layer_roles_fixture):
     )
 
     data["precipitation"] = DataArray(
-        [[20, 30, 1000], [20, 30, 200], [20, 30, 1000]], dims=["time_index", "cell_id"]
+        [[200, 200, 200], [200, 200, 200], [200, 200, 200]],
+        dims=["time_index", "cell_id"],
     )
     data["soil_moisture"] = xr.concat(
         [

--- a/tests/models/hydrology/test_hydrology_model.py
+++ b/tests/models/hydrology/test_hydrology_model.py
@@ -42,6 +42,10 @@ from virtual_rainforest.models.hydrology.hydrology_model import HydrologyModel
                     DEBUG,
                     "hydrology model: required var 'atmospheric_pressure_ref' checked",
                 ),
+                (
+                    DEBUG,
+                    "hydrology model: required var 'evapotranspiration' checked",
+                ),
             ),
         ),
         (
@@ -162,6 +166,10 @@ def test_hydrology_model_initialization(
                     DEBUG,
                     "hydrology model: required var 'atmospheric_pressure_ref' checked",
                 ),
+                (
+                    DEBUG,
+                    "hydrology model: required var 'evapotranspiration' checked",
+                ),
             ),
         ),
         (
@@ -209,6 +217,10 @@ def test_hydrology_model_initialization(
                 (
                     DEBUG,
                     "hydrology model: required var 'atmospheric_pressure_ref' checked",
+                ),
+                (
+                    DEBUG,
+                    "hydrology model: required var 'evapotranspiration' checked",
                 ),
             ),
         ),
@@ -385,11 +397,16 @@ def test_setup(
             dims=["cell_id"],
             coords={"cell_id": [0, 1, 2]},
         )
-
+        exp_stream_flow = DataArray(
+            [0, 1.018733, 100.0],
+            dims=["cell_id"],
+            coords={"cell_id": [0, 1, 2]},
+        )
         xr.testing.assert_allclose(model.data["soil_moisture"], exp_soil_moisture)
         xr.testing.assert_allclose(model.data["vertical_flow"], exp_vertical_flow)
         xr.testing.assert_allclose(model.data["surface_runoff"], exp_runoff)
         xr.testing.assert_allclose(model.data["soil_evaporation"], exp_soil_evap)
+        xr.testing.assert_allclose(model.data["stream_flow"], exp_stream_flow)
 
 
 @pytest.mark.parametrize(

--- a/tests/models/hydrology/test_hydrology_model.py
+++ b/tests/models/hydrology/test_hydrology_model.py
@@ -398,7 +398,7 @@ def test_setup(
             coords={"cell_id": [0, 1, 2]},
         )
         exp_stream_flow = DataArray(
-            [0, 1.018733, 100.0],
+            [0, 0., 80.126915],
             dims=["cell_id"],
             coords={"cell_id": [0, 1, 2]},
         )

--- a/tests/models/hydrology/test_hydrology_model.py
+++ b/tests/models/hydrology/test_hydrology_model.py
@@ -374,7 +374,7 @@ def test_setup(
                     dims=["layers", "cell_id"],
                 ),
                 DataArray(
-                    [[0.512498, 0.518842, 0.626396], [0.512498, 0.518842, 0.626396]],
+                    [[0.626396, 0.626396, 0.626396], [0.626396, 0.626396, 0.626396]],
                     dims=["layers", "cell_id"],
                 ),
             ],
@@ -388,7 +388,7 @@ def test_setup(
         )
 
         exp_vertical_flow = DataArray(
-            [0.252134, 0.273622, 0.964253],
+            [0.964253, 0.964253, 0.964253],
             dims=["cell_id"],
             coords={"cell_id": [0, 1, 2]},
         )
@@ -398,7 +398,7 @@ def test_setup(
             coords={"cell_id": [0, 1, 2]},
         )
         exp_stream_flow = DataArray(
-            [0, 0, 80.126915],
+            [80.126915, 80.126915, 80.126915],
             dims=["cell_id"],
             coords={"cell_id": [0, 1, 2]},
         )

--- a/tests/models/hydrology/test_hydrology_model.py
+++ b/tests/models/hydrology/test_hydrology_model.py
@@ -398,7 +398,7 @@ def test_setup(
             coords={"cell_id": [0, 1, 2]},
         )
         exp_stream_flow = DataArray(
-            [0, 0., 80.126915],
+            [0, 0, 80.126915],
             dims=["cell_id"],
             coords={"cell_id": [0, 1, 2]},
         )

--- a/virtual_rainforest/models/hydrology/constants.py
+++ b/virtual_rainforest/models/hydrology/constants.py
@@ -75,3 +75,7 @@ class HydroConsts:
 
     flux_to_mm_conversion: float = 3.35e-4
     """Factor to convert evaporative flux to mm."""
+
+    stream_flow_capacity: float = 100.000
+    """Stream flow capacity, mm per timestep. This is curretly an arbitrary value, but
+    could be used in the future to flag flood events."""

--- a/virtual_rainforest/models/hydrology/constants.py
+++ b/virtual_rainforest/models/hydrology/constants.py
@@ -76,6 +76,6 @@ class HydroConsts:
     flux_to_mm_conversion: float = 3.35e-4
     """Factor to convert evaporative flux to mm."""
 
-    stream_flow_capacity: float = 100.000
+    stream_flow_capacity: float = 5000.0
     """Stream flow capacity, mm per timestep. This is curretly an arbitrary value, but
     could be used in the future to flag flood events."""

--- a/virtual_rainforest/models/hydrology/hydrology_model.py
+++ b/virtual_rainforest/models/hydrology/hydrology_model.py
@@ -59,7 +59,10 @@ class HydrologyModel(BaseModel):
         ("air_temperature_ref", ("spatial",)),
         ("relative_humidity_ref", ("spatial",)),
         ("atmospheric_pressure_ref", ("spatial",)),
-        ("evapotranspiration", ("spatial",)),  # TODO decide on order of models
+        ("evapotranspiration", ("spatial",)),
+        # TODO this requires the plant model to run before the hydrology; this works as
+        # long as the p-model does not require soil moisture as an input. If it does, we
+        # have to discuss where we move the calculation of stream flow.
     )
     # TODO add time dimension
     """The required variables and axes for the hydrology model"""
@@ -253,8 +256,9 @@ class HydrologyModel(BaseModel):
 
         where :math:`P` is mean precipitation, :math:`ET` is evapotranspiration, and
         :math:`\Delta S` is the change in soil moisture. Note that this has to be called
-        after evapotranspiration is calculated by the plant model; so this might move to
-        a different model or the order of models might change.
+        after evapotranspiration is calculated by the plant model which works as long as
+        the P-model does not require soil mositure as an input. In the future, this
+        might move to a different model or the order of models might change.
         Horizontal flow between grid cells (above and below the surface) is currently
         not explicitly calculated.
 

--- a/virtual_rainforest/models/hydrology/hydrology_model.py
+++ b/virtual_rainforest/models/hydrology/hydrology_model.py
@@ -441,14 +441,13 @@ class HydrologyModel(BaseModel):
         )
 
         # Calculate stream flow as Q= P-ET-dS ; vertical flow is not considered
-        # assumption: ET has only the dimension `cell_id`
         # The maximum stream flow capacity is set to an arbitray value, could be used to
         # flag flood events
         stream_flow = DataArray(
             np.clip(
                 (
                     precipitation_surface
-                    - self.data["evapotranspiration"].isel(time_index=time_index)
+                    - self.data["evapotranspiration"].sum(dim="layers")
                     - (
                         self.data["soil_moisture"].mean(dim="layers")
                         - soil_moisture_evap


### PR DESCRIPTION
This PR adds a super simple stream flow equation to the hydrology model: Q=P-ET-dS . This requires the plant model to run first, but as the p-model does currently not need soil moisture as an input, that should work. I added ET to the dummy plant data set and made a small adjustment to the input precipitation. Once we add p-hydro or SPLASH, we will have to rejig this; maybe split the stream flow from the hydrology model.
For now, the new features gives us the stream flow Q for each grid cell which can then in a next step be summed up for the whole area or catchments within the study area. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
