### PR TITLE
Allow setting params with command-line arguments

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -295,7 +295,7 @@ def test_vr_run_model_issues(mocker, caplog, config_content, expected_log_entrie
     # Simple drop in replacement for the Config class that sidesteps TOML loading and
     # validation and simply asserts the resulting config dictionary contents.
     class MockConfig(dict):
-        def __init__(self, cfg_paths):
+        def __init__(self, cfg_paths, extra_params):
             self.update(config_content)
 
         def export_config(self, outfile: Path):
@@ -304,7 +304,7 @@ def test_vr_run_model_issues(mocker, caplog, config_content, expected_log_entrie
     mocker.patch("virtual_rainforest.main.Config", MockConfig)
 
     with pytest.raises(InitialisationError):
-        vr_run([], Path("./delete_me.toml"))
+        vr_run([], [], Path("./delete_me.toml"))
         # If vr_run is successful (which it shouldn't be) clean up the file
         Path("./delete_me.toml").unlink()
 

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -606,9 +606,6 @@ class Config(dict):
 
         Args:
             override_params: Extra parameter settings
-        Raises:
-            ValidationError: if an invalid value is provided for any configuration
-                             settings.
         """
         updated, conflicts = config_merge(self, override_params, conflicts=tuple())
 

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -321,7 +321,7 @@ class Config(dict):
         self.config_errors: list[tuple[str, Any]] = []
         """Configuration errors, as a list of tuples of key path and error details."""
         self.merged_schema: dict = {}
-        """The merged schema for the core and modules present in the configutation."""
+        """The merged schema for the core and modules present in the configuration."""
         self.validated: bool = False
         """A boolean flag indicating successful validation."""
 

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -31,7 +31,7 @@ import json
 import sys
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Iterator, Union
+from typing import Any, Iterator, Optional, Union
 
 import dpath.util  # type: ignore
 import tomli_w
@@ -298,12 +298,16 @@ class Config(dict):
     Args:
         cfg_paths: A string, Path or list of strings or Paths giving configuration
             file or directory paths.
+        extra_params: Extra parameters provided by the user.
         auto: flag to turn off automatic validation.
 
     """
 
     def __init__(
-        self, cfg_paths: Union[str, Path, list[Union[str, Path]]], auto: bool = True
+        self,
+        cfg_paths: Union[str, Path, list[Union[str, Path]]],
+        extra_params: Optional[list[dict[str, Any]]] = None,
+        auto: bool = True,
     ) -> None:
         # Standardise cfg_paths to list of Paths
         if isinstance(cfg_paths, (str, Path)):
@@ -312,6 +316,8 @@ class Config(dict):
             self.cfg_paths = [Path(p) for p in cfg_paths]
 
         # Define custom attributes
+        self.extra_params = deepcopy(extra_params) if extra_params else []
+        """A list of dictionaries of extra parameters supplied by the user."""
         self.toml_files: list[Path] = []
         """A list of TOML file paths resolved from the initial config paths."""
         self.toml_contents: dict[Path, dict] = {}
@@ -432,7 +438,7 @@ class Config(dict):
         """
 
         # Get the config dictionaries
-        input_dicts = list(self.toml_contents.values())
+        input_dicts = list(self.toml_contents.values()) + self.extra_params
 
         if len(input_dicts) == 0:
             # No input dicts, Config dict is empty

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -31,7 +31,7 @@ import json
 import sys
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Iterator, Optional, Union
+from typing import Any, Iterator, Union
 
 import dpath.util  # type: ignore
 import tomli_w
@@ -306,7 +306,7 @@ class Config(dict):
     def __init__(
         self,
         cfg_paths: Union[str, Path, list[Union[str, Path]]],
-        extra_params: Optional[list[dict[str, Any]]] = None,
+        extra_params: list[dict[str, Any]] = [],
         auto: bool = True,
     ) -> None:
         # Standardise cfg_paths to list of Paths
@@ -316,7 +316,7 @@ class Config(dict):
             self.cfg_paths = [Path(p) for p in cfg_paths]
 
         # Define custom attributes
-        self.extra_params = deepcopy(extra_params) if extra_params else []
+        self.extra_params = deepcopy(extra_params)
         """A list of dictionaries of extra parameters supplied by the user."""
         self.toml_files: list[Path] = []
         """A list of TOML file paths resolved from the initial config paths."""

--- a/virtual_rainforest/entry_points.py
+++ b/virtual_rainforest/entry_points.py
@@ -3,13 +3,15 @@ points to the virtual_rainforest package. At the moment a single entry point is 
 `vr_run`, which simply configures and runs a virtual rainforest simulation based on a
 set of configuration files.
 """  # noqa D210, D415
-
 import argparse
 import sys
 import textwrap
+from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 import virtual_rainforest as vr
+from virtual_rainforest.core.config import config_merge
 from virtual_rainforest.core.exceptions import ConfigurationError
 from virtual_rainforest.core.logger import LOGGER
 from virtual_rainforest.main import vr_run
@@ -20,6 +22,50 @@ if sys.version_info[:2] >= (3, 11):
 else:
     import tomli as tomllib
     from tomli import TOMLDecodeError
+
+
+def _parse_param_str(s: str) -> dict[str, Any]:
+    """Parse a single parameter string into a dict.
+
+    For example: hydrology.initial_soil_moisture=0.3
+
+    Raises:
+        ConfigurationError: If the command-line parameters are not valid TOML
+    """
+    try:
+        return tomllib.loads(s)
+    except TOMLDecodeError:
+        to_raise = ConfigurationError("Invalid format for command-line parameters")
+        LOGGER.critical(to_raise)
+        raise to_raise
+
+
+def _parse_command_line_params(params_str: Sequence[str]) -> dict[str, Any]:
+    """Parse extra parameters provided with command-line arguments.
+
+    Args:
+        params_str: Extra parameters in string format (e.g. my.parameter=0.2)
+
+    Returns:
+        A combined dict including all of the parameter values
+
+    Raises:
+        ConfigurationError: Invalid format for parameters or conflicting values supplied
+    """
+    all_params: dict[str, Any] = {}
+    conflicts: tuple = ()
+    for param_str in params_str:
+        param_dict = _parse_param_str(param_str)
+        all_params, conflicts = config_merge(all_params, param_dict, conflicts)
+
+    if conflicts:
+        to_raise = ConfigurationError(
+            "Conflicting values supplied for command-line arguments"
+        )
+        LOGGER.critical(to_raise)
+        raise to_raise
+
+    return all_params
 
 
 def _vr_run_cli() -> None:
@@ -81,12 +127,7 @@ def _vr_run_cli() -> None:
         raise to_raise
 
     # Parse any extra parameters passed using the --param flag
-    try:
-        extra_params = [tomllib.loads(p) for p in args.params]
-    except TOMLDecodeError:
-        to_raise = ConfigurationError("Invalid format for command-line parameters")
-        LOGGER.critical(to_raise)
-        raise to_raise
+    override_params = _parse_command_line_params(args.params)
 
     # Run the virtual rainforest run function
-    vr_run(args.cfg_paths, extra_params, Path(args.merge_file_path))
+    vr_run(args.cfg_paths, override_params, Path(args.merge_file_path))

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -277,7 +277,7 @@ def merge_continuous_data_files(
 
 def vr_run(
     cfg_paths: Union[str, Path, list[Union[str, Path]]],
-    extra_params: list[dict[str, Any]],
+    override_params: dict[str, Any],
     merge_file_path: Path,
 ) -> None:
     """Perform a virtual rainforest simulation.
@@ -289,12 +289,12 @@ def vr_run(
 
     Args:
         cfg_paths: Set of paths to configuration files
-        extra_params: Extra parameters provided by the user
+        override_params: Extra parameters provided by the user
         merge_file_path: Path to save merged config file to (i.e. folder location + file
             name)
     """
 
-    config = Config(cfg_paths, extra_params)
+    config = Config(cfg_paths, override_params)
     config.export_config(merge_file_path)
 
     grid = Grid.from_config(config)

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -276,7 +276,9 @@ def merge_continuous_data_files(
 
 
 def vr_run(
-    cfg_paths: Union[str, Path, list[Union[str, Path]]], merge_file_path: Path
+    cfg_paths: Union[str, Path, list[Union[str, Path]]],
+    extra_params: list[dict[str, Any]],
+    merge_file_path: Path,
 ) -> None:
     """Perform a virtual rainforest simulation.
 
@@ -287,11 +289,12 @@ def vr_run(
 
     Args:
         cfg_paths: Set of paths to configuration files
+        extra_params: Extra parameters provided by the user
         merge_file_path: Path to save merged config file to (i.e. folder location + file
             name)
     """
 
-    config = Config(cfg_paths)
+    config = Config(cfg_paths, extra_params)
     config.export_config(merge_file_path)
 
     grid = Grid.from_config(config)


### PR DESCRIPTION
# Description

This PR adds the option to set additional parameters when invoking `vr_run` by using command-line arguments, without having to create additional config files.

For example, it allows you to do something like this:

```sh
vr_run --param hydrology.initial_soil_moisture=0.2 --param some.other.param=value dummy_data/
```

The main motivation for this is that I want to be able to invoke `vr_run` in parallel with different parameters as part of my work on the SA (see #239). While that is currently possible, it requires generating config files as an intermediate step, which makes the process substantially more complex.

Closes #266.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
