### PR TITLE
Adding a litter model

### DIFF
--- a/docs/source/api/litter.md
+++ b/docs/source/api/litter.md
@@ -1,0 +1,21 @@
+---
+jupytext:
+  cell_metadata_filter: -all
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.8
+kernelspec:
+  display_name: vr_python3
+  language: python
+  name: vr_python3
+---
+
+# API reference for `litter` modules
+
+```{eval-rst}
+.. automodule:: virtual_rainforest.models.litter
+```

--- a/docs/source/api/litter/constants.md
+++ b/docs/source/api/litter/constants.md
@@ -1,0 +1,23 @@
+---
+jupytext:
+  cell_metadata_filter: -all
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.8
+kernelspec:
+  display_name: vr_python3
+  language: python
+  name: vr_python3
+---
+
+# API documentation for the {mod}`~virtual_rainforest.models.litter.constants` module
+
+```{eval-rst}
+.. automodule:: virtual_rainforest.models.litter.constants
+    :autosummary:
+    :members:
+```

--- a/docs/source/api/litter/litter_model.md
+++ b/docs/source/api/litter/litter_model.md
@@ -1,0 +1,24 @@
+---
+jupytext:
+  cell_metadata_filter: -all
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.8
+kernelspec:
+  display_name: vr_python3
+  language: python
+  name: vr_python3
+---
+
+# API documentation for the {mod}`~virtual_rainforest.models.litter.litter_model` module
+
+```{eval-rst}
+.. automodule:: virtual_rainforest.models.litter.litter_model
+    :autosummary:
+    :members:
+    :exclude-members: model_name
+```

--- a/docs/source/api/litter/litter_pools.md
+++ b/docs/source/api/litter/litter_pools.md
@@ -1,0 +1,23 @@
+---
+jupytext:
+  cell_metadata_filter: -all
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.8
+kernelspec:
+  display_name: vr_python3
+  language: python
+  name: vr_python3
+---
+
+# API documentation for the {mod}`~virtual_rainforest.models.litter.litter_pools` module
+
+```{eval-rst}
+.. automodule:: virtual_rainforest.models.litter.litter_pools
+    :autosummary:
+    :members:
+```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -117,6 +117,10 @@ team.
   Animal Constants <api/animals/constants.md> 
   Animal Carcasses <api/animals/carcasses.md> 
   Animal Dummy Plants and Soils <api/animals/dummy_plants_and_soil.md> 
+  Litter Overview <api/litter.md>
+  Litter Model <api/litter/litter_model.md>
+  Litter Pools <api/litter/litter_pools.md>
+  Litter Constants <api/litter/constants.md>
   
   
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,6 +188,10 @@ def dummy_litter_data(layer_roles_fixture):
     # manner
     data["litter_pool_above_metabolic"] = DataArray([0.3, 0.15, 0.07], dims=["cell_id"])
     """Above ground metabolic litter pool (kg C m^-3)"""
+    data["litter_pool_above_structural"] = DataArray(
+        [0.5, 0.25, 0.09], dims=["cell_id"]
+    )
+    """Above ground structural litter pool (kg C m^-3)"""
 
     return data
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,6 +193,52 @@ def dummy_litter_data(layer_roles_fixture):
     )
     """Above ground structural litter pool (kg C m^-3)"""
 
+    data["soil_temperature"] = xr.concat(
+        [DataArray(np.full((13, 3), np.nan)), DataArray(np.full((2, 3), 20))],
+        dim="dim_0",
+    )
+    data["soil_temperature"] = (
+        data["soil_temperature"]
+        .rename({"dim_0": "layers", "dim_1": "cell_id"})
+        .assign_coords(
+            {
+                "layers": np.arange(0, 15),
+                "layer_roles": ("layers", layer_roles_fixture),
+                "cell_id": data.grid.cell_id,
+            }
+        )
+    )
+
+    data["air_temperature"] = xr.concat(
+        [
+            DataArray(
+                [
+                    [30.0, 30.0, 30.0],
+                    [29.844995, 29.844995, 29.844995],
+                    [28.87117, 28.87117, 28.87117],
+                    [27.206405, 27.206405, 27.206405],
+                ],
+                dims=["layers", "cell_id"],
+            ),
+            DataArray(np.full((7, 3), np.nan), dims=["layers", "cell_id"]),
+            DataArray(
+                [
+                    [22.65, 22.65, 22.65],
+                    [16.145945, 16.145945, 16.145945],
+                ],
+                dims=["layers", "cell_id"],
+            ),
+            DataArray(np.full((2, 3), np.nan), dims=["layers", "cell_id"]),
+        ],
+        dim="layers",
+    ).assign_coords(
+        {
+            "layers": np.arange(0, 15),
+            "layer_roles": ("layers", layer_roles_fixture[0:15]),
+            "cell_id": data.grid.cell_id,
+        }
+    )
+
     return data
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,10 +113,11 @@ def dummy_carbon_data(layer_roles_fixture):
     grid = Grid(cell_nx=4, cell_ny=1)
     data = Data(grid)
 
-    # The required data is now added. This includes the three carbon pools: mineral
-    # associated organic matter, low molecular weight carbon, and microbial carbon. It
-    # also includes various factors of the physical environment: pH, bulk density, soil
-    # moisture, soil temperature, percentage clay in soil.
+    # The required data is now added. This includes the four carbon pools: mineral
+    # associated organic matter, low molecular weight carbon, microbial carbon and
+    # particulate organic matter. It also includes various factors of the physical
+    # environment: pH, bulk density, soil moisture, soil temperature, percentage clay in
+    # soil.
     data["soil_c_pool_lmwc"] = DataArray([0.05, 0.02, 0.1, 0.005], dims=["cell_id"])
     """Low molecular weight carbon pool (kg C m^-3)"""
     data["soil_c_pool_maom"] = DataArray([2.5, 1.7, 4.5, 0.5], dims=["cell_id"])
@@ -173,9 +174,34 @@ def dummy_carbon_data(layer_roles_fixture):
 
 
 @pytest.fixture
+def dummy_litter_data(layer_roles_fixture):
+    """Creates a dummy litter data object for use in tests."""
+
+    from virtual_rainforest.core.data import Data
+    from virtual_rainforest.core.grid import Grid
+
+    # Setup the data object with four cells.
+    grid = Grid(cell_nx=3, cell_ny=1)
+    data = Data(grid)
+
+    # These values are taken from SAFE Project data, albeit in a very unsystematic
+    # manner
+    data["litter_pool_above_metabolic"] = DataArray([0.3, 0.15, 0.07], dims=["cell_id"])
+    """Above ground metabolic litter pool (kg C m^-3)"""
+
+    return data
+
+
+@pytest.fixture
 def top_soil_layer_index(layer_roles_fixture):
     """The index of the top soil layer in the data fixtures."""
     return next(i for i, v in enumerate(layer_roles_fixture) if v == "soil")
+
+
+@pytest.fixture
+def surface_layer_index(layer_roles_fixture):
+    """The index of the top soil layer in the data fixtures."""
+    return next(i for i, v in enumerate(layer_roles_fixture) if v == "surface")
 
 
 @pytest.fixture

--- a/tests/models/litter/test_litter_model.py
+++ b/tests/models/litter/test_litter_model.py
@@ -1,0 +1,137 @@
+"""Test module for litter_model.py."""
+
+from contextlib import nullcontext as does_not_raise
+from copy import deepcopy
+from logging import DEBUG, ERROR, INFO
+
+import pint
+import pytest
+from xarray import DataArray
+
+from tests.conftest import log_check
+from virtual_rainforest.core.exceptions import InitialisationError
+from virtual_rainforest.models.litter.constants import LitterConsts
+from virtual_rainforest.models.litter.litter_model import LitterModel
+
+
+@pytest.fixture
+def litter_model_fixture(dummy_litter_data):
+    """Create a litter model fixture based on the dummy litter data."""
+
+    from virtual_rainforest.models.litter.litter_model import LitterModel
+
+    config = {
+        "core": {
+            "timing": {"start_date": "2020-01-01", "update_interval": "12 hours"},
+            "layers": {"soil_layers": 2, "canopy_layers": 10},
+        },
+    }
+    return LitterModel.from_config(dummy_litter_data, config, pint.Quantity("12 hours"))
+
+
+@pytest.mark.parametrize(
+    "bad_data,raises,expected_log_entries",
+    [
+        (
+            [],
+            does_not_raise(),
+            (
+                (
+                    DEBUG,
+                    "litter model: required var 'litter_pool_above_metabolic' checked",
+                ),
+                (
+                    DEBUG,
+                    "litter model: required var 'litter_pool_above_structural' checked",
+                ),
+            ),
+        ),
+        (
+            1,
+            pytest.raises(ValueError),
+            (
+                (
+                    ERROR,
+                    "litter model: init data missing required var "
+                    "'litter_pool_above_metabolic'",
+                ),
+                (
+                    ERROR,
+                    "litter model: init data missing required var "
+                    "'litter_pool_above_structural'",
+                ),
+                (
+                    ERROR,
+                    "litter model: error checking required_init_vars, see log.",
+                ),
+            ),
+        ),
+        (
+            2,
+            pytest.raises(InitialisationError),
+            (
+                (
+                    INFO,
+                    "Replacing data array for 'litter_pool_above_metabolic'",
+                ),
+                (
+                    DEBUG,
+                    "litter model: required var 'litter_pool_above_metabolic' checked",
+                ),
+                (
+                    DEBUG,
+                    "litter model: required var 'litter_pool_above_structural' checked",
+                ),
+                (
+                    ERROR,
+                    "Initial litter pools contain at least one negative value!",
+                ),
+            ),
+        ),
+    ],
+)
+def test_litter_model_initialization(
+    caplog, dummy_litter_data, bad_data, raises, expected_log_entries
+):
+    """Test `LitterModel` initialization."""
+
+    from virtual_rainforest.core.data import Data
+    from virtual_rainforest.core.grid import Grid
+
+    with raises:
+        # Initialize model
+        if bad_data:
+            # Make four cell grid
+            grid = Grid(cell_nx=4, cell_ny=1)
+            litter_data = Data(grid)
+            # On second test actually populate this data to test bounds
+            if bad_data == 2:
+                litter_data = deepcopy(dummy_litter_data)
+                # Put incorrect data in for lmwc
+                litter_data["litter_pool_above_metabolic"] = DataArray(
+                    [0.05, 0.02, -0.1], dims=["cell_id"]
+                )
+            # Initialise model with bad data object
+            model = LitterModel(
+                litter_data, pint.Quantity("1 week"), 2, 10, constants=LitterConsts
+            )
+        else:
+            model = LitterModel(
+                dummy_litter_data,
+                pint.Quantity("1 week"),
+                2,
+                10,
+                constants=LitterConsts,
+            )
+
+        # In cases where it passes then checks that the object has the right properties
+        assert set(["setup", "spinup", "update", "cleanup"]).issubset(dir(model))
+        assert model.model_name == "litter"
+        assert str(model) == "A litter model instance"
+        assert repr(model) == "LitterModel(update_interval = 1 week)"
+
+    # Final check that expected logging entries are produced
+    log_check(caplog, expected_log_entries)
+
+
+# TODO - test other functions for this module

--- a/tests/models/litter/test_litter_pools.py
+++ b/tests/models/litter/test_litter_pools.py
@@ -74,3 +74,22 @@ def test_calculate_litter_decay_metabolic_above(
     )
 
     assert np.allclose(actual_decay, expected_decay)
+
+
+def test_calculate_litter_decay_structural_above(
+    dummy_litter_data, temp_and_water_factors
+):
+    """Test calculation of above ground metabolic litter decay."""
+    from virtual_rainforest.models.litter.litter_pools import (
+        calculate_litter_decay_structural_above,
+    )
+
+    expected_decay = [0.000167429, 8.371483356e-5, 3.013734008e-5]
+
+    actual_decay = calculate_litter_decay_structural_above(
+        temperature_factor=temp_and_water_factors["temp_above"],
+        litter_pool_above_structural=dummy_litter_data["litter_pool_above_structural"],
+        litter_decay_coefficient=LitterConsts.litter_decay_constant_structural_above,
+    )
+
+    assert np.allclose(actual_decay, expected_decay)

--- a/tests/models/litter/test_litter_pools.py
+++ b/tests/models/litter/test_litter_pools.py
@@ -73,12 +73,8 @@ def test_calculate_litter_pool_updates(dummy_litter_data, surface_layer_index):
         surface_temp=dummy_litter_data["air_temperature"][
             surface_layer_index
         ].to_numpy(),
-        litter_pool_above_metabolic=dummy_litter_data[
-            "litter_pool_above_metabolic"
-        ].to_numpy(),
-        litter_pool_above_structural=dummy_litter_data[
-            "litter_pool_above_structural"
-        ].to_numpy(),
+        above_metabolic=dummy_litter_data["litter_pool_above_metabolic"].to_numpy(),
+        above_structural=dummy_litter_data["litter_pool_above_structural"].to_numpy(),
         update_interval=1.0,
         constants=LitterConsts,
     )

--- a/tests/models/litter/test_litter_pools.py
+++ b/tests/models/litter/test_litter_pools.py
@@ -12,7 +12,7 @@ from virtual_rainforest.models.litter.constants import LitterConsts
 
 @pytest.fixture
 def temp_and_water_factors(
-    dummy_climate_data, surface_layer_index, top_soil_layer_index
+    dummy_litter_data, surface_layer_index, top_soil_layer_index
 ):
     """Temperature and water factors for the various litter layers."""
     from virtual_rainforest.models.litter.litter_pools import (
@@ -20,14 +20,14 @@ def temp_and_water_factors(
     )
 
     temp_above = calculate_temperature_effect_on_litter_decomp(
-        dummy_climate_data["air_temperature"][surface_layer_index],
+        dummy_litter_data["air_temperature"][surface_layer_index],
         reference_temp=LitterConsts.litter_decomp_reference_temp,
         offset_temp=LitterConsts.litter_decomp_offset_temp,
         temp_response=LitterConsts.litter_decomp_temp_response,
     )
 
     temp_below = calculate_temperature_effect_on_litter_decomp(
-        dummy_climate_data["soil_temperature"][top_soil_layer_index],
+        dummy_litter_data["soil_temperature"][top_soil_layer_index],
         reference_temp=LitterConsts.litter_decomp_reference_temp,
         offset_temp=LitterConsts.litter_decomp_offset_temp,
         temp_response=LitterConsts.litter_decomp_temp_response,
@@ -58,9 +58,7 @@ def test_calculate_temperature_effect_on_litter_decomp(
     assert np.allclose(actual_factor, expected_factor)
 
 
-def test_calculate_litter_pool_updates(
-    dummy_climate_data, dummy_litter_data, surface_layer_index
-):
+def test_calculate_litter_pool_updates(dummy_litter_data, surface_layer_index):
     """Test that litter pool update calculation is correct."""
     from virtual_rainforest.models.litter.litter_pools import (
         calculate_litter_pool_updates,
@@ -72,7 +70,7 @@ def test_calculate_litter_pool_updates(
     }
 
     result = calculate_litter_pool_updates(
-        surface_temp=dummy_climate_data["air_temperature"][
+        surface_temp=dummy_litter_data["air_temperature"][
             surface_layer_index
         ].to_numpy(),
         litter_pool_above_metabolic=dummy_litter_data[

--- a/tests/models/litter/test_litter_pools.py
+++ b/tests/models/litter/test_litter_pools.py
@@ -1,0 +1,28 @@
+"""Test module for litter.litter_pools.py.
+
+This module tests the functionality of the litter pools module
+"""
+
+import numpy as np
+
+from virtual_rainforest.models.litter.constants import LitterConsts
+
+
+def test_calculate_temperature_effect_on_litter_decomp(
+    dummy_carbon_data, top_soil_layer_index
+):
+    """Test that temperature effects on decomposition are calculated correctly."""
+    from virtual_rainforest.models.litter.litter_pools import (
+        calculate_temperature_effect_on_litter_decomp,
+    )
+
+    expected_factor = [0.77760650, 0.88583053, 1.0, 0.41169183]
+
+    actual_factor = calculate_temperature_effect_on_litter_decomp(
+        dummy_carbon_data["soil_temperature"][top_soil_layer_index],
+        reference_temp=LitterConsts.litter_decomp_reference_temp,
+        offset_temp=LitterConsts.litter_decomp_offset_temp,
+        temp_response=LitterConsts.litter_decomp_temp_response,
+    )
+
+    assert np.allclose(actual_factor, expected_factor)

--- a/virtual_rainforest/models/litter/__init__.py
+++ b/virtual_rainforest/models/litter/__init__.py
@@ -1,0 +1,26 @@
+"""The :mod:`~virtual_rainforest.models.litter` module is one of the component models of
+the Virtual Rainforest. It is comprised of a number of submodules.
+
+Each of the litter sub-modules has its own API reference page:
+
+* The :mod:`~virtual_rainforest.models.litter.litter_model` submodule instantiates the
+  LitterModel class which consolidates the functionality of the litter model into a
+  single class, which the high level functions of the Virtual Rainforest can then make
+  use of.
+* The :mod:`~virtual_rainforest.models.litter.litter_pools` provides the set of litter
+  pools that the litter model is comprised of.
+* The :mod:`~virtual_rainforest.models.litter.constants` provides a set of dataclasses
+  containing the constants required by the broader litter model.
+"""  # noqa: D205, D415
+
+from importlib import resources
+
+from virtual_rainforest.core.config import register_schema
+from virtual_rainforest.models.litter.litter_model import LitterModel
+
+with resources.path(
+    "virtual_rainforest.models.litter", "litter_schema.json"
+) as schema_file_path:
+    register_schema(
+        module_name=LitterModel.model_name, schema_file_path=schema_file_path
+    )

--- a/virtual_rainforest/models/litter/constants.py
+++ b/virtual_rainforest/models/litter/constants.py
@@ -1,0 +1,12 @@
+"""The :mod:`~virtual_rainforest.models.litter.constants` module contains
+constants and parameters for the
+:mod:`~virtual_rainforest.models.litter.litter_model`. These parameters are constants
+in that they should not be changed during a particular simulation.
+"""  # noqa: D205, D415
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LitterConsts:
+    """Dataclass to store all constants for the `litter` model."""

--- a/virtual_rainforest/models/litter/constants.py
+++ b/virtual_rainforest/models/litter/constants.py
@@ -10,3 +10,21 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class LitterConsts:
     """Dataclass to store all constants for the `litter` model."""
+
+    litter_decomp_reference_temp: float = 40.0
+    """Reference temperature for litter decomposition [C].
+
+    Value is taken from :cite:t:`kirschbaum_modelling_2002`.
+    """
+
+    litter_decomp_offset_temp: float = 31.79
+    """Offset temperature for litter decomposition [C].
+
+    Value is taken from :cite:t:`kirschbaum_modelling_2002`.
+    """
+
+    litter_decomp_temp_response: float = 3.36
+    """Parameter controlling the temperature response strength of litter decomposition.
+
+    [unitless]. Value is taken from :cite:t:`kirschbaum_modelling_2002`.
+    """

--- a/virtual_rainforest/models/litter/constants.py
+++ b/virtual_rainforest/models/litter/constants.py
@@ -28,3 +28,9 @@ class LitterConsts:
 
     [unitless]. Value is taken from :cite:t:`kirschbaum_modelling_2002`.
     """
+
+    litter_decay_constant_metabolic_above: float = 0.56 / 7.0
+    """Decay constant for the above ground metabolic litter pool [day^-1].
+
+    Value is taken from :cite:t:`kirschbaum_modelling_2002`.
+    """

--- a/virtual_rainforest/models/litter/constants.py
+++ b/virtual_rainforest/models/litter/constants.py
@@ -34,3 +34,9 @@ class LitterConsts:
 
     Value is taken from :cite:t:`kirschbaum_modelling_2002`.
     """
+
+    litter_decay_constant_structural_above: float = 0.152 / 7.0
+    """Decay constant for the above ground structural litter pool [day^-1].
+
+    Value is taken from :cite:t:`kirschbaum_modelling_2002`.
+    """

--- a/virtual_rainforest/models/litter/constants.py
+++ b/virtual_rainforest/models/litter/constants.py
@@ -40,3 +40,17 @@ class LitterConsts:
 
     Value is taken from :cite:t:`kirschbaum_modelling_2002`.
     """
+
+    litter_input_to_metabolic_above: float = 0.000280628
+    """Litter input rate to metabolic above ground litter pool [kg C m^-2 day^-1].
+
+    This value was estimated (very unsystematically) from SAFE project data. This
+    constant will eventually be removed once the litter is linked to other models.
+    """
+
+    litter_input_to_structural_above: float = 0.00071869
+    """Litter input rate to metabolic above ground litter pool [kg C m^-2 day^-1].
+
+    This value was estimated (very unsystematically) from SAFE project data. This
+    constant will eventually be removed once the litter is linked to other models.
+    """

--- a/virtual_rainforest/models/litter/litter_model.py
+++ b/virtual_rainforest/models/litter/litter_model.py
@@ -85,10 +85,6 @@ class LitterModel(BaseModel):
             LOGGER.error(to_raise)
             raise to_raise
 
-        self.data
-        """A Data instance providing access to the shared simulation data."""
-        self.update_interval
-        """The time interval between model updates."""
         self.constants = constants
         """Set of constants for the litter model"""
 

--- a/virtual_rainforest/models/litter/litter_model.py
+++ b/virtual_rainforest/models/litter/litter_model.py
@@ -29,6 +29,8 @@ from virtual_rainforest.core.utils import check_valid_constant_names, set_layer_
 from virtual_rainforest.models.litter.constants import LitterConsts
 from virtual_rainforest.models.litter.litter_pools import calculate_litter_pool_updates
 
+# TODO - test this entire module
+
 
 class LitterModel(BaseModel):
     """A class defining the litter model.
@@ -157,6 +159,7 @@ class LitterModel(BaseModel):
                 self.surface_layer_index
             ].to_numpy(),
             constants=self.constants,
+            update_interval=self.update_interval.to("day").magnitude,
             **litter_pools,
         )
 

--- a/virtual_rainforest/models/litter/litter_model.py
+++ b/virtual_rainforest/models/litter/litter_model.py
@@ -123,7 +123,7 @@ class LitterModel(BaseModel):
 
         # Check if any constants have been supplied
         if "litter" in config and "constants" in config["litter"]:
-            # Checks that constants is config are as expected
+            # Checks that constants in config are as expected
             check_valid_constant_names(config, "litter", "LitterConsts")
             # If an error isn't raised then generate the dataclass
             constants = LitterConsts(**config["litter"]["constants"]["LitterConsts"])

--- a/virtual_rainforest/models/litter/litter_model.py
+++ b/virtual_rainforest/models/litter/litter_model.py
@@ -20,10 +20,12 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
 from pint import Quantity
 
 from virtual_rainforest.core.base_model import BaseModel
 from virtual_rainforest.core.data import Data
+from virtual_rainforest.core.exceptions import InitialisationError
 from virtual_rainforest.core.logger import LOGGER
 from virtual_rainforest.core.utils import check_valid_constant_names, set_layer_roles
 from virtual_rainforest.models.litter.constants import LitterConsts
@@ -75,7 +77,15 @@ class LitterModel(BaseModel):
     ):
         super().__init__(data, update_interval, **kwargs)
 
-        # TODO - Check for negative litter pools here
+        # Check that litter pool data is appropriately bounded
+        if np.any(data["litter_pool_above_metabolic"] < 0.0) or np.any(
+            data["litter_pool_above_structural"] < 0.0
+        ):
+            to_raise = InitialisationError(
+                "Initial litter pools contain at least one negative value!"
+            )
+            LOGGER.error(to_raise)
+            raise to_raise
 
         self.data
         """A Data instance providing access to the shared simulation data."""

--- a/virtual_rainforest/models/litter/litter_model.py
+++ b/virtual_rainforest/models/litter/litter_model.py
@@ -6,14 +6,14 @@ the abstract methods of the parent class (e.g.
 :func:`~virtual_rainforest.core.base_model.BaseModel.spinup`) are overwritten using
 placeholder functions that don't do anything. This will change as the Virtual Rainforest
 model develops. The factory method
-:func:`~virtual_rainforest.models.litter.litter_model.SoilModel.from_config` exists in a
-more complete state, and unpacks a small number of parameters from our currently pretty
-minimal configuration dictionary. These parameters are then used to generate a class
-instance. If errors crop here when converting the information from the config dictionary
-to the required types (e.g. :class:`~numpy.timedelta64`) they are caught and then
-logged, and at the end of the unpacking an error is thrown. This error should be caught
-and handled by downstream functions so that all model configuration failures can be
-reported as one.
+:func:`~virtual_rainforest.models.litter.litter_model.LitterModel.from_config` exists in
+a more complete state, and unpacks a small number of parameters from our currently
+pretty minimal configuration dictionary. These parameters are then used to generate a
+class instance. If errors crop here when converting the information from the config
+dictionary to the required types (e.g. :class:`~numpy.timedelta64`) they are caught and
+then logged, and at the end of the unpacking an error is thrown. This error should be
+caught and handled by downstream functions so that all model configuration failures can
+be reported as one.
 """  # noqa: D205, D415
 
 from __future__ import annotations

--- a/virtual_rainforest/models/litter/litter_model.py
+++ b/virtual_rainforest/models/litter/litter_model.py
@@ -1,0 +1,149 @@
+"""The :mod:`~virtual_rainforest.models.litter.litter_model` module creates a
+:class:`~virtual_rainforest.models.litter.litter_model.LitterModel` class as a child of
+the :class:`~virtual_rainforest.core.base_model.BaseModel` class. At present a lot of
+the abstract methods of the parent class (e.g.
+:func:`~virtual_rainforest.core.base_model.BaseModel.setup` and
+:func:`~virtual_rainforest.core.base_model.BaseModel.spinup`) are overwritten using
+placeholder functions that don't do anything. This will change as the Virtual Rainforest
+model develops. The factory method
+:func:`~virtual_rainforest.models.litter.litter_model.SoilModel.from_config` exists in a
+more complete state, and unpacks a small number of parameters from our currently pretty
+minimal configuration dictionary. These parameters are then used to generate a class
+instance. If errors crop here when converting the information from the config dictionary
+to the required types (e.g. :class:`~numpy.timedelta64`) they are caught and then
+logged, and at the end of the unpacking an error is thrown. This error should be caught
+and handled by downstream functions so that all model configuration failures can be
+reported as one.
+"""  # noqa: D205, D415
+
+from __future__ import annotations
+
+from typing import Any
+
+from pint import Quantity
+
+from virtual_rainforest.core.base_model import BaseModel
+from virtual_rainforest.core.data import Data
+from virtual_rainforest.core.logger import LOGGER
+from virtual_rainforest.core.utils import check_valid_constant_names, set_layer_roles
+from virtual_rainforest.models.litter.constants import LitterConsts
+
+
+class LitterModel(BaseModel):
+    """A class defining the litter model.
+
+    This model can be configured based on the data object and a config dictionary. At
+    present the underlying model this class wraps is quite simple (i.e. two litter
+    pools), but this will get more complex as the Virtual Rainforest develops.
+
+    Args:
+        data: The data object to be used in the model.
+        update_interval: Time to wait between updates of the model state.
+        soil_layers: The number of soil layers to be modelled.
+        canopy_layers: The number of canopy layers to be modelled.
+        constants: Set of constants for the litter model.
+    """
+
+    model_name = "litter"
+    """An internal name used to register the model and schema"""
+    lower_bound_on_time_scale = "30 minutes"
+    """Shortest time scale that the litter model can sensibly capture."""
+    upper_bound_on_time_scale = "3 months"
+    """Longest time scale that the litter model can sensibly capture."""
+    required_init_vars = ()
+    """Required initialisation variables for the litter model.
+
+    This is a set of variables that must be present in the data object used to create a
+    LitterModel , along with any core axes that those variables must map on to."""
+    vars_updated = []
+    """Variables updated by the litter model."""
+
+    def __init__(
+        self,
+        data: Data,
+        update_interval: Quantity,
+        soil_layers: int,
+        canopy_layers: int,
+        constants: LitterConsts,
+        **kwargs: Any,
+    ):
+        super().__init__(data, update_interval, **kwargs)
+
+        # TODO - Check for negative litter pools here
+
+        self.data
+        """A Data instance providing access to the shared simulation data."""
+        self.update_interval
+        """The time interval between model updates."""
+
+        # create a list of layer roles
+        layer_roles = set_layer_roles(canopy_layers, soil_layers)
+        # Find first soil layer from the list of layer roles
+        self.top_soil_layer_index = next(
+            i for i, v in enumerate(layer_roles) if v == "soil"
+        )
+        """The layer in the data object representing the first soil layer."""
+        # Find first soil layer from the list of layer roles
+        self.surface_layer_index = next(
+            i for i, v in enumerate(layer_roles) if v == "surface"
+        )
+        """The layer in the data object representing the surface layer."""
+
+    @classmethod
+    def from_config(
+        cls, data: Data, config: dict[str, Any], update_interval: Quantity
+    ) -> LitterModel:
+        """Factory function to initialise the litter model from configuration.
+
+        This function unpacks the relevant information from the configuration file, and
+        then uses it to initialise the model. If any information from the config is
+        invalid rather than returning an initialised model instance an error is raised.
+
+        Args:
+            data: A :class:`~virtual_rainforest.core.data.Data` instance.
+            config: The complete (and validated) Virtual Rainforest configuration.
+            update_interval: Frequency with which all models are updated
+        """
+
+        # Find number of soil and canopy layers
+        soil_layers = config["core"]["layers"]["soil_layers"]
+        canopy_layers = config["core"]["layers"]["canopy_layers"]
+
+        # Check if any constants have been supplied
+        if "litter" in config and "constants" in config["litter"]:
+            # Checks that constants is config are as expected
+            check_valid_constant_names(config, "litter", "LitterConsts")
+            # If an error isn't raised then generate the dataclass
+            constants = LitterConsts(**config["litter"]["constants"]["LitterConsts"])
+        else:
+            # If no constants are supplied then the defaults should be used
+            constants = LitterConsts()
+
+        LOGGER.info(
+            "Information required to initialise the litter model successfully "
+            "extracted."
+        )
+        return cls(data, update_interval, soil_layers, canopy_layers, constants)
+
+    def setup(self) -> None:
+        """Placeholder function to setup up the litter model."""
+
+    def spinup(self) -> None:
+        """Placeholder function to spin up the litter model."""
+
+    def update(self, time_index: int) -> None:
+        """Update the litter model by SOMEHOW.
+
+        TODO - Update the docstring when I've decided what this does
+
+        Args:
+            time_index: The index representing the current time step in the data object.
+        """
+
+        # TODO - Work out how litter pools updates should be calculated
+
+        # TODO - update the litter pools
+        # self.data.add_from_dict(updated_litter_pools)
+
+    def cleanup(self) -> None:
+        """Placeholder function for litter model cleanup."""

--- a/virtual_rainforest/models/litter/litter_model.py
+++ b/virtual_rainforest/models/litter/litter_model.py
@@ -144,8 +144,21 @@ class LitterModel(BaseModel):
             time_index: The index representing the current time step in the data object.
         """
 
+        # Find all litter pools
+        litter_pools = {
+            str(name): self.data[str(name)].to_numpy()
+            for name in self.data.data.keys()
+            if str(name).startswith("litter_pool_")
+        }
+
         # Find litter pool updates using the litter pool update function
-        updated_litter_pools = calculate_litter_pool_updates(self.data, self.constants)
+        updated_litter_pools = calculate_litter_pool_updates(
+            surface_temp=self.data["soil_temperature"][
+                self.surface_layer_index
+            ].to_numpy(),
+            constants=self.constants,
+            **litter_pools,
+        )
 
         # Update the litter pools
         self.data.add_from_dict(updated_litter_pools)

--- a/virtual_rainforest/models/litter/litter_model.py
+++ b/virtual_rainforest/models/litter/litter_model.py
@@ -150,13 +150,6 @@ class LitterModel(BaseModel):
             time_index: The index representing the current time step in the data object.
         """
 
-        # Find all litter pools
-        litter_pools = {
-            str(name): self.data[str(name)].to_numpy()
-            for name in self.data.data.keys()
-            if str(name).startswith("litter_pool_")
-        }
-
         # Find litter pool updates using the litter pool update function
         updated_litter_pools = calculate_litter_pool_updates(
             surface_temp=self.data["air_temperature"][
@@ -164,7 +157,8 @@ class LitterModel(BaseModel):
             ].to_numpy(),
             constants=self.constants,
             update_interval=self.update_interval.to("day").magnitude,
-            **litter_pools,
+            above_metabolic=self.data["litter_pool_above_metabolic"].to_numpy(),
+            above_structural=self.data["litter_pool_above_structural"].to_numpy(),
         )
 
         # Update the litter pools

--- a/virtual_rainforest/models/litter/litter_model.py
+++ b/virtual_rainforest/models/litter/litter_model.py
@@ -51,12 +51,15 @@ class LitterModel(BaseModel):
     """Shortest time scale that the litter model can sensibly capture."""
     upper_bound_on_time_scale = "3 months"
     """Longest time scale that the litter model can sensibly capture."""
-    required_init_vars = ()
+    required_init_vars = (
+        ("litter_pool_above_metabolic", ("spatial",)),
+        ("litter_pool_above_structural", ("spatial",)),
+    )
     """Required initialisation variables for the litter model.
 
     This is a set of variables that must be present in the data object used to create a
     LitterModel , along with any core axes that those variables must map on to."""
-    vars_updated = []
+    vars_updated = ["litter_pool_above_metabolic", "litter_pool_above_structural"]
     """Variables updated by the litter model."""
 
     def __init__(

--- a/virtual_rainforest/models/litter/litter_model.py
+++ b/virtual_rainforest/models/litter/litter_model.py
@@ -163,7 +163,7 @@ class LitterModel(BaseModel):
 
         # Find litter pool updates using the litter pool update function
         updated_litter_pools = calculate_litter_pool_updates(
-            surface_temp=self.data["soil_temperature"][
+            surface_temp=self.data["air_temperature"][
                 self.surface_layer_index
             ].to_numpy(),
             constants=self.constants,

--- a/virtual_rainforest/models/litter/litter_model.py
+++ b/virtual_rainforest/models/litter/litter_model.py
@@ -27,6 +27,7 @@ from virtual_rainforest.core.data import Data
 from virtual_rainforest.core.logger import LOGGER
 from virtual_rainforest.core.utils import check_valid_constant_names, set_layer_roles
 from virtual_rainforest.models.litter.constants import LitterConsts
+from virtual_rainforest.models.litter.litter_pools import calculate_litter_pool_updates
 
 
 class LitterModel(BaseModel):
@@ -75,6 +76,8 @@ class LitterModel(BaseModel):
         """A Data instance providing access to the shared simulation data."""
         self.update_interval
         """The time interval between model updates."""
+        self.constants = constants
+        """Set of constants for the litter model"""
 
         # create a list of layer roles
         layer_roles = set_layer_roles(canopy_layers, soil_layers)
@@ -132,18 +135,17 @@ class LitterModel(BaseModel):
         """Placeholder function to spin up the litter model."""
 
     def update(self, time_index: int) -> None:
-        """Update the litter model by SOMEHOW.
-
-        TODO - Update the docstring when I've decided what this does
+        """Calculate changes in the litter pools and use them to update the pools.
 
         Args:
             time_index: The index representing the current time step in the data object.
         """
 
-        # TODO - Work out how litter pools updates should be calculated
+        # Find litter pool updates using the litter pool update function
+        updated_litter_pools = calculate_litter_pool_updates(self.data, self.constants)
 
-        # TODO - update the litter pools
-        # self.data.add_from_dict(updated_litter_pools)
+        # Update the litter pools
+        self.data.add_from_dict(updated_litter_pools)
 
     def cleanup(self) -> None:
         """Placeholder function for litter model cleanup."""

--- a/virtual_rainforest/models/litter/litter_model.py
+++ b/virtual_rainforest/models/litter/litter_model.py
@@ -31,8 +31,6 @@ from virtual_rainforest.core.utils import check_valid_constant_names, set_layer_
 from virtual_rainforest.models.litter.constants import LitterConsts
 from virtual_rainforest.models.litter.litter_pools import calculate_litter_pool_updates
 
-# TODO - test this entire module
-
 
 class LitterModel(BaseModel):
     """A class defining the litter model.

--- a/virtual_rainforest/models/litter/litter_pools.py
+++ b/virtual_rainforest/models/litter/litter_pools.py
@@ -9,6 +9,10 @@ from xarray import DataArray
 
 from virtual_rainforest.models.litter.constants import LitterConsts
 
+# TODO - At the moment this module does not use litter chemistry (relative lignin
+# content) at all. We need to decide how we handle this and adjust the below functions
+# to use this at some point.
+
 
 # TODO - Think about how time step is used here
 def calculate_litter_pool_updates(
@@ -38,9 +42,6 @@ def calculate_litter_pool_updates(
 
     # TODO - only returning this to shut mypy up, this needs to change down the line
     return {"litter_pool_above_metabolic": DataArray(litter_pool_above_metabolic)}
-
-
-# TODO - Functions for input to each compartment
 
 
 def calculate_temperature_effect_on_litter_decomp(
@@ -93,3 +94,38 @@ def calculate_litter_decay_metabolic_above(
     """
 
     return litter_decay_coefficient * temperature_factor * litter_pool_above_metabolic
+
+
+def calculate_litter_decay_structural_above(
+    temperature_factor: NDArray[np.float32],
+    litter_pool_above_structural: NDArray[np.float32],
+    litter_decay_coefficient: float,
+) -> NDArray[np.float32]:
+    """Calculate decay of above ground structural litter pool.
+
+    This function is taken from :cite:t:`kirschbaum_modelling_2002`.
+
+    Args:
+        temperature_factor: A multiplicative factor capturing the impact of temperature
+            on litter decomposition [unitless]
+        litter_pool_above_structural: The size of the above ground structural litter
+            pool [kg C m^-2]
+        litter_decay_coefficient: The decay coefficient for the above ground structural
+            litter pool [day^-1]
+
+    Returns:
+        Rate of decay of the above ground structural litter pool [kg C m^-2 day^-1]
+    """
+
+    # Factor capturing the impact of litter chemistry on decomposition, calculated based
+    # on formula in Kirschbaum and Paul (2002) with the assumption that structural
+    # litter is 50% lignin. Keeping as a hard coded constant for now, as how litter
+    # chemistry is dealt with is going to be revised in the near future.
+    litter_chemistry_factor = 0.082085
+
+    return (
+        litter_decay_coefficient
+        * temperature_factor
+        * litter_pool_above_structural
+        * litter_chemistry_factor
+    )

--- a/virtual_rainforest/models/litter/litter_pools.py
+++ b/virtual_rainforest/models/litter/litter_pools.py
@@ -7,19 +7,37 @@ import numpy as np
 from numpy.typing import NDArray
 from xarray import DataArray
 
-from virtual_rainforest.core.data import Data
 from virtual_rainforest.models.litter.constants import LitterConsts
 
 
+# TODO - Think about how time step is used here
 def calculate_litter_pool_updates(
-    data: Data, constants: LitterConsts
+    surface_temp: NDArray[np.float32],
+    litter_pool_above_metabolic: NDArray[np.float32],
+    constants: LitterConsts,
 ) -> dict[str, DataArray]:
     """TODO - add a proper docstring here."""
+
+    # Calculate temperature factor for the above ground litter layers
+    temperature_factor_above = calculate_temperature_effect_on_litter_decomp(
+        temperature=surface_temp,
+        reference_temp=constants.litter_decomp_reference_temp,
+        offset_temp=constants.litter_decomp_offset_temp,
+        temp_response=constants.litter_decomp_temp_response,
+    )
+
+    # What other info is needed for metabolic above ground decay?
+    # metabolic_above_decay
+    calculate_litter_decay_metabolic_above(
+        temperature_factor_above,
+        litter_pool_above_metabolic,
+        litter_decay_coefficient=constants.litter_decay_constant_metabolic_above,
+    )
 
     # TODO - Work out actual content here
 
     # TODO - only returning this to shut mypy up, this needs to change down the line
-    return {"litter_pool_above_metabolic": data["litter_pool_above_metabolic"]}
+    return {"litter_pool_above_metabolic": DataArray(litter_pool_above_metabolic)}
 
 
 # TODO - Functions for input to each compartment
@@ -44,9 +62,34 @@ def calculate_temperature_effect_on_litter_decomp(
             [unitless]
 
     Returns:
-        A multiplicative factor capturing the impact of temperature
+        A multiplicative factor capturing the impact of temperature on litter
+        decomposition [unitless]
     """
 
     return np.exp(
         temp_response * (temperature - reference_temp) / (temperature + offset_temp)
     )
+
+
+def calculate_litter_decay_metabolic_above(
+    temperature_factor: NDArray[np.float32],
+    litter_pool_above_metabolic: NDArray[np.float32],
+    litter_decay_coefficient: float,
+) -> NDArray[np.float32]:
+    """Calculate decay of above ground metabolic litter pool.
+
+    This function is taken from :cite:t:`kirschbaum_modelling_2002`.
+
+    Args:
+        temperature_factor: A multiplicative factor capturing the impact of temperature
+            on litter decomposition [unitless]
+        litter_pool_above_metabolic: The size of the above ground metabolic litter pool
+            [kg C m^-2]
+        litter_decay_coefficient: The decay coefficient for the above ground metabolic
+            litter pool [day^-1]
+
+    Returns:
+        Rate of decay of the above ground metabolic litter pool [kg C m^-2 day^-1]
+    """
+
+    return litter_decay_coefficient * temperature_factor * litter_pool_above_metabolic

--- a/virtual_rainforest/models/litter/litter_pools.py
+++ b/virtual_rainforest/models/litter/litter_pools.py
@@ -16,8 +16,8 @@ from virtual_rainforest.models.litter.constants import LitterConsts
 
 def calculate_litter_pool_updates(
     surface_temp: NDArray[np.float32],
-    litter_pool_above_metabolic: NDArray[np.float32],
-    litter_pool_above_structural: NDArray[np.float32],
+    above_metabolic: NDArray[np.float32],
+    above_structural: NDArray[np.float32],
     update_interval: float,
     constants: LitterConsts,
 ) -> dict[str, DataArray]:
@@ -26,8 +26,8 @@ def calculate_litter_pool_updates(
     Args:
         surface_temp: Temperature of soil surface, which is assumed to be the same
             temperature of the above ground litter [C]
-        litter_pool_above_metabolic: Above ground metabolic litter pool [kg C m^-2]
-        litter_pool_above_structural: Above ground structural litter pool [kg C m^-2]
+        above_metabolic: Above ground metabolic litter pool [kg C m^-2]
+        above_structural: Above ground structural litter pool [kg C m^-2]
         update_interval: Interval that the litter pools are being updated for [days]
         constants: Set of constants for the litter model
 
@@ -46,12 +46,12 @@ def calculate_litter_pool_updates(
     # Calculate the pool decay rates
     metabolic_above_decay = calculate_litter_decay_metabolic_above(
         temperature_factor_above,
-        litter_pool_above_metabolic,
+        above_metabolic,
         litter_decay_coefficient=constants.litter_decay_constant_metabolic_above,
     )
     structural_above_decay = calculate_litter_decay_structural_above(
         temperature_factor_above,
-        litter_pool_above_structural,
+        above_structural,
         litter_decay_coefficient=constants.litter_decay_constant_structural_above,
     )
 
@@ -66,10 +66,10 @@ def calculate_litter_pool_updates(
     # Construct dictionary of data arrays to return
     new_litter_pools = {
         "litter_pool_above_metabolic": DataArray(
-            litter_pool_above_metabolic + change_in_metabolic_above, dims="cell_id"
+            above_metabolic + change_in_metabolic_above, dims="cell_id"
         ),
         "litter_pool_above_structural": DataArray(
-            litter_pool_above_structural + change_in_structural_above, dims="cell_id"
+            above_structural + change_in_structural_above, dims="cell_id"
         ),
     }
 

--- a/virtual_rainforest/models/litter/litter_pools.py
+++ b/virtual_rainforest/models/litter/litter_pools.py
@@ -64,13 +64,14 @@ def calculate_litter_pool_updates(
     ) * update_interval
 
     # Construct dictionary of data arrays to return
-    new_litter_pools = {}
-    new_litter_pools["litter_pool_above_metabolic"] = DataArray(
-        litter_pool_above_metabolic + change_in_metabolic_above, dims="cell_id"
-    )
-    new_litter_pools["litter_pool_above_structural"] = DataArray(
-        litter_pool_above_structural + change_in_structural_above, dims="cell_id"
-    )
+    new_litter_pools = {
+        "litter_pool_above_metabolic": DataArray(
+            litter_pool_above_metabolic + change_in_metabolic_above, dims="cell_id"
+        ),
+        "litter_pool_above_structural": DataArray(
+            litter_pool_above_structural + change_in_structural_above, dims="cell_id"
+        ),
+    }
 
     return new_litter_pools
 

--- a/virtual_rainforest/models/litter/litter_pools.py
+++ b/virtual_rainforest/models/litter/litter_pools.py
@@ -1,0 +1,52 @@
+"""The ``models.litter.litter_pools`` module  simulates the litter pools for the Virtual
+Rainforest. At the moment only two pools are modelled, above ground metabolic and above
+ground structural, but a wider variety of pools will be simulated in future.
+"""  # noqa: D205, D415
+
+import numpy as np
+from numpy.typing import NDArray
+from xarray import DataArray
+
+from virtual_rainforest.core.data import Data
+from virtual_rainforest.models.litter.constants import LitterConsts
+
+
+def calculate_litter_pool_updates(
+    data: Data, constants: LitterConsts
+) -> dict[str, DataArray]:
+    """TODO - add a proper docstring here."""
+
+    # TODO - Work out actual content here
+
+    # TODO - only returning this to shut mypy up, this needs to change down the line
+    return {"litter_pool_above_metabolic": data["litter_pool_above_metabolic"]}
+
+
+# TODO - Functions for input to each compartment
+
+
+def calculate_temperature_effect_on_litter_decomp(
+    temperature: NDArray[np.float32],
+    reference_temp: float,
+    offset_temp: float,
+    temp_response: float,
+) -> NDArray[np.float32]:
+    """Calculate the effect that temperature has on litter decomposition rates.
+
+    This function is taken from :cite:t:`kirschbaum_modelling_2002`.
+
+    Args:
+        temperature: The temperature of the litter layer [C]
+        reference_temp: The reference temperature for changes in litter decomposition
+            rates with temperature [C]
+        offset_temp: Temperature offset [C]
+        temp_response: Factor controlling response strength to changing temperature
+            [unitless]
+
+    Returns:
+        A multiplicative factor capturing the impact of temperature
+    """
+
+    return np.exp(
+        temp_response * (temperature - reference_temp) / (temperature + offset_temp)
+    )

--- a/virtual_rainforest/models/litter/litter_schema.json
+++ b/virtual_rainforest/models/litter/litter_schema.json
@@ -1,0 +1,15 @@
+{
+    "type": "object",
+    "properties": {
+        "litter": {
+            "description": "Configuration settings for the litter module",
+            "type": "object",
+            "properties": {},
+            "default": {},
+            "required": []
+        }
+    },
+    "required": [
+        "litter"
+    ]
+}

--- a/virtual_rainforest/models/litter/litter_schema.json
+++ b/virtual_rainforest/models/litter/litter_schema.json
@@ -4,7 +4,20 @@
         "litter": {
             "description": "Configuration settings for the litter module",
             "type": "object",
-            "properties": {},
+            "properties": {
+                "constants": {
+                    "description": "Constants for the litter module",
+                    "type": "object",
+                    "properties": {
+                        "LitterConsts": {
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "LitterConsts"
+                    ]
+                }
+            },
             "default": {},
             "required": []
         }

--- a/virtual_rainforest/models/soil/carbon.py
+++ b/virtual_rainforest/models/soil/carbon.py
@@ -1,7 +1,7 @@
 """The ``models.soil.carbon`` module  simulates the soil carbon cycle for the Virtual
-Rainforest. At the moment only two pools are modelled, these are low molecular weight
-carbon (LMWC) and mineral associated organic matter (MAOM). More pools and their
-interactions will be added at a later date.
+Rainforest. At the moment four pools are modelled, these are low molecular weight carbon
+(LMWC), mineral associated organic matter (MAOM), microbial biomass, and particulate
+organic matter (POM).
 """  # noqa: D205, D415
 
 import numpy as np

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -107,10 +107,6 @@ class SoilModel(BaseModel):
             LOGGER.error(to_raise)
             raise to_raise
 
-        self.data
-        """A Data instance providing access to the shared simulation data."""
-        self.update_interval
-        """The time interval between model updates."""
         # create a list of layer roles
         layer_roles = set_layer_roles(canopy_layers, soil_layers)
         # Find first soil layer from the list of layer roles

--- a/virtual_rainforest/models/soil/soil_model.py
+++ b/virtual_rainforest/models/soil/soil_model.py
@@ -43,7 +43,7 @@ class SoilModel(BaseModel):
 
     This model can be configured based on the data object and a config dictionary. It
     can be updated by numerical integration. At present the underlying model this class
-    wraps is quite simple (i.e. two soil carbon pools), but this will get more complex
+    wraps is quite simple (i.e. four soil carbon pools), but this will get more complex
     as the Virtual Rainforest develops.
 
     Args:


### PR DESCRIPTION
# Description

This pull request adds a litter model to the Virtual Rainforest. The purpose of this model is to handle the decomposition of complex biomass lying on or just under the forest floor.

I made this a separate model from the `soil` model for a couple of reasons:

1. There are plausible use cases (mainly animal focused) where you would want to track the litter (as a resource for consumption) but not the full soil nutrient cycles.
2. There's an alternative microbially explicit approach to modelling litter decay that I would like to try (if I get the time). I feel like this would be easier to implement with the litter model separated from the soil model.

At the moment, the model only has two pools "above_ground_metabolic" and "above_ground_structural" which represent the fast and slow decomposing above ground litter, respectively. In future, below ground pools and wood pools will also be added. The model will also get quite a lot more complex when we add leaf chemistry in (lignin, N and P).

I originally planned to add links from this model to the soil model in, but I thought that pull request was already getting large enough, so decided to save that for a later pull request.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
