### PR TITLE
Fix unified path merge bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 
 [tool.poetry.scripts]
-vr_run = "virtual_rainforest.entry_points:_vr_run_cli"
+vr_run = "virtual_rainforest.entry_points:vr_run_cli"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"

--- a/tests/core/test_cli_integration.py
+++ b/tests/core/test_cli_integration.py
@@ -1,0 +1,22 @@
+"""An integration test for the VR command-line interface."""
+import shutil
+from contextlib import nullcontext as does_not_raise
+from pathlib import Path
+from unittest.mock import patch
+
+
+def test_vr_run(shared_datadir):
+    """Test that the CLI can successfully run with example data."""
+    from virtual_rainforest.entry_points import vr_run_cli
+
+    args = [
+        str(shutil.which("vr_run")),
+        "--example",
+        "--outpath",
+        str(shared_datadir),
+        "--merge",
+        str(Path(shared_datadir) / "vr_full_model_configuration.toml"),
+    ]
+    with does_not_raise():
+        with patch("virtual_rainforest.entry_points.sys.argv", args):
+            vr_run_cli()

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -958,7 +958,7 @@ def test_merge_continuous_data_files(shared_datadir, dummy_carbon_data):
     variables_to_save = ["soil_c_pool_lmwc", "soil_temperature"]
     data_options = {
         "out_folder_continuous": str(shared_datadir),
-        "continuous_file_name": "all_continuous_data",
+        "out_continuous_file_name": "all_continuous_data",
     }
 
     # Save first data file
@@ -1045,7 +1045,7 @@ def test_merge_continuous_file_already_exists(
     variables_to_save = ["soil_c_pool_lmwc", "soil_temperature"]
     data_options = {
         "out_folder_continuous": str(shared_datadir),
-        "continuous_file_name": "already_exists",
+        "out_continuous_file_name": "already_exists",
     }
 
     # Save first data file

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -958,7 +958,7 @@ def test_merge_continuous_data_files(shared_datadir, dummy_carbon_data):
     variables_to_save = ["soil_c_pool_lmwc", "soil_temperature"]
     data_options = {
         "out_folder_continuous": str(shared_datadir),
-        "out_continuous_file_name": "all_continuous_data",
+        "out_continuous_file_name": "all_continuous_data.nc",
     }
 
     # Save first data file
@@ -1045,7 +1045,7 @@ def test_merge_continuous_file_already_exists(
     variables_to_save = ["soil_c_pool_lmwc", "soil_temperature"]
     data_options = {
         "out_folder_continuous": str(shared_datadir),
-        "out_continuous_file_name": "already_exists",
+        "out_continuous_file_name": "already_exists.nc",
     }
 
     # Save first data file

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -471,7 +471,7 @@ def merge_continuous_data_files(
     out_folder = Path(data_options["out_folder_continuous"])
 
     # Check that output file doesn't already exist
-    check_outfile(out_folder / f"{data_options['continuous_file_name']}.nc")
+    check_outfile(out_folder / f"{data_options['out_continuous_file_name']}.nc")
 
     # Open all files as a single dataset
     with open_mfdataset(continuous_data_files) as all_data:
@@ -479,7 +479,9 @@ def merge_continuous_data_files(
         all_data["layer_roles"] = all_data["layer_roles"].astype("S9")
 
         # Save and close complete dataset
-        all_data.to_netcdf(out_folder / f"{data_options['continuous_file_name']}.nc")
+        all_data.to_netcdf(
+            out_folder / f"{data_options['out_continuous_file_name']}.nc"
+        )
 
     # Iterate over all continuous files and delete them
     for file_path in continuous_data_files:

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -468,10 +468,13 @@ def merge_continuous_data_files(
 
     # Path to folder containing the continuous output (that merged file should be saved
     # to)
-    out_folder = Path(data_options["out_folder_continuous"])
+    out_path = (
+        Path(data_options["out_folder_continuous"])
+        / data_options["out_continuous_file_name"]
+    )
 
     # Check that output file doesn't already exist
-    check_outfile(out_folder / f"{data_options['out_continuous_file_name']}.nc")
+    check_outfile(out_path)
 
     # Open all files as a single dataset
     with open_mfdataset(continuous_data_files) as all_data:
@@ -479,9 +482,7 @@ def merge_continuous_data_files(
         all_data["layer_roles"] = all_data["layer_roles"].astype("S9")
 
         # Save and close complete dataset
-        all_data.to_netcdf(
-            out_folder / f"{data_options['out_continuous_file_name']}.nc"
-        )
+        all_data.to_netcdf(out_path)
 
     # Iterate over all continuous files and delete them
     for file_path in continuous_data_files:

--- a/virtual_rainforest/entry_points.py
+++ b/virtual_rainforest/entry_points.py
@@ -68,7 +68,7 @@ def _parse_command_line_params(
         raise to_raise
 
 
-def _vr_run_cli() -> None:
+def vr_run_cli() -> None:
     """Configure and run a Virtual Rainforest simulation.
 
     This program sets up and runs a simulation of the Virtual Rainforest model. At
@@ -88,7 +88,7 @@ def _vr_run_cli() -> None:
     """
 
     # Check function docstring exists, as -OO flag strips docstrings I believe
-    desc = textwrap.dedent(_vr_run_cli.__doc__ or "Python in -OO mode: no docs")
+    desc = textwrap.dedent(vr_run_cli.__doc__ or "Python in -OO mode: no docs")
     fmt = argparse.RawDescriptionHelpFormatter
     parser = argparse.ArgumentParser(description=desc, formatter_class=fmt)
 

--- a/virtual_rainforest/entry_points.py
+++ b/virtual_rainforest/entry_points.py
@@ -125,7 +125,7 @@ def vr_run_cli() -> None:
         version="%(prog)s {version}".format(version=vr.__version__),
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(sys.argv[1:])
 
     cfg_paths: list[str] = []
     if args.example:


### PR DESCRIPTION
# Description

In PR #280, I inadvertently broke things while resolving merge conflicts introduced by @jacobcook1995's PR.

Now invoking `vr_run` gives errors like so:

```
Traceback (most recent call last):
  File "/home/alex/code/virtual_rainforest/.venv/bin/vr_run", line 6, in <module>
    sys.exit(_vr_run_cli())
             ^^^^^^^^^^^^^
  File "/home/alex/code/virtual_rainforest/virtual_rainforest/entry_points.py", line 152, in _vr_run_cli
    vr_run(cfg_paths, override_params, Path(args.merge_file_path))
  File "/home/alex/code/virtual_rainforest/virtual_rainforest/main.py", line 287, in vr_run
    merge_continuous_data_files(
  File "/home/alex/code/virtual_rainforest/virtual_rainforest/core/data.py", line 474, in merge_continuous_data_files
    check_outfile(out_folder / f"{data_options['continuous_file_name']}.nc")
                                  ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'continuous_file_name'
```

I forgot to update the attribute names in the merged code and clearly also forgot to retest that everything was still working before merging. Sorry!

In an attempt to stop this from happening again, I've added a simple integration test for `vr_run`, which just runs the program with the example data. It takes < 10s to run on my machine, but if you want to speed it up, you could reduce the example data to be more minimal.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
