### PR TITLE
Fix path merge bug, take 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 
 [tool.poetry.scripts]
-vr_run = "virtual_rainforest.entry_points:_vr_run_cli"
+vr_run = "virtual_rainforest.entry_points:vr_run_cli"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"

--- a/tests/core/test_cli_integration.py
+++ b/tests/core/test_cli_integration.py
@@ -1,0 +1,22 @@
+"""An integration test for the VR command-line interface."""
+import shutil
+from contextlib import nullcontext as does_not_raise
+from pathlib import Path
+from unittest.mock import patch
+
+
+def test_vr_run(shared_datadir):
+    """Test that the CLI can successfully run with example data."""
+    from virtual_rainforest.entry_points import vr_run_cli
+
+    args = [
+        str(shutil.which("vr_run")),
+        "--example",
+        "--outpath",
+        str(shared_datadir),
+        "--merge",
+        str(Path(shared_datadir) / "vr_full_model_configuration.toml"),
+    ]
+    with does_not_raise():
+        with patch("virtual_rainforest.entry_points.sys.argv", args):
+            vr_run_cli()

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -958,7 +958,7 @@ def test_merge_continuous_data_files(shared_datadir, dummy_carbon_data):
     variables_to_save = ["soil_c_pool_lmwc", "soil_temperature"]
     data_options = {
         "out_folder_continuous": str(shared_datadir),
-        "continuous_file_name": "all_continuous_data",
+        "out_continuous_file_name": "all_continuous_data.nc",
     }
 
     # Save first data file
@@ -1045,7 +1045,7 @@ def test_merge_continuous_file_already_exists(
     variables_to_save = ["soil_c_pool_lmwc", "soil_temperature"]
     data_options = {
         "out_folder_continuous": str(shared_datadir),
-        "continuous_file_name": "already_exists",
+        "out_continuous_file_name": "already_exists.nc",
     }
 
     # Save first data file

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -53,6 +53,7 @@ def test_make_square_grid(cell_id):
     assert iprod == pytest.approx(0)
 
 
+@settings(deadline=None)
 @given(integers(min_value=0, max_value=99))
 def test_make_hex_grid(cell_id):
     """Test make_hex_grid()."""

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -468,10 +468,13 @@ def merge_continuous_data_files(
 
     # Path to folder containing the continuous output (that merged file should be saved
     # to)
-    out_folder = Path(data_options["out_folder_continuous"])
+    out_path = (
+        Path(data_options["out_folder_continuous"])
+        / data_options["out_continuous_file_name"]
+    )
 
     # Check that output file doesn't already exist
-    check_outfile(out_folder / f"{data_options['continuous_file_name']}.nc")
+    check_outfile(out_path)
 
     # Open all files as a single dataset
     with open_mfdataset(continuous_data_files) as all_data:
@@ -479,7 +482,7 @@ def merge_continuous_data_files(
         all_data["layer_roles"] = all_data["layer_roles"].astype("S9")
 
         # Save and close complete dataset
-        all_data.to_netcdf(out_folder / f"{data_options['continuous_file_name']}.nc")
+        all_data.to_netcdf(out_path)
 
     # Iterate over all continuous files and delete them
     for file_path in continuous_data_files:

--- a/virtual_rainforest/entry_points.py
+++ b/virtual_rainforest/entry_points.py
@@ -68,7 +68,7 @@ def _parse_command_line_params(
         raise to_raise
 
 
-def _vr_run_cli() -> None:
+def vr_run_cli() -> None:
     """Configure and run a Virtual Rainforest simulation.
 
     This program sets up and runs a simulation of the Virtual Rainforest model. At
@@ -88,7 +88,7 @@ def _vr_run_cli() -> None:
     """
 
     # Check function docstring exists, as -OO flag strips docstrings I believe
-    desc = textwrap.dedent(_vr_run_cli.__doc__ or "Python in -OO mode: no docs")
+    desc = textwrap.dedent(vr_run_cli.__doc__ or "Python in -OO mode: no docs")
     fmt = argparse.RawDescriptionHelpFormatter
     parser = argparse.ArgumentParser(description=desc, formatter_class=fmt)
 
@@ -125,7 +125,7 @@ def _vr_run_cli() -> None:
         version="%(prog)s {version}".format(version=vr.__version__),
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(sys.argv[1:])
 
     cfg_paths: list[str] = []
     if args.example:


### PR DESCRIPTION
# Description

@jacobcook1995 @dalonsoa @davidorme 

I had to unmerge my last PR, because it was causing CI failures, and I didn't clock this till after it was merged.

It's my fault for not checking this properly (sorry!), but it turns out that your branch protection rules weren't set up correctly, for either `main` or `develop`. You need to manually select what the required status checks are, otherwise GitHub will happily let you merge things that don't pass tests.

I've sorted it now, but for future reference this is the relevant section on the settings page:

![image](https://github.com/ImperialCollegeLondon/virtual_rainforest/assets/23149834/281f1e2b-491b-455e-80a1-b988fc1f971d)

It's worth knowing, because if you add a new runner (e.g. for a new version of Python), you also have to add it to the required status checks.

Let's try this again. I'll fix up the CI failures then request a review.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
