### PR TITLE
Fix: Correctly merge configs recursively

### DIFF
--- a/virtual_rainforest/entry_points.py
+++ b/virtual_rainforest/entry_points.py
@@ -134,7 +134,8 @@ def vr_run_cli() -> None:
     override_params: dict[str, Any] = {}
     if args.outpath:
         # Set the output path
-        override_params |= {"core": {"data_output_options": {"out_path": args.outpath}}}
+        outpath_opt = {"core": {"data_output_options": {"out_path": args.outpath}}}
+        override_params, _ = config_merge(override_params, outpath_opt)
     if args.params:
         # Parse any extra parameters passed using the --param flag
         _parse_command_line_params(args.params, override_params)


### PR DESCRIPTION
# Description

Currently, the code will clobber any "core" config options if an outpath is also provided on the command line. Fix by using the `config_merge()` function.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
