### PR TITLE
Remove `--merge` command-line option and replace with config option

### DIFF
--- a/tests/core/test_cli_integration.py
+++ b/tests/core/test_cli_integration.py
@@ -1,7 +1,6 @@
 """An integration test for the VR command-line interface."""
 import shutil
 from contextlib import nullcontext as does_not_raise
-from pathlib import Path
 from unittest.mock import patch
 
 
@@ -14,8 +13,6 @@ def test_vr_run(shared_datadir):
         "--example",
         "--outpath",
         str(shared_datadir),
-        "--merge",
-        str(Path(shared_datadir) / "vr_full_model_configuration.toml"),
     ]
     with does_not_raise():
         with patch("virtual_rainforest.entry_points.sys.argv", args):

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -11,6 +11,7 @@ from contextlib import nullcontext as does_not_raise
 from itertools import repeat
 from logging import CRITICAL, ERROR, INFO, WARNING
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -556,8 +557,10 @@ def test_Config_init_auto(caplog, shared_datadir, file_path, expected_log_entrie
     """Checks that auto validation passes as expected."""
     from virtual_rainforest.core.config import Config
 
-    Config(shared_datadir / file_path, auto=True)
-    log_check(caplog, expected_log_entries)
+    with patch.object(Config, "export_config") as export_mock:
+        Config(shared_datadir / file_path, auto=True)
+        log_check(caplog, expected_log_entries)
+        export_mock.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -303,7 +303,7 @@ def test_vr_run_model_issues(mocker, caplog, config_content, expected_log_entrie
     mocker.patch("virtual_rainforest.main.Config", MockConfig)
 
     with pytest.raises(InitialisationError):
-        vr_run([], [], Path("./delete_me.toml"))
+        vr_run([], [])
         # If vr_run is successful (which it shouldn't be) clean up the file
         Path("./delete_me.toml").unlink()
 

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -326,12 +326,14 @@ class Config(dict):
     The :meth:`~virtual_rainforest.core.config.Config.export_config` method can be used
     to export the compiled and validated configuration as a single TOML file.
 
+    If the core.data_output_options.save_merged_config option is set to true a merged
+    config file will be automatically generated, unless ``auto`` is set to false.
+
     Args:
         cfg_paths: A string, Path or list of strings or Paths giving configuration
             file or directory paths.
         override_params: Extra parameters provided by the user.
-        auto: flag to turn off automatic validation.
-
+        auto: flag to turn off automatic validation and merged config file generation.
     """
 
     def __init__(
@@ -369,6 +371,13 @@ class Config(dict):
             self.override_config(override_params)
             self.build_schema()
             self.validate_config()
+
+            # If the user has indicated that they want a merged config file, generate it
+            # now
+            data_opt = self["core"]["data_output_options"]
+            if data_opt["save_merged_config"]:
+                outfile = Path(data_opt["out_path"]) / data_opt["out_merge_file_name"]
+                self.export_config(outfile)
 
     def resolve_config_paths(self) -> None:
         """Resolve config file paths into a set of TOML config files.

--- a/virtual_rainforest/core/core_schema.json
+++ b/virtual_rainforest/core/core_schema.json
@@ -132,6 +132,11 @@
                      "type": "boolean",
                      "default": true
                   },
+                  "save_merged_config": {
+                     "description": "Whether to save a merged TOML file containing all config options",
+                     "type": "boolean",
+                     "default": true
+                  },
                   "out_path": {
                      "description": "File path for output files",
                      "type": "string",
@@ -158,6 +163,12 @@
                      "type": "string",
                      "default": "final_state.nc",
                      "pattern": "^[^/\\\\]+$"
+                  },
+                  "out_merge_file_name": {
+                     "description": "Name for TOML file containing merged configs",
+                     "type": "string",
+                     "default": "vr_full_model_configuration.toml",
+                     "pattern": "^[^/\\\\]+$"
                   }
                },
                "default": {},
@@ -165,9 +176,11 @@
                   "save_initial_state",
                   "save_continuous_data",
                   "save_final_state",
+                  "save_merged_config",
                   "out_initial_file_name",
                   "out_continuous_file_name",
-                  "out_final_file_name"
+                  "out_final_file_name",
+                  "out_merge_file_name"
                ]
             },
             "layers": {

--- a/virtual_rainforest/entry_points.py
+++ b/virtual_rainforest/entry_points.py
@@ -7,7 +7,6 @@ import argparse
 import sys
 import textwrap
 from collections.abc import Sequence
-from pathlib import Path
 from typing import Any
 
 import virtual_rainforest as vr
@@ -81,10 +80,10 @@ def vr_run_cli() -> None:
     files (cfg_paths). The set of config files found in those locations are then
     combined and validated to make sure that they contain a complete and consistent
     configuration for a virtual_rainforest simulation. The resolved complete
-    configuration is then written to a single consolidated config file (--merge). If a
-    specific location isn't provided via the --merge option, the consolidated file is
-    saved in the folder `vr_run` was called in under the name
-    `vr_full_model_configuration.toml`.
+    configuration will then be written to a single consolidated config file in the
+    output path with a default name of `vr_full_model_configuration.toml`. This can be
+    disabled by setting the `core.data_output_options.save_merged_config` option to
+    false.
     """
 
     # Check function docstring exists, as -OO flag strips docstrings I believe
@@ -95,14 +94,6 @@ def vr_run_cli() -> None:
     parser.add_argument("cfg_paths", type=str, help="Paths to config files", nargs="*")
     parser.add_argument(
         "-o", "--outpath", type=str, help="Path for output files", dest="outpath"
-    )
-    parser.add_argument(
-        "-m",
-        "--merge",
-        type=str,
-        default="./vr_full_model_configuration.toml",
-        help="Path for merged config file.",
-        dest="merge_file_path",
     )
     parser.add_argument(
         "-p",
@@ -149,4 +140,4 @@ def vr_run_cli() -> None:
         _parse_command_line_params(args.params, override_params)
 
     # Run the virtual rainforest run function
-    vr_run(cfg_paths, override_params, Path(args.merge_file_path))
+    vr_run(cfg_paths, override_params)

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -192,7 +192,6 @@ def extract_timing_details(
 def vr_run(
     cfg_paths: Union[str, Path, Sequence[Union[str, Path]]],
     override_params: dict[str, Any],
-    merge_file_path: Path,
 ) -> None:
     """Perform a virtual rainforest simulation.
 
@@ -209,7 +208,6 @@ def vr_run(
     """
 
     config = Config(cfg_paths, override_params)
-    config.export_config(merge_file_path)
 
     grid = Grid.from_config(config)
     data = Data(grid)


### PR DESCRIPTION
# Description

Currently, setting the path for the merged config file is a different process to setting the path for other simulation output files:

1. It can only be set via a command-line argument
2. This command-line argument comprises the full path (i.e. including directory), meaning that the output path (e.g. set by the `--outpath` argument) is not used
3. There is no option to disable its generation

I have added a couple of config options to control the generation of merged config files:

- `core.data_output_options.save_merged_config` - for enabling/disabling generation
- `core.data_output_options.out_merge_file_name` - the name of the merged config file (**not** the whole path!)

If generated, merged config files will now always be saved to the output path along with other output files. I have removed the `--merge` option as keeping it around with the existing behaviour would have made the code more complex and I don't think it's necessary anyway; if a user wants to change the merged config file name then they can use the `--param` option, as for other parameters.

Fixes #270.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
