### PR TITLE
soil evaporation constraint

### DIFF
--- a/tests/models/hydrology/test_above_ground.py
+++ b/tests/models/hydrology/test_above_ground.py
@@ -38,6 +38,7 @@ def test_calculate_soil_evaporation(wind, dens_air, latvap):
         relative_humidity=np.array([70, 80, 90]),
         atmospheric_pressure=np.array([90, 90, 90]),
         soil_moisture=np.array([0.1, 0.5, 0.9]),
+        soil_moisture_residual=0.1,
         celsius_to_kelvin=HydroConsts.celsius_to_kelvin,
         density_air=dens_air,
         latent_heat_vapourisation=latvap,
@@ -45,7 +46,7 @@ def test_calculate_soil_evaporation(wind, dens_air, latvap):
         heat_transfer_coefficient=HydroConsts.heat_transfer_coefficient,
     )
 
-    exp_result = np.array([1.523354, 3.86474, 4.473155])
+    exp_result = np.array([0.053332, 3.86474, 4.473155])
     np.testing.assert_allclose(result, exp_result, rtol=0.01)
 
 

--- a/tests/models/hydrology/test_above_ground.py
+++ b/tests/models/hydrology/test_above_ground.py
@@ -33,12 +33,13 @@ def test_calculate_soil_evaporation(wind, dens_air, latvap):
     )
 
     result = calculate_soil_evaporation(
-        temperature=np.array([10.0, 20.0, 30.0]),
+        temperature=np.array([20.0, 20.0, 30.0]),
         wind_speed=wind,
-        relative_humidity=np.array([70, 80, 90]),
+        relative_humidity=np.array([80, 80, 90]),
         atmospheric_pressure=np.array([90, 90, 90]),
-        soil_moisture=np.array([0.1, 0.5, 0.9]),
+        soil_moisture=np.array([0.01, 0.1, 0.5]),
         soil_moisture_residual=0.1,
+        soil_moisture_capacity=0.9,
         celsius_to_kelvin=HydroConsts.celsius_to_kelvin,
         density_air=dens_air,
         latent_heat_vapourisation=latvap,
@@ -46,7 +47,7 @@ def test_calculate_soil_evaporation(wind, dens_air, latvap):
         heat_transfer_coefficient=HydroConsts.heat_transfer_coefficient,
     )
 
-    exp_result = np.array([0.053332, 3.86474, 4.473155])
+    exp_result = np.array([0.060855, 0.060855, 4.473155])
     np.testing.assert_allclose(result, exp_result, rtol=0.01)
 
 

--- a/virtual_rainforest/models/hydrology/above_ground.py
+++ b/virtual_rainforest/models/hydrology/above_ground.py
@@ -20,6 +20,7 @@ def calculate_soil_evaporation(
     atmospheric_pressure: NDArray[np.float32],
     soil_moisture: NDArray[np.float32],
     soil_moisture_residual: Union[float, NDArray[np.float32]],
+    soil_moisture_capacity: Union[float, NDArray[np.float32]],
     wind_speed: Union[float, NDArray[np.float32]],
     celsius_to_kelvin: float,
     density_air: Union[float, NDArray[np.float32]],
@@ -51,6 +52,7 @@ def calculate_soil_evaporation(
         atmospheric_pressure: atmospheric pressure at reference height, [kPa]
         soil_moisture: Volumetric relative water content, [unitless]
         soil_moisture_residual: residual soil moisture, [unitless]
+        soil_moisture_capacity: soil moisture capacity, [unitless]
         wind_speed: wind speed at reference height, [m s-1]
         celsius_to_kelvin: factor to convert teperature from Celsius to Kelvin
         density_air: density if air, [kg m-3]
@@ -66,7 +68,11 @@ def calculate_soil_evaporation(
     temperature_k = temperature + celsius_to_kelvin
 
     # Available soil moisture
-    soil_moisture_free = soil_moisture - soil_moisture_residual
+    soil_moisture_free = np.clip(
+        (soil_moisture - soil_moisture_residual),
+        0.0,
+        (soil_moisture_capacity - soil_moisture_residual),
+    )
 
     # Estimate alpha using the Barton (1979) equation
     barton_ratio = (1.8 * soil_moisture_free) / (soil_moisture_free + 0.3)

--- a/virtual_rainforest/models/hydrology/hydrology_model.py
+++ b/virtual_rainforest/models/hydrology/hydrology_model.py
@@ -462,6 +462,7 @@ class HydrologyModel(BaseModel):
                 atmospheric_pressure=subcanopy_pressure,
                 soil_moisture=top_soil_moisture_vol,
                 soil_moisture_residual=self.constants.soil_moisture_residual,
+                soil_moisture_capacity=self.constants.soil_moisture_capacity,
                 wind_speed=0.1,  # m/s TODO wind_speed in data object
                 celsius_to_kelvin=self.constants.celsius_to_kelvin,
                 density_air=self.constants.density_air,

--- a/virtual_rainforest/models/hydrology/hydrology_model.py
+++ b/virtual_rainforest/models/hydrology/hydrology_model.py
@@ -406,6 +406,13 @@ class HydrologyModel(BaseModel):
             * soil_layer_thickness
         ).to_numpy()
 
+        top_soil_moisture_capacity_mm = (
+            self.constants.soil_moisture_capacity * soil_layer_thickness[0]
+        )
+        top_soil_moisture_residual_mm = (
+            self.constants.soil_moisture_residual * soil_layer_thickness[0]
+        )
+
         # Create lists for output variables to store daily data
         daily_lists: dict = {name: [] for name in self.vars_updated}
 
@@ -443,15 +450,18 @@ class HydrologyModel(BaseModel):
             soil_moisture_infiltrated = np.clip(
                 soil_moisture_mm[0] + precipitation_surface,
                 0,
-                (self.constants.soil_moisture_capacity * soil_layer_thickness[0]),
+                top_soil_moisture_capacity_mm,
             )
 
             # Calculate daily soil evaporation, [mm]
+            top_soil_moisture_vol = soil_moisture_infiltrated / soil_layer_thickness[0]
+
             soil_evaporation = above_ground.calculate_soil_evaporation(
                 temperature=subcanopy_temperature,
                 relative_humidity=subcanopy_humidity,
                 atmospheric_pressure=subcanopy_pressure,
-                soil_moisture=soil_moisture_infiltrated / soil_layer_thickness[0],
+                soil_moisture=top_soil_moisture_vol,
+                soil_moisture_residual=self.constants.soil_moisture_residual,
                 wind_speed=0.1,  # m/s TODO wind_speed in data object
                 celsius_to_kelvin=self.constants.celsius_to_kelvin,
                 density_air=self.constants.density_air,
@@ -465,7 +475,11 @@ class HydrologyModel(BaseModel):
             soil_moisture_evap: NDArray[np.float32] = np.concatenate(
                 (
                     np.expand_dims(
-                        (soil_moisture_infiltrated - soil_evaporation),
+                        np.clip(
+                            (soil_moisture_infiltrated - soil_evaporation),
+                            top_soil_moisture_residual_mm,
+                            top_soil_moisture_capacity_mm,
+                        ),
                         axis=0,
                     ),
                     soil_moisture_mm[1:],


### PR DESCRIPTION
This PR makes sure that soil moisture does not fall below residual soil moisture. This was likely the cause of this error occurring during `vr_run` : 

path/virtual_rainforest/virtual_rainforest/models/hydrology/below_ground.py:79: RuntimeWarning: invalid value encountered in sqrt* np.sqrt(effective_saturation)

I didn't add a specific test or warning message.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
