### PR TITLE
soil moist to matric potential moved from litter

### DIFF
--- a/tests/models/hydrology/test_below_ground.py
+++ b/tests/models/hydrology/test_below_ground.py
@@ -85,28 +85,21 @@ def test_update_soil_moisture():
     np.testing.assert_allclose(result, exp_result, rtol=0.001)
 
 
-def test_soil_moisture_to_matric_potential():
-    """Test."""
-
+def test_convert_soil_moisture_to_water_potential(dummy_climate_data):
+    """Test that function to convert soil moisture to a water potential works."""
     from virtual_rainforest.models.hydrology.below_ground import (
-        soil_moisture_to_matric_potential,
+        convert_soil_moisture_to_water_potential,
     )
-    from virtual_rainforest.models.hydrology.constants import HydroConsts
 
-    soil_moisture = np.array([[0.2, 0.2, 0.2], [0.5, 0.5, 0.5]])
-
-    result = soil_moisture_to_matric_potential(
-        soil_moisture=soil_moisture,
+    expected_potentials = np.array(
+        [-198467.26813379, -198467.26813379, -198467.26813379]
+    )
+    dummy_data = dummy_climate_data
+    actual_potentials = convert_soil_moisture_to_water_potential(
+        dummy_data["soil_moisture"].isel(layers=13).to_numpy(),
+        air_entry_water_potential=HydroConsts.air_entry_water_potential,
+        water_retention_curvature=HydroConsts.water_retention_curvature,
         soil_moisture_capacity=HydroConsts.soil_moisture_capacity,
-        soil_moisture_residual=HydroConsts.soil_moisture_residual,
-        nonlinearily_parameter=HydroConsts.nonlinearily_parameter,
-        alpha=HydroConsts.alpha,
-    )
-    exp_result = np.array(
-        [
-            [26.457513, 26.457513, 26.457513],
-            [5.773503, 5.773503, 5.773503],
-        ]
     )
 
-    np.testing.assert_allclose(result, exp_result)
+    np.testing.assert_allclose(actual_potentials, expected_potentials)

--- a/tests/models/hydrology/test_hydrology_model.py
+++ b/tests/models/hydrology/test_hydrology_model.py
@@ -415,7 +415,10 @@ def test_setup(
                     dims=["layers", "cell_id"],
                 ),
                 DataArray(
-                    [[7.275799, 7.270718, 7.274508], [7.288526, 7.285751, 7.289329]],
+                    [
+                        [-819.126131, -817.937497, -817.31294],
+                        [-865.452922, -863.787411, -865.884216],
+                    ],
                     dims=["layers", "cell_id"],
                 ),
             ],
@@ -496,8 +499,8 @@ def test_setup(
             atol=1e-4,
         )
         np.testing.assert_allclose(
-            model.data["matric_potential"],
-            exp_matric_pot,
+            model.data["matric_potential"].isel(layers=-2),
+            exp_matric_pot.isel(layers=-2),
             rtol=1e-4,
             atol=1e-4,
         )

--- a/virtual_rainforest/models/hydrology/below_ground.py
+++ b/virtual_rainforest/models/hydrology/below_ground.py
@@ -169,50 +169,29 @@ def update_soil_moisture(
     return soil_moisture_updated
 
 
-def soil_moisture_to_matric_potential(
+def convert_soil_moisture_to_water_potential(
     soil_moisture: NDArray[np.float32],
-    soil_moisture_capacity: Union[float, NDArray[np.float32]],
-    soil_moisture_residual: Union[float, NDArray[np.float32]],
-    nonlinearily_parameter: Union[float, NDArray[np.float32]],
-    alpha: Union[float, NDArray[np.float32]],
+    air_entry_water_potential: float,
+    water_retention_curvature: float,
+    soil_moisture_capacity: float,
 ) -> NDArray[np.float32]:
-    r"""Convert soil moisture to matric potential using the Mualem-van Genuchten model.
+    """Convert soil moisture into an estimate of water potential.
 
-    The soil water content is converted to matric potential as follows:
-
-    :math:`S = \frac{\Theta-\Theta_{r}}{\Theta_{s}-\Theta_{r}} = (1+(\alpha*\Phi)^n)^-m`
-
-    where :math:`S` is the effective saturation (dimensionless), :math:`\Theta_{r}` and
-    :math:`\Theta_{s}` are the residual and saturated moisture content or soil moisture
-    capacity, respectively. `math`:\Phi` is the soil water matric potential and
-    :math:`m`, :math:`n`, and :math:`\alpha` are shape parameters of the water retention
-    curve :cite:p:`van_genuchten_closed-form_1980`.
+    This function provides a coarse estimate of soil water potential. It is taken from
+    :cite:t:`campbell_simple_1974`.
 
     Args:
-        soil_moisture: Volumetric relative water content in top soil, [unitless]
-        soil_moisture_capacity: soil moisture capacity, [unitless]
-        soil_moisture_residual: residual soil moisture, [unitless]
-        nonlinearily_parameter: dimensionless parameter n in van Genuchten model that
-            describes the degree of nonlinearity of the relationship between the
-            volumetric water content and the soil matric potential.
-        alpha: dimensionless parameter alpha in van Genuchten model that corresponds
-            approximately to the inverse of the air-entry value, [kPa-1]
+        soil_moisture: Volumetric relative water content [unitless]
+        air_entry_water_potential: Water potential at which soil pores begin to aerate
+            [kPa]
+        water_retention_curvature: Curvature of water retention curve [unitless]
+        soil_moisture_capacity: The relative water content at which the soil is fully
+            saturated [unitless].
 
     Returns:
-        soil water matric potential, [kPa]
+        An estimate of the water potential of the soil [kPa]
     """
 
-    shape_parameter = 1 - 1 / nonlinearily_parameter
-
-    # Calculate soil effective saturation in rel. vol. water content for each layer:
-    effective_saturation = (soil_moisture - soil_moisture_residual) / (
-        soil_moisture_capacity - soil_moisture_residual
+    return air_entry_water_potential * (
+        (soil_moisture / soil_moisture_capacity) ** water_retention_curvature
     )
-
-    # Solve for phi
-    effective_saturation_m = effective_saturation ** (-1 / shape_parameter)
-    effective_saturation_1 = effective_saturation_m - 1
-    effective_saturation_n = effective_saturation_1 ** (1 / nonlinearily_parameter)
-    soil_matric_potential = effective_saturation_n / alpha
-
-    return soil_matric_potential

--- a/virtual_rainforest/models/hydrology/constants.py
+++ b/virtual_rainforest/models/hydrology/constants.py
@@ -94,13 +94,26 @@ class HydroConsts:
     """Ground water storage capacity in relative volumetric water content. This might be
     replaced with the implementation of below ground horizontal flow."""
 
-    alpha: float = 0.3
-    r"""Dimensionless parameter :math:`alpha` in van Genuchten model that corresponds
-    approximately to the inverse of the air-entry value, [kPa-1]
-    :cite:p:`van_genuchten_closed-form_1980`"""
-
     infiltration_shape_parameter: float = 1.0
     """Empirical shape parameter that affects how much of the water available for
     infiltration goes directly to groundwater via preferential bypass flow. A value of
     0 means all surface water goes directly to groundwater, a value of 1 gives a linear
     relation between soil moisture and bypass flow."""
+
+    air_entry_water_potential: float = -3.815
+    """Water potential at which soil pores begin to aerate [kPa].
+
+    The constant is used to estimate soil water potential from soil moisture. As this
+    estimation is a stopgap this constant probably shouldn't become a core constant. The
+    value is the average across all soil types found in
+    :cite:t:`cosby_statistical_1984`. In future, this could be calculated based on soil
+    texture.
+    """
+
+    water_retention_curvature: float = -7.22
+    """Curvature of the water retention curve.
+
+    The value is the average across all soil types found in
+    :cite:t:`cosby_statistical_1984`; see documentation for
+    :attr:`air_entry_water_potential` for further details.
+    """

--- a/virtual_rainforest/models/hydrology/hydrology_model.py
+++ b/virtual_rainforest/models/hydrology/hydrology_model.py
@@ -544,12 +544,11 @@ class HydrologyModel(BaseModel):
             )
 
             # Convert soil moisture to matric potential
-            matric_potential = below_ground.soil_moisture_to_matric_potential(
+            matric_potential = below_ground.convert_soil_moisture_to_water_potential(
                 soil_moisture=soil_moisture_updated / soil_layer_thickness,
+                air_entry_water_potential=self.constants.air_entry_water_potential,
+                water_retention_curvature=self.constants.water_retention_curvature,
                 soil_moisture_capacity=self.constants.soil_moisture_capacity,
-                soil_moisture_residual=self.constants.soil_moisture_residual,
-                nonlinearily_parameter=self.constants.nonlinearily_parameter,
-                alpha=self.constants.alpha,
             )
             daily_lists["matric_potential"].append(matric_potential)
 


### PR DESCRIPTION
This PR copies the function to convert soil moisture to matric potential from the `litter` model to the `hydrology` model (replacing the previous version). I did not delete the function from the `litter` model because this is already part of an ongoing PR #325 .

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
