### PR TITLE
Feature/vertical flow average

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,8 +186,8 @@ def dummy_carbon_data(layer_roles_fixture):
     data["litter_C_mineralisation_rate"] = DataArray(
         [0.00212106, 0.00106053, 0.00049000, 0.0055], dims=["cell_id"]
     )
-    # Data for combined vertical flow (for entire timestep)
-    data["vertical_flow"] = DataArray([3.0, 15.0, 75.0, 47.7], dims=["cell_id"])
+    # Data for average vertical flow
+    data["vertical_flow"] = DataArray([0.1, 0.5, 2.5, 1.59], dims=["cell_id"])
 
     # The layer dependant data has to be handled separately
     data["soil_moisture"] = xr.concat(

--- a/tests/models/hydrology/test_hydrology_model.py
+++ b/tests/models/hydrology/test_hydrology_model.py
@@ -402,7 +402,7 @@ def test_setup(
             coords={"cell_id": [0, 1, 2]},
         )
         exp_vertical_flow = DataArray(
-            [1.04541883, 1.04787099, 1.04524967],
+            [1.111498, 1.114365, 1.11434],
             dims=["cell_id"],
             coords={"cell_id": [0, 1, 2]},
         )

--- a/tests/models/hydrology/test_hydrology_model.py
+++ b/tests/models/hydrology/test_hydrology_model.py
@@ -402,7 +402,7 @@ def test_setup(
             coords={"cell_id": [0, 1, 2]},
         )
         exp_vertical_flow = DataArray(
-            [62.72513, 62.87226, 62.71498],
+            [1.04541883, 1.04787099, 1.04524967],
             dims=["cell_id"],
             coords={"cell_id": [0, 1, 2]},
         )

--- a/tests/models/soil/test_carbon.py
+++ b/tests/models/soil/test_carbon.py
@@ -43,8 +43,7 @@ def test_calculate_soil_carbon_updates(dummy_carbon_data, top_soil_layer_index):
         soil_water_potential=dummy_carbon_data["matric_potential"][
             top_soil_layer_index
         ].to_numpy(),
-        # TODO - Change this once average vertical flow is used
-        vertical_flow_rate=dummy_carbon_data["vertical_flow"] / 30.0,
+        vertical_flow_rate=dummy_carbon_data["vertical_flow"],
         soil_temp=dummy_carbon_data["soil_temperature"][top_soil_layer_index],
         clay_fraction=dummy_carbon_data["clay_fraction"],
         mineralisation_rate=dummy_carbon_data["litter_C_mineralisation_rate"],

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -290,7 +290,7 @@ def test_update(mocker, soil_model_fixture, dummy_carbon_data):
             Dataset(
                 data_vars=dict(
                     lmwc=DataArray(
-                        [0.04823845, 0.02119714, 0.0895863, 0.00528887], dims="cell_id"
+                        [0.04826774, 0.02126701, 0.09200601, 0.00544793], dims="cell_id"
                     ),
                     maom=DataArray(
                         [2.49936689, 1.70118553, 4.50085129, 0.50000614], dims="cell_id"
@@ -463,14 +463,10 @@ def test_construct_full_soil_model(dummy_carbon_data, top_soil_layer_index):
         if str(name).startswith("soil_c_pool_") or str(name).startswith("soil_enzyme_")
     }
 
-    # Find rate of flow per day
-    vertical_flow_per_day = dummy_carbon_data["vertical_flow"].to_numpy() / 30.0
-
     rate_of_change = construct_full_soil_model(
         0.0,
         pools=pools,
         data=dummy_carbon_data,
-        vertical_flow_per_day=vertical_flow_per_day,
         no_cells=4,
         top_soil_layer_index=top_soil_layer_index,
         delta_pools_ordered=delta_pools_ordered,

--- a/virtual_rainforest/models/hydrology/above_ground.py
+++ b/virtual_rainforest/models/hydrology/above_ground.py
@@ -30,7 +30,7 @@ def calculate_soil_evaporation(
     heat_transfer_coefficient: float,
     extinction_coefficient_global_radiation: float,
 ) -> NDArray[np.float32]:
-    r"""Calculate soil evaporation based classical bulk aerodynamic formulation.
+    r"""Calculate soil evaporation based on classical bulk aerodynamic formulation.
 
     This function uses the so-called 'alpha' method to estimate the evaporative flux
     :cite:p:`mahfouf_comparative_1991`.
@@ -51,7 +51,7 @@ def calculate_soil_evaporation(
 
     :math:`E_{act} = E_{g} * exp(-\kappa_{gb}*LAI)`
 
-    where :math:`kappa_{gb}` is the extinction coefficient for global radiation, and
+    where :math:`\kappa_{gb}` is the extinction coefficient for global radiation, and
     :math:`LAI` is the total leaf area index.
 
     Args:

--- a/virtual_rainforest/models/hydrology/below_ground.py
+++ b/virtual_rainforest/models/hydrology/below_ground.py
@@ -20,7 +20,7 @@ def calculate_vertical_flow(
     groundwater_capacity: Union[float, NDArray[np.float32]],
     seconds_to_day: float,
 ) -> NDArray[np.float32]:
-    r"""Calculate vertical water flow through soil column.
+    r"""Calculate vertical water flow through soil column, [mm d-1].
 
     To calculate the flow of water through unsaturated soil, this function uses the
     Richards equation. First, the function calculates the effective saturation :math:`S`
@@ -65,7 +65,7 @@ def calculate_vertical_flow(
         seconds_to_day: factor to convert between second and day
 
     Returns:
-        volumetric flow rate of water, [mm/timestep]
+        volumetric flow rate of water, [mm d-1]
     """
     shape_parameter = 1 - 1 / nonlinearily_parameter
 

--- a/virtual_rainforest/models/hydrology/hydrology_model.py
+++ b/virtual_rainforest/models/hydrology/hydrology_model.py
@@ -348,7 +348,8 @@ class HydrologyModel(BaseModel):
 
         Vertical flow between soil layers is calculated using the Richards equation, see
         :func:`~virtual_rainforest.models.hydrology.below_ground.calculate_vertical_flow`
-        . That function returns mean vertical flow in mm per day. Note that there are
+        . Here, the mean vertical flow in mm per day that goes though the top soil layer
+        is returned to the data object. Note that there are
         severe limitations to this approach on the temporal and spatial scale of this
         model and this can only be treated as a very rough approximation!
 

--- a/virtual_rainforest/models/hydrology/hydrology_model.py
+++ b/virtual_rainforest/models/hydrology/hydrology_model.py
@@ -307,7 +307,7 @@ class HydrologyModel(BaseModel):
         * surface_runoff, [mm], equivalent to SPLASH runoff
         * surface_runoff_accumulated, [mm]
         * soil_evaporation, [mm]
-        * vertical_flow, [mm/timestep]
+        * vertical_flow, [mm d-1]
         * groundwater_storage, [mm]
         * subsurface_flow, [mm]
         * baseflow, [mm]
@@ -348,7 +348,7 @@ class HydrologyModel(BaseModel):
 
         Vertical flow between soil layers is calculated using the Richards equation, see
         :func:`~virtual_rainforest.models.hydrology.below_ground.calculate_vertical_flow`
-        . That function returns total vertical flow in mm. Note that there are
+        . That function returns mean vertical flow in mm per day. Note that there are
         severe limitations to this approach on the temporal and spatial scale of this
         model and this can only be treated as a very rough approximation!
 
@@ -500,7 +500,7 @@ class HydrologyModel(BaseModel):
                 )
             )
 
-            # Calculate vertical flow between soil layers in mm per time step
+            # Calculate vertical flow between soil layers in mm per day
             # Note that there are severe limitations to this approach on the temporal
             # spatial scale of this model and this can only be treated as a very rough
             # approximation to discuss nutrient leaching.
@@ -590,7 +590,7 @@ class HydrologyModel(BaseModel):
             )
 
         soil_hydrology["vertical_flow"] = DataArray(
-            np.sum(daily_lists["vertical_flow"], axis=(0, 1)),
+            np.mean(daily_lists["vertical_flow"], axis=(0, 1)),
             dims="cell_id",
             coords={"cell_id": self.data.grid.cell_id},
         )

--- a/virtual_rainforest/models/hydrology/hydrology_model.py
+++ b/virtual_rainforest/models/hydrology/hydrology_model.py
@@ -575,7 +575,7 @@ class HydrologyModel(BaseModel):
         # create output dict as intermediate step to not overwrite data directly
         soil_hydrology = {}
 
-        # Calculate monthly accumulated values
+        # Calculate monthly accumulated/mean values with 'cell_id' dimension only
         for var in [
             "precipitation_surface",
             "surface_runoff",
@@ -589,8 +589,8 @@ class HydrologyModel(BaseModel):
                 coords={"cell_id": self.data.grid.cell_id},
             )
 
-        soil_hydrology["vertical_flow"] = DataArray(
-            np.mean(daily_lists["vertical_flow"], axis=(0, 1)),
+        soil_hydrology["vertical_flow"] = DataArray(  # vertical flow thought top soil
+            np.mean(np.stack(daily_lists["vertical_flow"][0], axis=1), axis=1),
             dims="cell_id",
             coords={"cell_id": self.data.grid.cell_id},
         )


### PR DESCRIPTION
This PR changes the unit of the vertical flow in the data object from accumulated mm per time step (month) to mean mm per day. This is what the soil model needs as an input and it saved some conversions.

Fixes #347 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
