### PR TITLE
Changed `open_mfdataset` call to use `lock=False` to fix `vr_run` halt

### DIFF
--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -497,7 +497,7 @@ def merge_continuous_data_files(
     check_outfile(out_path)
 
     # Open all files as a single dataset
-    with open_mfdataset(continuous_data_files) as all_data:
+    with open_mfdataset(continuous_data_files, lock=False) as all_data:
         # Specify type of the layer roles object to allow for quicker saving by dask
         all_data["layer_roles"] = all_data["layer_roles"].astype("S9")
 


### PR DESCRIPTION
# Description

Where `open_mfdataset` is used it is now called with the `lock=false` option selected. This should prevent `vr_run` from halting during CI.

I couldn't think of any way to prove that this has fixed the issue, but I did run `vr_run` locally 10 times without a stall. Previously this would have caused ~3 stalls on average.

Partially addresses #354, think the issue should be kept open so we have a way of tracking if this fix works sufficiently well.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
