### PR TITLE
Remove Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - uses: pre-commit/action@v3.0.0
 
   test:
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.9" , "3.10", "3.11" ]
+        python-version: [ "3.10", "3.11" ]
 
     steps:
     - uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
       run: poetry run pytest --cov-report xml
 
     - name: Upload coverage to Codecov
-      if: (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9')
+      if: (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10')
       uses: codecov/codecov-action@v3
 
   docs_build:
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,8 @@ repos:
     rev: v0.33.0
     hooks:
     - id: markdownlint
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.13.0
+    hooks:
+      - id: pyupgrade
+        args: [--py310-plus]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -110,6 +110,7 @@ nitpick_ignore = [
     ("py:class", "virtual_rainforest.models.abiotic.energy_balance.EnergyBalance"),
     # Something off about JSONSchema intersphinx mapping?
     ("py:obj", "virtual_rainforest.core.schema.ValidatorWithDefaults.ID_OF"),
+    ("py:class", "virtual_rainforest.core.grid.GRID_STRUCTURE_SIG"),
 ]
 intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -110,7 +110,7 @@ nitpick_ignore = [
     ("py:class", "virtual_rainforest.models.abiotic.energy_balance.EnergyBalance"),
     # Something off about JSONSchema intersphinx mapping?
     ("py:obj", "virtual_rainforest.core.schema.ValidatorWithDefaults.ID_OF"),
-    ("py:class", "virtual_rainforest.core.grid.GRID_STRUCTURE_SIG"),
+    ("py:obj", "virtual_rainforest.core.grid.GRID_STRUCTURE_SIG"),
 ]
 intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Collection of fixtures to assist the testing scripts."""
 from logging import DEBUG
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import pytest
@@ -18,7 +18,7 @@ LOGGER.setLevel(DEBUG)
 def log_check(
     caplog: pytest.LogCaptureFixture,
     expected_log: tuple[tuple],
-    subset: Optional[slice] = None,
+    subset: slice | None = None,
 ) -> None:
     """Helper function to check that the captured log is as expected.
 

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -879,8 +879,7 @@ def test_save_timeslice_to_netcdf(
 
         # Check that only expected variables were added
         assert (
-            set(saved_data.keys()) - set(["soil_c_pool_lmwc", "soil_temperature"])
-            == set()
+            set(saved_data.keys()) - {"soil_c_pool_lmwc", "soil_temperature"} == set()
         )
         # Finally, close the dataset
         saved_data.close()

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -100,9 +100,13 @@ def test_merge_schemas():
         }
     )
 
-    assert set(merged_schemas["required"]) == set(
-        ["abiotic_simple", "animals", "plants", "soil", "core"]
-    )
+    assert set(merged_schemas["required"]) == {
+        "abiotic_simple",
+        "animals",
+        "plants",
+        "soil",
+        "core",
+    }
 
 
 def test_extend_with_default():

--- a/tests/models/animals/test_animal_communities.py
+++ b/tests/models/animals/test_animal_communities.py
@@ -68,7 +68,7 @@ class TestAnimalCommunity:
         self, animal_community_instance, animal_cohort_instance
     ):
         """Test the all_animal_cohorts property."""
-        from typing import Iterable
+        from collections.abc import Iterable
 
         # Add an animal cohort to the community
         animal_community_instance.animal_cohorts["herbivorous_mammal"].append(

--- a/tests/models/plants/test_community.py
+++ b/tests/models/plants/test_community.py
@@ -97,7 +97,7 @@ def test_PlantCommunities__init__(caplog, flora, vars, raises, exp_log):
         if isinstance(raises, does_not_raise):
             # Check the expected contents of plants_obj
             assert len(plants_obj) == 4
-            cids = set([0, 1, 2, 3])
+            cids = {0, 1, 2, 3}
             assert set(plants_obj.keys()) == cids
             for cid in cids:
                 assert len(plants_obj[cid]) == 1

--- a/virtual_rainforest/core/axes.py
+++ b/virtual_rainforest/core/axes.py
@@ -45,7 +45,7 @@ The :class:`~virtual_rainforest.core.axes.AxisValidator` subclasses defined for 
 """  # noqa: D205, D415
 
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Type
+from typing import Any
 
 import numpy as np
 from xarray import DataArray
@@ -163,7 +163,7 @@ class AxisValidator(ABC):
         """
 
 
-AXIS_VALIDATORS: dict[str, list[Type[AxisValidator]]] = {}
+AXIS_VALIDATORS: dict[str, list[type[AxisValidator]]] = {}
 """A registry for different axis validators subclasses
 
 This registry contains a dictionary of lists of AxisValidator subclasses. Each list
@@ -206,12 +206,12 @@ def validate_dataarray(
         RuntimeError: If more than one validator reports that it can validate an input.
     """
 
-    validation_dict: dict[str, Optional[str]] = {}
+    validation_dict: dict[str, str | None] = {}
     to_raise: Exception
 
     # Get the validators applying to each axis
     for axis in AXIS_VALIDATORS:
-        validators: list[Type[AxisValidator]] = AXIS_VALIDATORS[axis]
+        validators: list[type[AxisValidator]] = AXIS_VALIDATORS[axis]
 
         # Get the set of dim names across all of the validators for this axis
         validator_dims = set.union(*[v.dim_names for v in validators])

--- a/virtual_rainforest/core/config.py
+++ b/virtual_rainforest/core/config.py
@@ -11,7 +11,7 @@ import sys
 from collections.abc import Sequence
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 import tomli_w
 from jsonschema import FormatChecker
@@ -169,20 +169,20 @@ class Config(dict):
 
     def __init__(
         self,
-        cfg_paths: Union[str, Path, Sequence[Union[str, Path]]] = [],
-        cfg_strings: Union[str, list[str]] = [],
+        cfg_paths: str | Path | Sequence[str | Path] = [],
+        cfg_strings: str | list[str] = [],
         override_params: dict[str, Any] = {},
         auto: bool = True,
     ) -> None:
         # Define custom attributes
         self.cfg_paths: list[Path] = []
         """The configuration file paths, normalised from the cfg_paths argument."""
-        self.toml_files: list[Union[str, Path]] = []
+        self.toml_files: list[str | Path] = []
         """A list of TOML file paths resolved from the initial config paths."""
         self.cfg_strings: list[str] = []
         """A list of strings containing TOML content, provided by the ``cfg_strings``
         argument."""
-        self.toml_contents: dict[Union[str, Path], dict] = {}
+        self.toml_contents: dict[str | Path, dict] = {}
         """A dictionary of the parsed TOML contents of config files or strings, keyed by
         file path or string index."""
         self.merge_conflicts: list = []
@@ -282,9 +282,9 @@ class Config(dict):
                 self.toml_files.append(path)
 
         # Check that no files are resolved twice
-        dupl_files = set(
-            [str(md) for md in self.toml_files if self.toml_files.count(md) > 1]
-        )
+        dupl_files = {
+            str(md) for md in self.toml_files if self.toml_files.count(md) > 1
+        }
         if dupl_files:
             all_valid = False
             LOGGER.error(f"Repeated files in config paths: {','.join(dupl_files)}")

--- a/virtual_rainforest/core/data.py
+++ b/virtual_rainforest/core/data.py
@@ -121,7 +121,7 @@ file.
 """  # noqa: D205, D415
 
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 from xarray import DataArray, Dataset, open_mfdataset
@@ -160,7 +160,7 @@ class Data:
         """The configured Grid to be used in a simulation."""
         self.data = Dataset()
         """The :class:`~xarray.Dataset` used to store data."""
-        self.variable_validation: dict[str, dict[str, Optional[str]]] = {}
+        self.variable_validation: dict[str, dict[str, str | None]] = {}
         """Records validation details for loaded variables.
 
         The validation details for each variable is stored in this dictionary using the
@@ -318,9 +318,9 @@ class Data:
             # for other loading problems
             data_var_names = [v["var_name"] for v in data_config["variable"]]
 
-            dupl_names = set(
-                [str(md) for md in data_var_names if data_var_names.count(md) > 1]
-            )
+            dupl_names = {
+                str(md) for md in data_var_names if data_var_names.count(md) > 1
+            }
             if dupl_names:
                 LOGGER.error("Duplicate variable names in data configuration.")
                 clean_load = False
@@ -355,7 +355,7 @@ class Data:
             raise ConfigurationError(msg)
 
     def save_to_netcdf(
-        self, output_file_path: Path, variables_to_save: Optional[list[str]] = None
+        self, output_file_path: Path, variables_to_save: list[str] | None = None
     ) -> None:
         """Save the contents of the data object as a NetCDF file.
 
@@ -521,7 +521,7 @@ class DataGenerator:
         spatial_axis: str,
         temporal_axis: str,
         temporal_interpolation: np.timedelta64,
-        seed: Optional[int],
+        seed: int | None,
         method: str,  # one of the numpy.random.Generator methods
         **kwargs: Any,
     ) -> None:

--- a/virtual_rainforest/core/grid.py
+++ b/virtual_rainforest/core/grid.py
@@ -33,7 +33,7 @@ grid of that type. Users can register their own grid types using the `register_g
 decorator.
 """
 
-GRID_STRUCTURE_SIG: TypeAlias = tuple[list[int], list[Any]]
+GRID_STRUCTURE_SIG: TypeAlias = tuple[list[int], list[Polygon]]
 """Type signature of the data structure to be returned from grid creator functions.
 
 The first value is a list of integer cell ids, the second is a matching list of the

--- a/virtual_rainforest/core/grid.py
+++ b/virtual_rainforest/core/grid.py
@@ -13,7 +13,8 @@ underlying the simulation and to identify the neighbourhood connections of cells
 from __future__ import annotations
 
 import json
-from typing import Any, Callable, Optional, Sequence, Tuple, Union
+from collections.abc import Callable, Sequence
+from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
@@ -32,7 +33,7 @@ grid of that type. Users can register their own grid types using the `register_g
 decorator.
 """
 
-GRID_STRUCTURE_SIG = Tuple[list[int], list[Polygon]]
+GRID_STRUCTURE_SIG = tuple[list[int], list[Polygon]]
 """Signature of the data structure to be returned from grid creator functions.
 
 The first value is a list of integer cell ids, the second is a matching list of the
@@ -263,10 +264,10 @@ class Grid:
 
         # Define other attributes set by methods
         # TODO - this might become a networkx graph
-        self._neighbours: Optional[list[NDArray[np.int_]]] = None
+        self._neighbours: list[NDArray[np.int_]] | None = None
 
         # Do not by default store the full distance matrix
-        self._distances: Optional[NDArray] = None
+        self._distances: NDArray | None = None
 
     @property
     def neighbours(self) -> list[NDArray[np.int_]]:
@@ -381,7 +382,7 @@ class Grid:
         self,
         edges: bool = True,
         vertices: bool = False,
-        distance: Optional[float] = None,
+        distance: float | None = None,
     ) -> None:
         """Populate the neighbour list for a Grid object.
 
@@ -409,8 +410,8 @@ class Grid:
 
     def get_distances(
         self,
-        cell_from: Optional[Union[int, Sequence[int]]],
-        cell_to: Optional[Union[int, Sequence[int]]],
+        cell_from: int | Sequence[int] | None,
+        cell_to: int | Sequence[int] | None,
     ) -> np.ndarray:
         """Calculate euclidean distances between cell centroids.
 
@@ -459,7 +460,7 @@ class Grid:
         self,
         x_coords: np.ndarray,
         y_coords: np.ndarray,
-    ) -> list[list[Optional[int]]]:
+    ) -> list[list[int | None]]:
         """Map a set of coordinates onto grid cells.
 
         This function loops over points defined by pairs of x and y coordinates and maps
@@ -502,8 +503,8 @@ class Grid:
         self,
         x_coords: np.ndarray,
         y_coords: np.ndarray,
-        x_idx: Optional[np.ndarray],
-        y_idx: Optional[np.ndarray],
+        x_idx: np.ndarray | None,
+        y_idx: np.ndarray | None,
     ) -> tuple[np.ndarray, np.ndarray]:
         """Returns indexing to map xy coordinates a single cell_id axis.
 
@@ -549,7 +550,7 @@ class Grid:
             raise ValueError("Dimensions of x/y indices do not match coordinates")
 
         # Find the set of total number of cell mappings per point
-        cell_counts = set([len(mp) for mp in cell_map])
+        cell_counts = {len(mp) for mp in cell_map}
 
         # Raise an exception where not all coords fall in a grid cell
         if 0 in cell_counts:

--- a/virtual_rainforest/core/grid.py
+++ b/virtual_rainforest/core/grid.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable, Sequence
-from typing import Any
+from typing import Any, TypeAlias
 
 import numpy as np
 from numpy.typing import NDArray
@@ -33,8 +33,8 @@ grid of that type. Users can register their own grid types using the `register_g
 decorator.
 """
 
-GRID_STRUCTURE_SIG = tuple[list[int], list[Polygon]]
-"""Signature of the data structure to be returned from grid creator functions.
+GRID_STRUCTURE_SIG: TypeAlias = tuple[list[int], list[Any]]
+"""Type signature of the data structure to be returned from grid creator functions.
 
 The first value is a list of integer cell ids, the second is a matching list of the
 polygons for each cell id. Although cell ids could be a numpy array, the numpy int types
@@ -106,12 +106,15 @@ def make_square_grid(
     cell_y = np.flipud(idx_y) * scale_factor
 
     # Get the list of polygons
-    cell_list = [
+    cell_polygon_list: list[Polygon] = [
         translate(prototype, xoff=xf, yoff=yf)
         for xf, yf in zip(cell_x.flatten(), cell_y.flatten())
     ]
 
-    return cell_ids.flatten().tolist(), cell_list
+    # Get list of ids
+    cell_ids_list: list[int] = cell_ids.flatten().tolist()
+
+    return cell_ids_list, cell_polygon_list
 
 
 @register_grid(grid_type="hexagon")
@@ -169,12 +172,15 @@ def make_hex_grid(
     cell_y = 1.5 * side_length * np.flipud(idx_y)
 
     # Get the list of polygons
-    cell_list = [
+    cell_polygon_list: list[Polygon] = [
         translate(prototype, xoff=xf, yoff=yf)
         for xf, yf in zip(cell_x.flatten(), cell_y.flatten())
     ]
 
-    return cell_ids.flatten().tolist(), cell_list
+    # Get list of ids
+    cell_ids_list: list[int] = cell_ids.flatten().tolist()
+
+    return cell_ids_list, cell_polygon_list
 
 
 class Grid:

--- a/virtual_rainforest/core/readers.py
+++ b/virtual_rainforest/core/readers.py
@@ -31,8 +31,8 @@ using :func:`~virtual_rainforest.core.axes.validate_dataarray`. For example:
         # code to turn tif file into a data array
 """  # noqa: D205, D415
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from xarray import DataArray, load_dataset
 

--- a/virtual_rainforest/core/schema.py
+++ b/virtual_rainforest/core/schema.py
@@ -24,8 +24,9 @@ The JSONSchema documents for a module should be loaded when a model is imported 
 
 
 import json
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
 
 import dpath
 from jsonschema import Draft202012Validator, exceptions, validators
@@ -60,13 +61,12 @@ def set_defaults(
         if "default" in subschema:
             instance.setdefault(property, subschema["default"])
 
-    for error in Draft202012Validator.VALIDATORS["properties"](
+    yield from Draft202012Validator.VALIDATORS["properties"](
         validator,
         properties,
         instance,
         schema,
-    ):
-        yield error
+    )
 
 
 ValidatorWithDefaults = validators.extend(

--- a/virtual_rainforest/entry_points.py
+++ b/virtual_rainforest/entry_points.py
@@ -9,7 +9,7 @@ import textwrap
 from collections.abc import Sequence
 from pathlib import Path
 from shutil import copytree, ignore_patterns
-from typing import Any, Optional
+from typing import Any
 
 import virtual_rainforest as vr
 from virtual_rainforest import example_data_path
@@ -103,7 +103,7 @@ def install_example_directory(install_dir: Path) -> int:
     return 0
 
 
-def vr_run_cli(args_list: Optional[list[str]] = None) -> int:
+def vr_run_cli(args_list: list[str] | None = None) -> int:
     """Configure and run a Virtual Rainforest simulation.
 
     This program sets up and runs a Virtual Rainforest simulation. The program expects
@@ -159,7 +159,7 @@ def vr_run_cli(args_list: Optional[list[str]] = None) -> int:
     parser.add_argument(
         "--version",
         action="version",
-        version="%(prog)s {version}".format(version=vr.__version__),
+        version=f"%(prog)s {vr.__version__}",
     )
 
     parser.add_argument("cfg_paths", type=str, help="Paths to config files", nargs="*")

--- a/virtual_rainforest/main.py
+++ b/virtual_rainforest/main.py
@@ -9,7 +9,7 @@ from graphlib import CycleError, TopologicalSorter
 from itertools import chain
 from math import ceil
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any
 
 import pint
 from numpy import datetime64, timedelta64
@@ -215,10 +215,10 @@ def _get_model_sequence(
 
 
 def vr_run(
-    cfg_paths: Union[str, Path, Sequence[Union[str, Path]]] = [],
-    cfg_strings: Union[str, list[str]] = [],
+    cfg_paths: str | Path | Sequence[str | Path] = [],
+    cfg_strings: str | list[str] = [],
     override_params: dict[str, Any] = {},
-    logfile: Optional[Path] = None,
+    logfile: Path | None = None,
 ) -> None:
     """Perform a virtual rainforest simulation.
 

--- a/virtual_rainforest/models/animals/animal_cohorts.py
+++ b/virtual_rainforest/models/animals/animal_cohorts.py
@@ -8,9 +8,9 @@ Notes:
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from math import ceil
 from random import choice
-from typing import Optional, Sequence
 
 from numpy import random, timedelta64
 
@@ -121,7 +121,7 @@ class AnimalCohort:
             temperature,
             self.functional_group.metabolic_rate_terms,
             self.functional_group.metabolic_type,
-        ) * float((dt / timedelta64(1, "D")))
+        ) * float(dt / timedelta64(1, "D"))
 
         self.mass_current -= min(self.mass_current, mass_metabolized)
 
@@ -256,7 +256,7 @@ class AnimalCohort:
         animal_list: Sequence[Resource],
         carcass_pool: DecayPool,
         excrement_pool: DecayPool,
-    ) -> Optional[Resource]:  # Note the optional here, temporary
+    ) -> Resource | None:  # Note the optional here, temporary
         """This function handles selection of resources from a list of options.
 
         Currently, this function is passed a list of plant or animal resources from

--- a/virtual_rainforest/models/animals/animal_communities.py
+++ b/virtual_rainforest/models/animals/animal_communities.py
@@ -9,9 +9,9 @@ Notes:
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable
 from itertools import chain
 from random import choice
-from typing import Callable, Iterable
 
 from numpy import timedelta64
 
@@ -43,7 +43,7 @@ class AnimalCommunity:
         data: Data,
         community_key: int,
         neighbouring_keys: list[int],
-        get_destination: Callable[[int], "AnimalCommunity"],
+        get_destination: Callable[[int], AnimalCommunity],
         constants: AnimalConsts = AnimalConsts(),
     ) -> None:
         # The constructor of the AnimalCommunity class.

--- a/virtual_rainforest/models/hydrology/above_ground.py
+++ b/virtual_rainforest/models/hydrology/above_ground.py
@@ -5,7 +5,6 @@ runoff, bypass flow, and river discharge.
 """  # noqa: D205, D415
 
 from math import sqrt
-from typing import Optional, Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -19,13 +18,13 @@ def calculate_soil_evaporation(
     relative_humidity: NDArray[np.float32],
     atmospheric_pressure: NDArray[np.float32],
     soil_moisture: NDArray[np.float32],
-    soil_moisture_residual: Union[float, NDArray[np.float32]],
-    soil_moisture_capacity: Union[float, NDArray[np.float32]],
+    soil_moisture_residual: float | NDArray[np.float32],
+    soil_moisture_capacity: float | NDArray[np.float32],
     leaf_area_index: NDArray[np.float32],
-    wind_speed: Union[float, NDArray[np.float32]],
+    wind_speed: float | NDArray[np.float32],
     celsius_to_kelvin: float,
-    density_air: Union[float, NDArray[np.float32]],
-    latent_heat_vapourisation: Union[float, NDArray[np.float32]],
+    density_air: float | NDArray[np.float32],
+    latent_heat_vapourisation: float | NDArray[np.float32],
     gas_constant_water_vapour: float,
     heat_transfer_coefficient: float,
     extinction_coefficient_global_radiation: float,
@@ -291,7 +290,7 @@ def calculate_interception(
 def distribute_monthly_rainfall(
     total_monthly_rainfall: NDArray[np.float32],
     num_days: int,
-    seed: Optional[int] = None,
+    seed: int | None = None,
 ) -> NDArray[np.float32]:
     """Distributes total monthly rainfall over the specified number of days.
 
@@ -367,7 +366,7 @@ def calculate_bypass_flow(
 
 def convert_mm_flow_to_m3_per_second(
     river_discharge_mm: NDArray[np.float32],
-    area: Union[int, float],
+    area: int | float,
     days: int,
     seconds_to_day: float,
     meters_to_millimeters: float,

--- a/virtual_rainforest/models/hydrology/below_ground.py
+++ b/virtual_rainforest/models/hydrology/below_ground.py
@@ -3,7 +3,6 @@ processes for the Virtual Rainforest. This includes vertical flow, soil moisture
 matric potential, groundwater storage, and subsurface horizontal flow.
 """  # noqa: D205, D415
 
-from typing import Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -12,12 +11,12 @@ from numpy.typing import NDArray
 def calculate_vertical_flow(
     soil_moisture: NDArray[np.float32],
     soil_layer_thickness: NDArray[np.float32],
-    soil_moisture_capacity: Union[float, NDArray[np.float32]],
-    soil_moisture_residual: Union[float, NDArray[np.float32]],
-    hydraulic_conductivity: Union[float, NDArray[np.float32]],
-    hydraulic_gradient: Union[float, NDArray[np.float32]],
-    nonlinearily_parameter: Union[float, NDArray[np.float32]],
-    groundwater_capacity: Union[float, NDArray[np.float32]],
+    soil_moisture_capacity: float | NDArray[np.float32],
+    soil_moisture_residual: float | NDArray[np.float32],
+    hydraulic_conductivity: float | NDArray[np.float32],
+    hydraulic_gradient: float | NDArray[np.float32],
+    nonlinearily_parameter: float | NDArray[np.float32],
+    groundwater_capacity: float | NDArray[np.float32],
     seconds_to_day: float,
 ) -> NDArray[np.float32]:
     r"""Calculate vertical water flow through soil column, [mm d-1].
@@ -205,10 +204,10 @@ def update_groundwater_storge(
     groundwater_storage: NDArray[np.float32],
     vertical_flow_to_groundwater: NDArray[np.float32],
     bypass_flow: NDArray[np.float32],
-    max_percolation_rate_uzlz: Union[float, NDArray[np.float32]],
-    groundwater_loss: Union[float, NDArray[np.float32]],
-    reservoir_const_upper_groundwater: Union[float, NDArray[np.float32]],
-    reservoir_const_lower_groundwater: Union[float, NDArray[np.float32]],
+    max_percolation_rate_uzlz: float | NDArray[np.float32],
+    groundwater_loss: float | NDArray[np.float32],
+    reservoir_const_upper_groundwater: float | NDArray[np.float32],
+    reservoir_const_lower_groundwater: float | NDArray[np.float32],
 ) -> dict[str, NDArray[np.float32]]:
     r"""Update groundwater storage and calculate below ground horizontal flow.
 

--- a/virtual_rainforest/models/hydrology/hydrology_model.py
+++ b/virtual_rainforest/models/hydrology/hydrology_model.py
@@ -18,7 +18,7 @@ downstream functions so that all model configuration failures can be reported as
 from __future__ import annotations
 
 from math import sqrt
-from typing import Any, Union
+from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
@@ -395,7 +395,7 @@ class HydrologyModel(BaseModel):
         days: int = 30
 
         # Set seed for random rainfall generator
-        seed: Union[None, int] = kwargs.pop("seed", None)
+        seed: None | int = kwargs.pop("seed", None)
 
         # Select variables at relevant heights for current time step
         hydro_input = setup_hydrology_input_current_timestep(
@@ -692,7 +692,7 @@ def setup_hydrology_input_current_timestep(
     data: Data,
     time_index: int,
     days: int,
-    seed: Union[None, int],
+    seed: None | int,
     layer_roles: list[str],
     soil_moisture_capacity: float,
     soil_moisture_residual: float,

--- a/virtual_rainforest/models/litter/litter_pools.py
+++ b/virtual_rainforest/models/litter/litter_pools.py
@@ -16,8 +16,6 @@ The amount of lignin in both the structural pools and the dead wood pool is trac
 This is tracked because litter chemistry is a major determinant of litter decay rates.
 """  # noqa: D205, D415
 
-from typing import Union
-
 import numpy as np
 from numpy.typing import NDArray
 
@@ -735,9 +733,9 @@ def calculate_carbon_mineralised(
 
 
 def calculate_change_in_lignin(
-    input_carbon: Union[float, NDArray[np.float32]],
+    input_carbon: float | NDArray[np.float32],
     updated_pool_carbon: NDArray[np.float32],
-    input_lignin: Union[float, NDArray[np.float32]],
+    input_lignin: float | NDArray[np.float32],
     old_pool_lignin: NDArray[np.float32],
 ) -> NDArray[np.float32]:
     """Calculate the change in the lignin concentration of a particular litter pool.

--- a/virtual_rainforest/models/plants/community.py
+++ b/virtual_rainforest/models/plants/community.py
@@ -7,8 +7,8 @@ NOTE - much of this will be outsourced to pyrealm.
 
 """  # noqa: D205, D415
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Mapping
 
 import numpy as np
 from numpy.typing import NDArray


### PR DESCRIPTION
# Description

This PR is intended to remove Python 3.9. It adds `pyupgrade` to the `pre-commit` hooks with a minimum Python version of 3.10 and that then made a bunch of changes automatically. These are mostly:

- Replacing e.g. `set([1,2,3])` with the set literal `{1,2,3}`
- Replacing e.g. `Optional[int]` with `int | None`

Fixes #324

But at the moment, there are some issues about the documentation of `vr.core.grid.GRID_STRUCTURE_SIG`. I've updated the way that type alias is created, but `sphinx` is throwing errors. I _think_ it believes the type alias (`tuple[list[int], list[Polygon]]` is an actual tuple and is trying to document the `__repr__`, `count` and `index` methods?

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
