### PR TITLE
Add initial version of Variables

### DIFF
--- a/virtual_rainforest/core/variables.py
+++ b/virtual_rainforest/core/variables.py
@@ -1,0 +1,79 @@
+"""Module for all variables."""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Variable:
+    """Base class for all variables."""
+
+    name: str = ""
+    descritpion: str = ""
+    units: str = ""
+
+    def __init_subclass__(cls, name: str, descritpion: str, units: str) -> None:
+        """Checks if the variable class is unique and registers it.
+
+        Args:
+            name (str): Name of the variable.
+            descritpion (str): Description of the variable.
+            units (str): Units to use for the variable across the project.
+
+        Raises:
+            ValueError: If a variable class with the same name is already registered.
+            ValueError: If a variable with the same name field is already registered.
+        """
+        cls.name = name
+        cls.descritpion = descritpion
+        cls.units = units
+
+        if cls.__name__ in _UNIQUE_VARIABLES_CLASSES:
+            raise ValueError(f"Variable class {cls.__name__} already registered.")
+
+        if cls.name in _UNIQUE_VARIABLES_NAMES:
+            raise ValueError(f"Variable name {cls.name} already registered.")
+
+        _UNIQUE_VARIABLES_CLASSES.append(cls.__name__)
+        _UNIQUE_VARIABLES_NAMES.append(cls.name)
+
+    def __new__(cls) -> "Variable":
+        """Creates a new variable of this type or returns an existing one.
+
+        Returns:
+            Variable: The new or existing variable of this type.
+        """
+        if cls.name not in VARABLES_REGISTRY:
+            VARABLES_REGISTRY[cls.name] = super().__new__(cls)
+
+        return VARABLES_REGISTRY[cls.name]
+
+
+_UNIQUE_VARIABLES_CLASSES: list[str] = []
+_UNIQUE_VARIABLES_NAMES: list[str] = []
+VARABLES_REGISTRY: dict[str, Variable] = {}
+
+
+class Temperature(Variable, name="temperature", descritpion="Temperature", units="K"):
+    """Temperature variable."""
+
+
+class Pressure(Variable, name="pressure", descritpion="Pressure", units="Pa"):
+    """Pressure variable."""
+
+
+if __name__ == "__main__":
+    print(_UNIQUE_VARIABLES_CLASSES)
+    print(_UNIQUE_VARIABLES_NAMES)
+
+    T = Temperature()
+    P = Pressure()
+
+    T2 = Temperature()
+    P2 = Pressure()
+
+    assert T is T2
+    assert P is P2
+    assert T == T2
+    assert P == P2
+
+    # This should raise an error
+    # T.name = "T2"

--- a/virtual_rainforest/core/variables.py
+++ b/virtual_rainforest/core/variables.py
@@ -70,6 +70,8 @@ if __name__ == "__main__":
     T2 = Temperature()
     P2 = Pressure()
 
+    print(VARABLES_REGISTRY)
+
     assert T is T2
     assert P is P2
     assert T == T2

--- a/virtual_rainforest/core/variables.py
+++ b/virtual_rainforest/core/variables.py
@@ -1,14 +1,14 @@
 """Module for all variables."""
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
 class Variable:
     """Base class for all variables."""
 
-    name: str = ""
-    descritpion: str = ""
-    units: str = ""
+    name: str = field(init=False)
+    descritpion: str = field(init=False)
+    units: str = field(init=False)
 
     def __init_subclass__(cls, name: str, descritpion: str, units: str) -> None:
         """Checks if the variable class is unique and registers it.


### PR DESCRIPTION
# Description

Initial attempt at creating a Variable class that can be used to define the metadata of all the variables in Virtual Rainforest. For now, a proof of concept to gather feedback on the implementation. 

I'm assuming here that:
- Only one class for any given variable can exist.
- There name given to a variable must be unique.
- Variables are singleton - so only one instance of each variable can exist. 
- Variables are immutable and will not be change anywhere in the project. 

# Outstanding questions

- How is the registry meant to be used?
- Is it registering the variables by `variable.name` ok or is shall we use a different field?
- Do we need to protect it somehow so that it can only be modified when creating a new subclass, eg. by making it private and only exposing a copy of it with a function like `get_variable_registry()`?
- What fields do you want to include? Need full list with types.
- What variables do you want to include? Need full list with field values.

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
