### PR TITLE
Adding automodule hooks for plants model to docs

### DIFF
--- a/docs/source/api/plants/plant_structures.md
+++ b/docs/source/api/plants/plant_structures.md
@@ -1,0 +1,48 @@
+---
+jupytext:
+  cell_metadata_filter: -all
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.8
+kernelspec:
+  display_name: vr_python3
+  language: python
+  name: vr_python3
+---
+
+# Plant structures for the {mod}`~virtual_rainforest.models.plants` module
+
+This page documents three submodules of the `plants` module:
+
+1. The plant functional types (PFTs) that make up the flora used in a simulation.
+2. The plant community structures, describing the cohorts of stems of different PFTs
+   with different diameters at breast height within a grid cell.
+3. The canopy structure generated in a grid cell by the plant community.
+
+## The plant {mod}`~virtual_rainforest.models.plants.functional_types` module
+
+```{eval-rst}
+.. automodule:: virtual_rainforest.models.plants.functional_types
+    :autosummary:
+    :members:
+```
+
+## The plants {mod}`~virtual_rainforest.models.plants.community` module
+
+```{eval-rst}
+.. automodule:: virtual_rainforest.models.plants.community
+    :autosummary:
+    :members:
+```
+
+## The plants {mod}`~virtual_rainforest.models.plants.canopy` module
+
+```{eval-rst}
+.. automodule:: virtual_rainforest.models.plants.canopy
+    :autosummary:
+    :members:
+```

--- a/docs/source/api/plants/plants_model.md
+++ b/docs/source/api/plants/plants_model.md
@@ -1,0 +1,40 @@
+---
+jupytext:
+  cell_metadata_filter: -all
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.8
+kernelspec:
+  display_name: vr_python3
+  language: python
+  name: vr_python3
+---
+
+# API documentation for the plants model
+
+```{eval-rst}
+.. automodule:: virtual_rainforest.models.plants
+    :autosummary:
+    :members:
+```
+
+## The {mod}`~virtual_rainforest.models.plants.plants_model` module
+
+```{eval-rst}
+.. automodule:: virtual_rainforest.models.plants.plants_model
+    :autosummary:
+    :members:
+    :exclude-members: model_name
+```
+
+## The plants {mod}`~virtual_rainforest.models.plants.constants` module
+
+```{eval-rst}
+.. automodule:: virtual_rainforest.models.plants.constants
+    :autosummary:
+    :members:
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -106,6 +106,7 @@ nitpicky = True
 nitpick_ignore = [
     ("py:class", "numpy.int64"),
     ("py:class", "numpy.float32"),
+    ("py:class", "numpy._typing._array_like._ScalarType_co"),
     # TODO - Delete this once Vivienne has merged this feature into develop
     ("py:class", "virtual_rainforest.models.abiotic.energy_balance.EnergyBalance"),
     # Something off about JSONSchema intersphinx mapping?

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -126,8 +126,8 @@ team.
   Litter Model <api/litter/litter_model.md>
   Litter Pools <api/litter/litter_pools.md>
   Litter Constants <api/litter/constants.md>
-  
-  
+  Plants Model <api/plants/plants_model.md>
+  Plants Strucutres <api/plants/plant_structures.md>
 ```
 
 ```{eval-rst}

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -127,7 +127,7 @@ team.
   Litter Pools <api/litter/litter_pools.md>
   Litter Constants <api/litter/constants.md>
   Plants Model <api/plants/plants_model.md>
-  Plants Strucutres <api/plants/plant_structures.md>
+  Plants Structures <api/plants/plant_structures.md>
 ```
 
 ```{eval-rst}

--- a/virtual_rainforest/models/plants/constants.py
+++ b/virtual_rainforest/models/plants/constants.py
@@ -1,5 +1,5 @@
-"""This submodule contains a set of dataclasses containing constants used in the
-:mod:`~virtual_rainforest.models.plants` module.
+"""This submodule contains a set of dataclasses containing constants used
+in the :mod:`~virtual_rainforest.models.plants` module.
 """  # noqa: D205, D415
 
 from dataclasses import dataclass
@@ -9,7 +9,7 @@ from virtual_rainforest.core.constants_class import ConstantsDataclass
 
 @dataclass(frozen=True)
 class PlantsConsts(ConstantsDataclass):
-    """Constants for the :mod:`~virtual_rainforest.models.plants`model."""
+    """Constants for the :mod:`~virtual_rainforest.models.plants` model."""
 
     placeholder: float = 1.0
     """Placeholder constant."""

--- a/virtual_rainforest/models/plants/functional_types.py
+++ b/virtual_rainforest/models/plants/functional_types.py
@@ -16,7 +16,9 @@ class PlantFunctionalType:
     """Data class containing plant functional type definitions."""
 
     pft_name: str
+    """The name of the plant functional type."""
     max_height: float
+    """The maximum stem height of the plant functional type."""
 
 
 class Flora(dict):
@@ -33,7 +35,7 @@ class Flora(dict):
     Args:
         pfts: A list of ``PlantFunctionalType`` instances, which must not have
             duplicated
-            :class:`~virtual_rainforest.models.plants.functional_types.PlantFunctionalType.pft_name`
+            :attr:`~virtual_rainforest.models.plants.functional_types.PlantFunctionalType.pft_name`
             attributes.
     """
 


### PR DESCRIPTION
# Description

This PR adds missing `autodoc` hooks for the `models/plants` docstrings.

Fixes #379 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [-] Code is commented, particularly in hard-to-understand areas
- [-] Tests added that prove fix is effective or that feature works
