### PR TITLE
Fixing broken tests

### DIFF
--- a/virtual_rainforest/example_data/config/vr_run.toml
+++ b/virtual_rainforest/example_data/config/vr_run.toml
@@ -1,5 +1,6 @@
 [core]
 [hydrology.depends]
+init = ['plants']
 update = ['plants', 'abiotic_simple']
 [abiotic_simple]
 [animals]


### PR DESCRIPTION
# Description

Hopefully this fixes #390.

I think the issue is that the `hydrology` model needs to initialise _after_ `plants`, because that populates the `leaf_area_index` data. That isn't explicitly set in the configuration, so then I think we are getting platform specific variation in the way `TopologicalSorter` is returning 'tied' models, such that `plants` and `hydrology` can vary in their execution order.

More generally - this kinda thing needs to break in a much more informative way, but the variables stuff is targeted at this (#370, #388).

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
