### PR TITLE
Adding non-predation mortality and semelparity to the Animal Module.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,6 +191,7 @@ def fixture_config():
         taxa = "bird"
         diet = "carnivore"
         metabolic_type = "endothermic"
+        reproductive_type = "iteroparous"
         birth_mass = 0.1
         adult_mass = 1.0
         [[animals.functional_groups]]
@@ -198,6 +199,7 @@ def fixture_config():
         taxa = "bird"
         diet = "herbivore"
         metabolic_type = "endothermic"
+        reproductive_type = "iteroparous"
         birth_mass = 0.05
         adult_mass = 0.5
         [[animals.functional_groups]]
@@ -205,6 +207,7 @@ def fixture_config():
         taxa = "mammal"
         diet = "carnivore"
         metabolic_type = "endothermic"
+        reproductive_type = "iteroparous"
         birth_mass = 4.0
         adult_mass = 40.0
         [[animals.functional_groups]]
@@ -212,6 +215,7 @@ def fixture_config():
         taxa = "mammal"
         diet = "herbivore"
         metabolic_type = "endothermic"
+        reproductive_type = "iteroparous"
         birth_mass = 1.0
         adult_mass = 10.0
         [[animals.functional_groups]]
@@ -219,6 +223,7 @@ def fixture_config():
         taxa = "insect"
         diet = "carnivore"
         metabolic_type = "ectothermic"
+        reproductive_type = "semelparous"
         birth_mass = 0.001
         adult_mass = 0.01
         [[animals.functional_groups]]
@@ -226,6 +231,7 @@ def fixture_config():
         taxa = "insect"
         diet = "herbivore"
         metabolic_type = "ectothermic"
+        reproductive_type = "iteroparous"
         birth_mass = 0.0005
         adult_mass = 0.005
         """

--- a/tests/core/data/all_config.toml
+++ b/tests/core/data/all_config.toml
@@ -36,6 +36,7 @@ diet = "carnivore"
 metabolic_type = "endothermic"
 birth_mass = 0.1
 adult_mass = 1.0
+reproductive_type = "iteroparous"
 
 [[animals.functional_groups]]
 name = "herbivorous_bird"
@@ -44,6 +45,7 @@ diet = "herbivore"
 metabolic_type = "endothermic"
 birth_mass = 0.05
 adult_mass = 0.5
+reproductive_type = "iteroparous"
 
 [[animals.functional_groups]]
 name = "carnivorous_mammal"
@@ -52,6 +54,7 @@ diet = "carnivore"
 metabolic_type = "endothermic"
 birth_mass = 4.0
 adult_mass = 40.0
+reproductive_type = "iteroparous"
 
 [[animals.functional_groups]]
 name = "herbivorous_mammal"
@@ -60,6 +63,7 @@ diet = "herbivore"
 metabolic_type = "endothermic"
 birth_mass = 1.0
 adult_mass = 10.0
+reproductive_type = "iteroparous"
 
 [[animals.functional_groups]]
 name = "carnivorous_insect"
@@ -68,6 +72,7 @@ diet = "carnivore"
 metabolic_type = "ectothermic"
 birth_mass = 0.001
 adult_mass = 0.01
+reproductive_type = "iteroparous"
 
 [[animals.functional_groups]]
 name = "herbivorous_insect"
@@ -76,3 +81,4 @@ diet = "herbivore"
 metabolic_type = "ectothermic"
 birth_mass = 0.0005
 adult_mass = 0.005
+reproductive_type = "semelparous"

--- a/tests/models/animals/data/example_functional_group_import.csv
+++ b/tests/models/animals/data/example_functional_group_import.csv
@@ -1,7 +1,9 @@
-name,taxa,diet,metabolic_type,birth_mass,adult_mass
-carnivorous_bird,bird,carnivore,endothermic,0.1,1.0
-herbivorous_bird,bird,herbivore,endothermic,0.05,0.5
-carnivorous_mammal,mammal,carnivore,endothermic,4.0,40.0
-herbivorous_mammal,mammal,herbivore,endothermic,1.0,10.0
-carnivorous_insect,insect,carnivore,ectothermic,0.001,0.01
-herbivorous_insect,insect,herbivore,ectothermic,0.0005,0.005
+name,taxa,diet,metabolic_type,reproductive_type,birth_mass,adult_mass
+carnivorous_bird,bird,carnivore,endothermic,iteroparous,0.1,1.0
+herbivorous_bird,bird,herbivore,endothermic,iteroparous,0.05,0.5
+carnivorous_mammal,mammal,carnivore,endothermic,iteroparous,4.0,40.0
+herbivorous_mammal,mammal,herbivore,endothermic,iteroparous,1.0,10.0
+carnivorous_insect,insect,carnivore,ectothermic,iteroparous,0.001,0.01
+herbivorous_insect,insect,herbivore,ectothermic,iteroparous,0.0005,0.005
+carnivorous_insect,insect,carnivore,ectothermic,semelparous,0.001,0.01
+herbivorous_insect,insect,herbivore,ectothermic,semelparous,0.0005,0.005

--- a/tests/models/animals/data/example_functional_group_import.csv
+++ b/tests/models/animals/data/example_functional_group_import.csv
@@ -3,7 +3,7 @@ carnivorous_bird,bird,carnivore,endothermic,iteroparous,0.1,1.0
 herbivorous_bird,bird,herbivore,endothermic,iteroparous,0.05,0.5
 carnivorous_mammal,mammal,carnivore,endothermic,iteroparous,4.0,40.0
 herbivorous_mammal,mammal,herbivore,endothermic,iteroparous,1.0,10.0
-carnivorous_insect,insect,carnivore,ectothermic,iteroparous,0.001,0.01
-herbivorous_insect,insect,herbivore,ectothermic,iteroparous,0.0005,0.005
-carnivorous_insect,insect,carnivore,ectothermic,semelparous,0.001,0.01
-herbivorous_insect,insect,herbivore,ectothermic,semelparous,0.0005,0.005
+carnivorous_insect_iteroparous,insect,carnivore,ectothermic,iteroparous,0.001,0.01
+herbivorous_insect_iteroparous,insect,herbivore,ectothermic,iteroparous,0.0005,0.005
+carnivorous_insect_semelparous,insect,carnivore,ectothermic,semelparous,0.001,0.01
+herbivorous_insect_semelparous,insect,herbivore,ectothermic,semelparous,0.0005,0.005

--- a/tests/models/animals/test_animal_cohorts.py
+++ b/tests/models/animals/test_animal_cohorts.py
@@ -1052,7 +1052,7 @@ class TestAnimalCohort:
             ),
         ],
     )
-    def test_total_non_predation_mortality(
+    def test_inflict_non_predation_mortality(
         self,
         mocker,
         is_mature,
@@ -1107,7 +1107,7 @@ class TestAnimalCohort:
         print(f"Initial individuals: {cohort.individuals}")
 
         # Run the method
-        cohort.total_non_predation_mortality(dt, carcass_pool_instance)
+        cohort.inflict_non_predation_mortality(dt, carcass_pool_instance)
 
         # Calculate expected number of deaths inside the test
         u_bg_value = sf.background_mortality(u_bg)

--- a/tests/models/animals/test_animal_communities.py
+++ b/tests/models/animals/test_animal_communities.py
@@ -233,41 +233,78 @@ class TestAnimalCommunity:
             not in animal_community_instance.animal_cohorts["herbivorous_mammal"]
         )
 
+    @pytest.mark.parametrize(
+        "reproductive_type, initial_mass, expected_offspring",
+        [
+            pytest.param("iteroparous", 10, 1, id="iteroparous_survival"),
+            pytest.param("semelparous", 10, 1, id="semelparous_death"),
+        ],
+    )
     def test_birth(
-        self, animal_community_instance, animal_cohort_instance, constants_instance
+        self,
+        reproductive_type,
+        initial_mass,
+        expected_offspring,
+        animal_community_instance,
+        animal_cohort_instance,
     ):
-        """Test the birth method in AnimalCommunity."""
+        """Test the birth method in AnimalCommunity under various conditions."""
 
         # Setup initial conditions
         parent_cohort_name = animal_cohort_instance.name
-        animal_community_instance.animal_cohorts[parent_cohort_name].append(
-            animal_cohort_instance
+        animal_cohort_instance.functional_group.reproductive_type = reproductive_type
+        animal_cohort_instance.functional_group.birth_mass = (
+            2  # Assuming a specific birth mass
         )
-        initial_cohort_count = len(
+        animal_cohort_instance.mass_current = initial_mass
+        animal_cohort_instance.individuals = 10
+
+        # Prepare the community
+        animal_community_instance.animal_cohorts[parent_cohort_name] = [
+            animal_cohort_instance
+        ]
+
+        number_cohorts = len(
             animal_community_instance.animal_cohorts[parent_cohort_name]
         )
-
-        # Set the reproductive mass of the parent cohort to ensure it can reproduce
-        required_mass_for_birth = (
-            animal_cohort_instance.functional_group.adult_mass
-            * constants_instance.birth_mass_threshold
-            - animal_cohort_instance.functional_group.adult_mass
-        )
-
-        animal_cohort_instance.reproductive_mass = required_mass_for_birth
 
         # Call the birth method
         animal_community_instance.birth(animal_cohort_instance)
 
         # Assertions
-        # 1. Check that a new cohort is added
-        new_cohort_count = len(
-            animal_community_instance.animal_cohorts[parent_cohort_name]
-        )
-        assert new_cohort_count == initial_cohort_count + 1
+        # 1. Check for changes in the parent cohort based on reproductive type
+        if reproductive_type == "semelparous":
+            # The parent should be removed if it dies
+            assert (
+                animal_cohort_instance
+                not in animal_community_instance.animal_cohorts[parent_cohort_name]
+            )
+        else:
+            # Reproductive mass should be reset
+            assert animal_cohort_instance.reproductive_mass == 0
+            # The parent should still be present in the community
+            assert (
+                animal_cohort_instance
+                in animal_community_instance.animal_cohorts[parent_cohort_name]
+            )
 
-        # 2. Check that the reproductive mass of the parent cohort is reduced to 0
-        assert animal_cohort_instance.reproductive_mass == 0
+        # 2. Check that the offspring were added if reproduction occurred
+
+        if expected_offspring and reproductive_type == "semelparous":
+            assert (
+                len(animal_community_instance.animal_cohorts[parent_cohort_name])
+                == number_cohorts
+            )
+        elif expected_offspring and reproductive_type == "iteroparous":
+            assert (
+                len(animal_community_instance.animal_cohorts[parent_cohort_name])
+                == number_cohorts + 1
+            )
+        else:
+            assert (
+                len(animal_community_instance.animal_cohorts[parent_cohort_name])
+                == number_cohorts
+            )
 
     def test_birth_community(self, animal_community_instance, constants_instance):
         """Test the thresholding behavior of birth_community."""

--- a/tests/models/animals/test_animal_communities.py
+++ b/tests/models/animals/test_animal_communities.py
@@ -482,7 +482,7 @@ class TestAnimalCommunity:
             pytest.param(10, id="ten_days"),
         ],
     )
-    def test_inflict_natural_mortality_community(
+    def test_inflict_non_predation_mortality_community(
         self, mocker, animal_community_instance, days
     ):
         """Testing natural mortality infliction for the entire community."""
@@ -492,18 +492,18 @@ class TestAnimalCommunity:
 
         animal_community_instance.populate_community()
 
-        # Mock the total_non_predation_mortality method
+        # Mock the inflict_non_predation_mortality method
         mock_mortality = mocker.patch(
             "virtual_ecosystem.models.animals.animal_cohorts.AnimalCohort."
-            "total_non_predation_mortality"
+            "inflict_non_predation_mortality"
         )
 
         # Call the community method to inflict natural mortality
-        animal_community_instance.inflict_natural_mortality_community(dt)
+        animal_community_instance.inflict_non_predation_mortality_community(dt)
 
         number_of_days = float(dt / timedelta64(1, "D"))
 
-        # Assert the total_non_predation_mortality method was called for each cohort
+        # Assert the inflict_non_predation_mortality method was called for each cohort
         for cohorts in animal_community_instance.animal_cohorts.values():
             for cohort in cohorts:
                 mock_mortality.assert_called_with(

--- a/tests/models/animals/test_animal_communities.py
+++ b/tests/models/animals/test_animal_communities.py
@@ -483,7 +483,7 @@ class TestAnimalCommunity:
         ],
     )
     def test_inflict_natural_mortality_community(
-        self, animal_community_instance, mocker, days
+        self, mocker, animal_community_instance, days
     ):
         """Testing natural mortality infliction for the entire community."""
         from numpy import timedelta64
@@ -506,7 +506,9 @@ class TestAnimalCommunity:
         # Assert the total_non_predation_mortality method was called for each cohort
         for cohorts in animal_community_instance.animal_cohorts.values():
             for cohort in cohorts:
-                mock_mortality.assert_called_with(number_of_days)
+                mock_mortality.assert_called_with(
+                    number_of_days, animal_community_instance.carcass_pool
+                )
 
         # Check if cohorts with no individuals left are flagged as not alive
         for cohorts in animal_community_instance.animal_cohorts.values():

--- a/tests/models/animals/test_animal_communities.py
+++ b/tests/models/animals/test_animal_communities.py
@@ -60,8 +60,10 @@ class TestAnimalCommunity:
             "herbivorous_bird",
             "carnivorous_mammal",
             "herbivorous_mammal",
-            "carnivorous_insect",
-            "herbivorous_insect",
+            "carnivorous_insect_iteroparous",
+            "herbivorous_insect_iteroparous",
+            "carnivorous_insect_semelparous",
+            "herbivorous_insect_semelparous",
         ]
 
     def test_all_animal_cohorts_property(
@@ -219,7 +221,13 @@ class TestAnimalCommunity:
         )
         assert animal_cohort_instance.is_alive
         animal_community_instance.remove_dead_cohort(animal_cohort_instance)
+        assert (
+            animal_cohort_instance
+            in animal_community_instance.animal_cohorts["herbivorous_mammal"]
+        )
+        animal_cohort_instance.is_alive = False
         assert not animal_cohort_instance.is_alive
+        animal_community_instance.remove_dead_cohort(animal_cohort_instance)
         assert (
             animal_cohort_instance
             not in animal_community_instance.animal_cohorts["herbivorous_mammal"]

--- a/tests/models/animals/test_animal_model.py
+++ b/tests/models/animals/test_animal_model.py
@@ -178,7 +178,7 @@ def test_update_method_sequence(mocker, prepared_animal_model_instance):
         "migrate_community",
         "birth_community",
         "metabolize_community",
-        "inflict_natural_mortality_community",
+        "inflict_non_predation_mortality_community",
         "remove_dead_cohort_community",
         "increase_age_community",
     ]

--- a/tests/models/animals/test_animal_model.py
+++ b/tests/models/animals/test_animal_model.py
@@ -67,6 +67,7 @@ def test_animal_model_initialization(
             taxa = "bird"
             diet = "carnivore"
             metabolic_type = "endothermic"
+            reproductive_type = "iteroparous"
             birth_mass = 0.1
             adult_mass = 1.0
             [[animals.functional_groups]]
@@ -74,6 +75,7 @@ def test_animal_model_initialization(
             taxa = "bird"
             diet = "herbivore"
             metabolic_type = "endothermic"
+            reproductive_type = "iteroparous"
             birth_mass = 0.05
             adult_mass = 0.5
             [[animals.functional_groups]]
@@ -81,6 +83,7 @@ def test_animal_model_initialization(
             taxa = "mammal"
             diet = "carnivore"
             metabolic_type = "endothermic"
+            reproductive_type = "iteroparous"
             birth_mass = 4.0
             adult_mass = 40.0
             [[animals.functional_groups]]
@@ -88,6 +91,7 @@ def test_animal_model_initialization(
             taxa = "mammal"
             diet = "herbivore"
             metabolic_type = "endothermic"
+            reproductive_type = "iteroparous"
             birth_mass = 1.0
             adult_mass = 10.0
             """,

--- a/tests/models/animals/test_functional_group.py
+++ b/tests/models/animals/test_functional_group.py
@@ -4,11 +4,11 @@ import pytest
 
 
 class TestFunctionalGroup:
-    """Test Animal class."""
+    """Test FunctionalGroup class."""
 
     @pytest.mark.parametrize(
         (
-            "name, taxa, diet, metabolic_type, "
+            "name, taxa, diet, metabolic_type, reproductive_type, "
             "birth_mass, adult_mass, dam_law_exp, dam_law_coef, conv_eff"
         ),
         [
@@ -17,6 +17,7 @@ class TestFunctionalGroup:
                 "mammal",
                 "herbivore",
                 "endothermic",
+                "iteroparous",
                 1.0,
                 10.0,
                 -0.75,
@@ -28,6 +29,7 @@ class TestFunctionalGroup:
                 "mammal",
                 "carnivore",
                 "endothermic",
+                "iteroparous",
                 4.0,
                 40.0,
                 -0.75,
@@ -39,6 +41,7 @@ class TestFunctionalGroup:
                 "bird",
                 "herbivore",
                 "endothermic",
+                "iteroparous",
                 0.05,
                 0.5,
                 -0.75,
@@ -50,6 +53,7 @@ class TestFunctionalGroup:
                 "bird",
                 "carnivore",
                 "endothermic",
+                "iteroparous",
                 0.1,
                 1.0,
                 -0.75,
@@ -57,10 +61,11 @@ class TestFunctionalGroup:
                 0.25,
             ),
             (
-                "herbivorous_insect",
+                "herbivorous_insect_iteroparous",
                 "insect",
                 "herbivore",
                 "ectothermic",
+                "iteroparous",
                 0.0005,
                 0.005,
                 -0.75,
@@ -68,10 +73,35 @@ class TestFunctionalGroup:
                 0.1,
             ),
             (
-                "carnivorous_insect",
+                "carnivorous_insect_iteroparous",
                 "insect",
                 "carnivore",
                 "ectothermic",
+                "iteroparous",
+                0.001,
+                0.01,
+                -0.75,
+                2.00,
+                0.25,
+            ),
+            (
+                "herbivorous_insect_semelparous",
+                "insect",
+                "herbivore",
+                "ectothermic",
+                "semelparous",
+                0.0005,
+                0.005,
+                -0.75,
+                5.00,
+                0.1,
+            ),
+            (
+                "carnivorous_insect_semelparous",
+                "insect",
+                "carnivore",
+                "ectothermic",
+                "semelparous",
                 0.001,
                 0.01,
                 -0.75,
@@ -86,6 +116,7 @@ class TestFunctionalGroup:
         taxa,
         diet,
         metabolic_type,
+        reproductive_type,
         birth_mass,
         adult_mass,
         dam_law_exp,
@@ -97,6 +128,7 @@ class TestFunctionalGroup:
         from virtual_ecosystem.models.animals.animal_traits import (
             DietType,
             MetabolicType,
+            ReproductiveType,
             TaxaType,
         )
         from virtual_ecosystem.models.animals.constants import AnimalConsts
@@ -107,6 +139,7 @@ class TestFunctionalGroup:
             taxa,
             diet,
             metabolic_type,
+            reproductive_type,
             birth_mass,
             adult_mass,
             constants=AnimalConsts(),
@@ -115,29 +148,61 @@ class TestFunctionalGroup:
         assert func_group.taxa == TaxaType(taxa)
         assert func_group.diet == DietType(diet)
         assert func_group.metabolic_type == MetabolicType(metabolic_type)
+        assert func_group.reproductive_type == ReproductiveType(reproductive_type)
         assert func_group.damuths_law_terms[0] == dam_law_exp
         assert func_group.damuths_law_terms[1] == dam_law_coef
         assert func_group.conversion_efficiency == conv_eff
 
 
 @pytest.mark.parametrize(
-    "index, name, taxa, diet, metabolic_type",
+    "index, name, taxa, diet, metabolic_type, reproductive_type",
     [
-        (0, "carnivorous_bird", "bird", "carnivore", "endothermic"),
-        (1, "herbivorous_bird", "bird", "herbivore", "endothermic"),
-        (2, "carnivorous_mammal", "mammal", "carnivore", "endothermic"),
-        (3, "herbivorous_mammal", "mammal", "herbivore", "endothermic"),
-        (4, "carnivorous_insect", "insect", "carnivore", "ectothermic"),
-        (5, "herbivorous_insect", "insect", "herbivore", "ectothermic"),
+        (0, "carnivorous_bird", "bird", "carnivore", "endothermic", "iteroparous"),
+        (1, "herbivorous_bird", "bird", "herbivore", "endothermic", "iteroparous"),
+        (2, "carnivorous_mammal", "mammal", "carnivore", "endothermic", "iteroparous"),
+        (3, "herbivorous_mammal", "mammal", "herbivore", "endothermic", "iteroparous"),
+        (
+            4,
+            "carnivorous_insect_iteroparous",
+            "insect",
+            "carnivore",
+            "ectothermic",
+            "iteroparous",
+        ),
+        (
+            5,
+            "herbivorous_insect_iteroparous",
+            "insect",
+            "herbivore",
+            "ectothermic",
+            "iteroparous",
+        ),
+        (
+            6,
+            "carnivorous_insect_semelparous",
+            "insect",
+            "carnivore",
+            "ectothermic",
+            "semelparous",
+        ),
+        (
+            7,
+            "herbivorous_insect_semelparous",
+            "insect",
+            "herbivore",
+            "ectothermic",
+            "semelparous",
+        ),
     ],
 )
 def test_import_functional_groups(
-    shared_datadir, index, name, taxa, diet, metabolic_type
+    shared_datadir, index, name, taxa, diet, metabolic_type, reproductive_type
 ):
     """Testing import functional groups."""
     from virtual_ecosystem.models.animals.animal_traits import (
         DietType,
         MetabolicType,
+        ReproductiveType,
         TaxaType,
     )
     from virtual_ecosystem.models.animals.constants import AnimalConsts
@@ -148,9 +213,10 @@ def test_import_functional_groups(
 
     file = shared_datadir / "example_functional_group_import.csv"
     fg_list = import_functional_groups(file, constants=AnimalConsts())
-    assert len(fg_list) == 6
+    assert len(fg_list) == 8
     assert isinstance(fg_list[index], FunctionalGroup)
     assert fg_list[index].name == name
     assert fg_list[index].taxa == TaxaType(taxa)
     assert fg_list[index].diet == DietType(diet)
     assert fg_list[index].metabolic_type == MetabolicType(metabolic_type)
+    assert fg_list[index].reproductive_type == ReproductiveType(reproductive_type)

--- a/tests/models/animals/test_scaling_functions.py
+++ b/tests/models/animals/test_scaling_functions.py
@@ -1,7 +1,5 @@
 """Test module for scaling_functions.py."""
 
-from math import exp
-
 import pytest
 
 
@@ -278,24 +276,18 @@ def test_background_mortality(input_value, expected_output):
 @pytest.mark.parametrize(
     "lambda_se, t_to_maturity, t_since_maturity, expected_mortality",
     [
-        pytest.param(0.01, 100, 50, 0.07389056, id="typical_case"),
-        pytest.param(0.01, 50, 100, 0.01648721, id="more_since_than_to"),
+        pytest.param(0.01, 100, 50, 0.01648721, id="typical_case"),
+        pytest.param(0.01, 50, 100, 0.07389056, id="more_since_than_to"),
         pytest.param(0.0, 100, 50, 0.0, id="zero_senescence_rate"),
         pytest.param(
             0.01,
             0,
             100,
-            0.01,
+            None,
             id="zero_time_to_maturity",
-        ),
-        pytest.param(
-            0.01,
-            100,
-            0,
-            0.0,
-            id="zero_time_since_maturity",
             marks=pytest.mark.xfail(reason="Division by zero"),
         ),
+        pytest.param(0.01, 100, 0, 0.01, id="zero_time_since_maturity"),
     ],
 )
 def test_senescence_mortality(
@@ -303,61 +295,89 @@ def test_senescence_mortality(
 ):
     """Test the calculation of senescence mortality rate."""
 
-    # Calculate mortality using the imported function from your module
     from virtual_ecosystem.models.animals.scaling_functions import senescence_mortality
 
-    result = senescence_mortality(lambda_se, t_to_maturity, t_since_maturity)
-    assert result == pytest.approx(
-        expected_mortality
-    ), "The calculated mortality did not match the expected value."
+    if t_to_maturity == 0:
+        with pytest.raises(ZeroDivisionError):
+            senescence_mortality(lambda_se, t_to_maturity, t_since_maturity)
+    else:
+        result = senescence_mortality(lambda_se, t_to_maturity, t_since_maturity)
+        assert result == pytest.approx(
+            expected_mortality
+        ), "The calculated mortality did not match the expected value."
 
 
 @pytest.mark.parametrize(
-    "lambda_max, J_st, zeta_st, mass_current, mass_max, expected_mortality",
+    "lambda_max, J_st, zeta_st, mass_current, mass_max, expected_mortality, param_id",
     [
         pytest.param(
-            0.1,
-            0.5,
+            1.0,
+            0.6,
             0.05,
             50,
             100,
-            0.1 / (1 + exp(-((50 - 0.5 * 100) / (0.05 * 100)))),
-            id="normal_case",
+            0.880797077,
+            "half_mass_case",
+            id="half_mass_case",
         ),
         pytest.param(
-            0.1,
-            0.5,
+            1.0,
+            0.6,
             0.05,
             0,
             100,
-            0.1 / (1 + exp(-((0 - 0.5 * 100) / (0.05 * 100)))),
+            0.999993855,
+            "zero_mass",
             id="zero_mass",
         ),
         pytest.param(
-            0.1,
-            0.5,
+            1.0,
+            0.6,
             0.05,
             100,
             100,
-            0.1 / (1 + exp(-((100 - 0.5 * 100) / (0.05 * 100)))),
+            0.00033535,
+            "mass_equals_max",
             id="mass_equals_max",
         ),
         pytest.param(
-            0.1,
-            0.5,
+            1.0,
+            0.6,
             0.05,
             200,
             100,
-            0.1 / (1 + exp(-((200 - 0.5 * 100) / (0.05 * 100)))),
+            0.0,
+            "mass_exceeds_max",
             id="mass_exceeds_max",
         ),
     ],
 )
 def test_starvation_mortality(
-    lambda_max, J_st, zeta_st, mass_current, mass_max, expected_mortality
+    lambda_max, J_st, zeta_st, mass_current, mass_max, expected_mortality, param_id
 ):
-    """Test the calculation of starvation mortality based on body mass."""
+    """Test the calculation of starvation mortality based on body mass.
+
+    Args:
+        lambda_max (float): The maximum possible instantaneous fractional starvation
+         mortality rate.
+        J_st (float): Determines the inflection point of the logistic function
+         describing the ratio of the realised mortality rate to the maximum rate.
+        zeta_st (float): The scaling of the logistic function describing the ratio of
+                         realised mortality rate to the maximum rate.
+        mass_current (float): The current mass of the animal cohort.
+        mass_max (float): The maximum body mass ever achieved by individuals of this
+         type.
+        expected_mortality (float): The expected mortality rate.
+        param_id (str): Identifier for the test case.
+
+    """
     from virtual_ecosystem.models.animals.scaling_functions import starvation_mortality
+
+    # Diagnostics
+    print(
+        f"Testing with: lambda_max={lambda_max}, J_st={J_st}, zeta_st={zeta_st}, "
+        f"mass_current={mass_current}, mass_max={mass_max}, param_id={param_id}"
+    )
 
     # Call the function with provided parameters
     mortality_rate = starvation_mortality(
@@ -365,9 +385,16 @@ def test_starvation_mortality(
     )
 
     # Assert that the returned mortality rate matches the expected mortality rate
-    assert mortality_rate == pytest.approx(
-        expected_mortality
-    ), "The calculated starvation mortality does not match the expected value."
+    assert mortality_rate == pytest.approx(expected_mortality), (
+        f"Test {param_id}: The calculated starvation mortality {mortality_rate} does"
+        f" not match the expected value {expected_mortality}."
+    )
+
+    # Diagnostics
+    print(
+        f"Test {param_id} passed: Calculated mortality rate: {mortality_rate}, "
+        f"Expected mortality rate: {expected_mortality}"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/models/animals/test_scaling_functions.py
+++ b/tests/models/animals/test_scaling_functions.py
@@ -355,22 +355,7 @@ def test_senescence_mortality(
 def test_starvation_mortality(
     lambda_max, J_st, zeta_st, mass_current, mass_max, expected_mortality, param_id
 ):
-    """Test the calculation of starvation mortality based on body mass.
-
-    Args:
-        lambda_max (float): The maximum possible instantaneous fractional starvation
-         mortality rate.
-        J_st (float): Determines the inflection point of the logistic function
-         describing the ratio of the realised mortality rate to the maximum rate.
-        zeta_st (float): The scaling of the logistic function describing the ratio of
-                         realised mortality rate to the maximum rate.
-        mass_current (float): The current mass of the animal cohort.
-        mass_max (float): The maximum body mass ever achieved by individuals of this
-         type.
-        expected_mortality (float): The expected mortality rate.
-        param_id (str): Identifier for the test case.
-
-    """
+    """Test the calculation of starvation mortality based on body mass."""
     from virtual_ecosystem.models.animals.scaling_functions import starvation_mortality
 
     # Diagnostics

--- a/virtual_ecosystem/example_data/config/animal_functional_groups.toml
+++ b/virtual_ecosystem/example_data/config/animal_functional_groups.toml
@@ -5,6 +5,7 @@ name = "carnivorous_bird"
 taxa = "bird"
 diet = "carnivore"
 metabolic_type = "endothermic"
+reproductive_type = "iteroparous"
 birth_mass = 0.1
 adult_mass = 1.0
 
@@ -13,6 +14,7 @@ name = "herbivorous_bird"
 taxa = "bird"
 diet = "herbivore"
 metabolic_type = "endothermic"
+reproductive_type = "iteroparous"
 birth_mass = 0.05
 adult_mass = 0.5
 
@@ -21,6 +23,7 @@ name = "carnivorous_mammal"
 taxa = "mammal"
 diet = "carnivore"
 metabolic_type = "endothermic"
+reproductive_type = "iteroparous"
 birth_mass = 4.0
 adult_mass = 40.0
 
@@ -29,6 +32,7 @@ name = "herbivorous_mammal"
 taxa = "mammal"
 diet = "herbivore"
 metabolic_type = "endothermic"
+reproductive_type = "iteroparous"
 birth_mass = 1.0
 adult_mass = 10.0
 
@@ -37,6 +41,7 @@ name = "carnivorous_insect"
 taxa = "insect"
 diet = "carnivore"
 metabolic_type = "ectothermic"
+reproductive_type = "iteroparous"
 birth_mass = 0.001
 adult_mass = 0.01
 
@@ -45,5 +50,6 @@ name = "herbivorous_insect"
 taxa = "insect"
 diet = "herbivore"
 metabolic_type = "ectothermic"
+reproductive_type = "semelparous"
 birth_mass = 0.0005
 adult_mass = 0.005

--- a/virtual_ecosystem/models/animals/animal_cohorts.py
+++ b/virtual_ecosystem/models/animals/animal_cohorts.py
@@ -766,10 +766,10 @@ class AnimalCohort:
 
         return min(1.0, probability_of_dispersal)
 
-    def total_non_predation_mortality(
+    def inflict_non_predation_mortality(
         self, dt: float, carcass_pool: CarcassPool
     ) -> None:
-        """Combine background, senescence, and starvation mortalities."""
+        """Inflict combined background, senescence, and starvation mortalities."""
 
         pop_size = self.individuals
         mass_current = self.mass_current

--- a/virtual_ecosystem/models/animals/animal_cohorts.py
+++ b/virtual_ecosystem/models/animals/animal_cohorts.py
@@ -766,7 +766,9 @@ class AnimalCohort:
 
         return min(1.0, probability_of_dispersal)
 
-    def total_non_predation_mortality(self, dt: float) -> None:
+    def total_non_predation_mortality(
+        self, dt: float, carcass_pool: CarcassPool
+    ) -> None:
         """Combine background, senescence, and starvation mortalities."""
 
         pop_size = self.individuals
@@ -802,4 +804,4 @@ class AnimalCohort:
         number_dead = ceil(pop_size * (1 - exp(-u_t * dt)))
 
         # Remove the dead individuals from the cohort
-        self.individuals -= number_dead
+        self.die_individual(number_dead, carcass_pool)

--- a/virtual_ecosystem/models/animals/animal_cohorts.py
+++ b/virtual_ecosystem/models/animals/animal_cohorts.py
@@ -769,7 +769,13 @@ class AnimalCohort:
     def inflict_non_predation_mortality(
         self, dt: float, carcass_pool: CarcassPool
     ) -> None:
-        """Inflict combined background, senescence, and starvation mortalities."""
+        """Inflict combined background, senescence, and starvation mortalities.
+
+        Args:
+            dt: The time passed in the timestep (days).
+            carcass_pool: The local carcass pool to which dead individuals go.
+
+        """
 
         pop_size = self.individuals
         mass_current = self.mass_current

--- a/virtual_ecosystem/models/animals/animal_cohorts.py
+++ b/virtual_ecosystem/models/animals/animal_cohorts.py
@@ -788,7 +788,8 @@ class AnimalCohort:
             self.constants.u_bg
         )  # constant background mortality
 
-        if self.is_mature is True:
+        u_se = 0.0
+        if self.is_mature:
             # senescence mortality is only experienced by mature adults.
             u_se = sf.senescence_mortality(
                 self.constants.lambda_se, t_to_maturity, t_since_maturity

--- a/virtual_ecosystem/models/animals/animal_communities.py
+++ b/virtual_ecosystem/models/animals/animal_communities.py
@@ -193,6 +193,7 @@ class AnimalCommunity:
                 * parent_cohort.constants.semelparity_mass_loss
             )
             parent_cohort.mass_current -= non_reproductive_mass_loss
+            # kill the semelparous parent cohort
             parent_cohort.is_alive = False
         else:
             non_reproductive_mass_loss = 0.0

--- a/virtual_ecosystem/models/animals/animal_communities.py
+++ b/virtual_ecosystem/models/animals/animal_communities.py
@@ -167,7 +167,9 @@ class AnimalCommunity:
     def remove_dead_cohort_community(self) -> None:
         """This handles remove_dead_cohort for all cohorts in a community."""
         for cohort in chain.from_iterable(self.animal_cohorts.values()):
-            self.remove_dead_cohort(cohort)
+            if cohort.individuals <= 0:
+                cohort.is_alive = False
+                self.remove_dead_cohort(cohort)
 
     def birth(self, parent_cohort: AnimalCohort) -> None:
         """Produce a new AnimalCohort through reproduction.
@@ -336,8 +338,8 @@ class AnimalCommunity:
     def inflict_natural_mortality_community(self, dt: timedelta64) -> None:
         """This handles natural mortality for all cohorts in a community.
 
-        TODO Replace the number_of_days format with a passthrough of the initialized
-        dt straight to the scaling function that sets the cohort rates.
+        This includes background mortality, starvation, and, for mature cohorts,
+        senescence.
 
         Args:
             dt: Number of days over which the metabolic costs should be calculated.
@@ -345,6 +347,7 @@ class AnimalCommunity:
         """
         number_of_days = float(dt / timedelta64(1, "D"))
         for cohort in self.all_animal_cohorts:
-            cohort.inflict_natural_mortality(self.carcass_pool, number_of_days)
+            cohort.total_non_predation_mortality(number_of_days)
             if cohort.individuals <= 0:
+                cohort.is_alive = False
                 self.remove_dead_cohort(cohort)

--- a/virtual_ecosystem/models/animals/animal_communities.py
+++ b/virtual_ecosystem/models/animals/animal_communities.py
@@ -350,7 +350,7 @@ class AnimalCommunity:
         """
         number_of_days = float(dt / timedelta64(1, "D"))
         for cohort in self.all_animal_cohorts:
-            cohort.total_non_predation_mortality(number_of_days)
+            cohort.total_non_predation_mortality(number_of_days, self.carcass_pool)
             if cohort.individuals <= 0:
                 cohort.is_alive = False
                 self.remove_dead_cohort(cohort)

--- a/virtual_ecosystem/models/animals/animal_communities.py
+++ b/virtual_ecosystem/models/animals/animal_communities.py
@@ -338,7 +338,7 @@ class AnimalCommunity:
         for cohort in self.all_animal_cohorts:
             cohort.increase_age(dt)
 
-    def inflict_natural_mortality_community(self, dt: timedelta64) -> None:
+    def inflict_non_predation_mortality_community(self, dt: timedelta64) -> None:
         """This handles natural mortality for all cohorts in a community.
 
         This includes background mortality, starvation, and, for mature cohorts,
@@ -350,7 +350,7 @@ class AnimalCommunity:
         """
         number_of_days = float(dt / timedelta64(1, "D"))
         for cohort in self.all_animal_cohorts:
-            cohort.total_non_predation_mortality(number_of_days, self.carcass_pool)
+            cohort.inflict_non_predation_mortality(number_of_days, self.carcass_pool)
             if cohort.individuals <= 0:
                 cohort.is_alive = False
                 self.remove_dead_cohort(cohort)

--- a/virtual_ecosystem/models/animals/animal_communities.py
+++ b/virtual_ecosystem/models/animals/animal_communities.py
@@ -192,6 +192,7 @@ class AnimalCommunity:
         """
         # semelparous organisms use a portion of their non-reproductive mass to make
         # offspring and then they die
+        non_reproductive_mass_loss = 0.0
         if parent_cohort.functional_group.reproductive_type == "semelparous":
             non_reproductive_mass_loss = (
                 parent_cohort.mass_current
@@ -200,8 +201,6 @@ class AnimalCommunity:
             parent_cohort.mass_current -= non_reproductive_mass_loss
             # kill the semelparous parent cohort
             parent_cohort.is_alive = False
-        else:
-            non_reproductive_mass_loss = 0.0
 
         number_offspring = (
             int(

--- a/virtual_ecosystem/models/animals/animal_communities.py
+++ b/virtual_ecosystem/models/animals/animal_communities.py
@@ -160,7 +160,6 @@ class AnimalCommunity:
         """
 
         if not cohort.is_alive:
-            # LOGGER.debug("An animal cohort has died")
             self.animal_cohorts[cohort.name].remove(cohort)
         elif cohort.is_alive:
             LOGGER.exception("An animal cohort which is alive cannot be removed.")
@@ -191,9 +190,10 @@ class AnimalCommunity:
         if parent_cohort.functional_group.reproductive_type == "semelparous":
             non_reproductive_mass_loss = (
                 parent_cohort.mass_current
-                * parent_cohort.functional_group.semelparity_mass_loss
+                * parent_cohort.constants.semelparity_mass_loss
             )
             parent_cohort.mass_current -= non_reproductive_mass_loss
+            parent_cohort.is_alive = False
         else:
             non_reproductive_mass_loss = 0.0
 

--- a/virtual_ecosystem/models/animals/animal_model.py
+++ b/virtual_ecosystem/models/animals/animal_model.py
@@ -249,7 +249,7 @@ class AnimalModel(
                 float(self.data["air_temperature"][0][community.community_key].values),
                 self.update_interval_timedelta,
             )
-            community.inflict_natural_mortality_community(
+            community.inflict_non_predation_mortality_community(
                 self.update_interval_timedelta
             )
             community.remove_dead_cohort_community()

--- a/virtual_ecosystem/models/animals/animal_traits.py
+++ b/virtual_ecosystem/models/animals/animal_traits.py
@@ -26,3 +26,10 @@ class TaxaType(Enum):
     MAMMAL = "mammal"
     BIRD = "bird"
     INSECT = "insect"
+
+
+class ReproductiveType(Enum):
+    """Enumeration for reproductive types."""
+
+    SEMELPAROUS = "semelparous"
+    ITEROPAROUS = "iteroparous"

--- a/virtual_ecosystem/models/animals/constants.py
+++ b/virtual_ecosystem/models/animals/constants.py
@@ -227,7 +227,28 @@ class AnimalConsts(ConstantsDataclass):
     dispersal is attempted."""
 
     # Madingley reproductive parameters
-    semelparity_mass_loss = 0.2  # Toy value until I find the real one
+    semelparity_mass_loss = 0.5  # chi [Madingley] [unitless]
+    """The proportion of non-reproductive mass lost in semelparous reproduction."""
+
+    # Madingley mortality parameters
+    u_bg = 10.0**-3.0  # u_bg [Madingley] [day^-1]
+    """The constant background mortality faced by all animals."""
+
+    lambda_se = 3.0 * 10.0**-3.0  # lambda_se [Madingley] [day^-1]
+    """The instantaneous rate of senescence mortality at the point of maturity."""
+
+    lambda_max = 1.0  # lambda_max [Madingley] [day^-1]
+    """The maximum possible instantaneous fractional starvation mortality rate."""
+
+    J_st = 0.6  # J_st [Madingley] [unitless]
+    """Determines the inflection point of the logistic function describing ratio of the
+    realised mortality rate to the maximum rate."""
+
+    zeta_st = 0.05  # zeta_st [Madingley] [unitless]
+    """The scaling of the logistic function describing the ratio of the realised
+    mortality rate to the maximum rate."""
+
+    instant_senescence = 0.1  # toy value
 
 
 DECAY_FRACTION_EXCREMENT: float = 0.5

--- a/virtual_ecosystem/models/animals/constants.py
+++ b/virtual_ecosystem/models/animals/constants.py
@@ -248,8 +248,6 @@ class AnimalConsts(ConstantsDataclass):
     """The scaling of the logistic function describing the ratio of the realised
     mortality rate to the maximum rate."""
 
-    instant_senescence = 0.1  # toy value
-
 
 DECAY_FRACTION_EXCREMENT: float = 0.5
 """Fraction of excrement that is assumed to decay rather than be consumed [unitless].

--- a/virtual_ecosystem/models/animals/constants.py
+++ b/virtual_ecosystem/models/animals/constants.py
@@ -226,6 +226,9 @@ class AnimalConsts(ConstantsDataclass):
     """Ratio of current body-mass to adult body-mass at which starvation-response
     dispersal is attempted."""
 
+    # Madingley reproductive parameters
+    semelparity_mass_loss = 0.2  # Toy value until I find the real one
+
 
 DECAY_FRACTION_EXCREMENT: float = 0.5
 """Fraction of excrement that is assumed to decay rather than be consumed [unitless].

--- a/virtual_ecosystem/models/animals/functional_group.py
+++ b/virtual_ecosystem/models/animals/functional_group.py
@@ -49,7 +49,7 @@ class FunctionalGroup:
         self.metabolic_type = MetabolicType(metabolic_type)
         """The metabolic type of the functional group."""
         self.reproductive_type = ReproductiveType(reproductive_type)
-        """The reproductive type of the functional grou."""
+        """The reproductive type of the functional group."""
         self.birth_mass = birth_mass
         """The mass of the functional group at birth."""
         self.adult_mass = adult_mass

--- a/virtual_ecosystem/models/animals/functional_group.py
+++ b/virtual_ecosystem/models/animals/functional_group.py
@@ -8,6 +8,7 @@ import pandas as pd
 from virtual_ecosystem.models.animals.animal_traits import (
     DietType,
     MetabolicType,
+    ReproductiveType,
     TaxaType,
 )
 from virtual_ecosystem.models.animals.constants import AnimalConsts
@@ -32,6 +33,7 @@ class FunctionalGroup:
         taxa: str,
         diet: str,
         metabolic_type: str,
+        reproductive_type: str,
         birth_mass: float,
         adult_mass: float,
         constants: AnimalConsts = AnimalConsts(),
@@ -45,7 +47,9 @@ class FunctionalGroup:
         self.diet = DietType(diet)
         """The diet of the functional group."""
         self.metabolic_type = MetabolicType(metabolic_type)
-        """The metabolic type of the functional group"""
+        """The metabolic type of the functional group."""
+        self.reproductive_type = ReproductiveType(reproductive_type)
+        """The reproductive type of the functional grou."""
         self.birth_mass = birth_mass
         """The mass of the functional group at birth."""
         self.adult_mass = adult_mass
@@ -114,6 +118,7 @@ def import_functional_groups(
             row.taxa,
             row.diet,
             row.metabolic_type,
+            row.reproductive_type,
             row.birth_mass,
             row.adult_mass,
             constants=constants,

--- a/virtual_ecosystem/models/animals/module_schema.json
+++ b/virtual_ecosystem/models/animals/module_schema.json
@@ -23,6 +23,9 @@
                             "metabolic_type": {
                                 "type": "string"
                             },
+                            "reproductive_type": {
+                                "type": "string"
+                            },
                             "birth_mass": {
                                 "type": "number"
                             },
@@ -35,6 +38,7 @@
                             "taxa",
                             "diet",
                             "metabolic_type",
+                            "reproductive_type",
                             "birth_mass",
                             "adult_mass"
                         ]

--- a/virtual_ecosystem/models/animals/scaling_functions.py
+++ b/virtual_ecosystem/models/animals/scaling_functions.py
@@ -291,6 +291,13 @@ def senescence_mortality(
 ) -> float:
     """Age-based mortality.
 
+    Madingley describes the equation as exp(time_to_maturity/time_since_maturity) but I
+    suspect this is an error and that it should be inverted. If, for example, it took
+    1000 days to reach maturity and the cohort had been mature for 1 day, then the
+    instantaneous rate of senescence mortality would be lambda_se * exp(1000/1). This
+    would also mean that the rate of senescence would decrease over time. Therefore, I
+    have inverted the relationship below.
+
     Args:
         lambda_se: The instantaneous rate of senescence mortality at point of maturity
                     [day^-1].
@@ -305,7 +312,7 @@ def senescence_mortality(
     t_pm = t_to_maturity  # time it took to reach maturity
     t_bm = t_since_maturity  # time since maturity
 
-    u_se = lambda_se * exp(t_pm / t_bm)
+    u_se = lambda_se * exp(t_bm / t_pm)
 
     return u_se
 
@@ -314,6 +321,9 @@ def starvation_mortality(
     lambda_max: float, J_st: float, zeta_st: float, mass_current: float, mass_max: float
 ) -> float:
     """Mortality from body-mass loss.
+
+    There is a error in the madingley paper that does not follow their source code. The
+    paper uses exp(k) instead of exp(-k).
 
     Args:
         lambda_max: The maximum possible instantaneous fractional starvation mortality
@@ -332,8 +342,8 @@ def starvation_mortality(
 
     M_i_t = mass_current
     M_i_max = mass_max
-
-    u_st = lambda_max / (1 + exp(-(M_i_t - J_st * M_i_max) / (zeta_st * M_i_max)))
+    k = -(M_i_t - J_st * M_i_max) / (zeta_st * M_i_max)  # extra step to follow source
+    u_st = lambda_max / (1 + exp(-k))
 
     return u_st
 

--- a/virtual_ecosystem/models/animals/scaling_functions.py
+++ b/virtual_ecosystem/models/animals/scaling_functions.py
@@ -241,7 +241,7 @@ def prey_group_selection(
 
 
 def natural_mortality_scaling(mass: float, terms: tuple) -> float:
-    """The function to determine the natural mortality rate of animal cohorts.
+    """Determine the natural mortality rate of animal cohorts.
 
     Relationship from: Dureuil & Froese 2021
 
@@ -266,6 +266,76 @@ def natural_mortality_scaling(mass: float, terms: tuple) -> float:
     daily_mortality_prob = 1 - exp(-daily_mortality_rate)
 
     return daily_mortality_prob
+
+
+def background_mortality(u_bg: float) -> float:
+    """Constant background rate of wastebasket mortality.
+
+    This function does nothing but return a constant at the moment.
+    I am leaving it in so there is a clear way to alter the assumptions about
+    background mortality as we move into testing and validation.
+
+    Args:
+        u_bg: The constant of background mortality [day^-1].
+
+    Returns:
+        The background rate of mortality faced by a cohort [day^-1].
+
+    """
+
+    return u_bg
+
+
+def senescence_mortality(
+    lambda_se: float, t_to_maturity: float, t_since_maturity: float
+) -> float:
+    """Age-based mortality.
+
+    Args:
+        lambda_se: The instantaneous rate of senescence mortality at point of maturity
+                    [day^-1].
+        t_to_maturity: The time it took the cohort to reach maturity [days].
+        t_since_maturity: The time elapsed since the cohort reached maturity [days].
+
+    Returns:
+        The rate of senescence mortality faced by an animal cohort [day^-1].
+
+    """
+
+    t_pm = t_to_maturity  # time it took to reach maturity
+    t_bm = t_since_maturity  # time since maturity
+
+    u_se = lambda_se * exp(t_pm / t_bm)
+
+    return u_se
+
+
+def starvation_mortality(
+    lambda_max: float, J_st: float, zeta_st: float, mass_current: float, mass_max: float
+) -> float:
+    """Mortality from body-mass loss.
+
+    Args:
+        lambda_max: The maximum possible instantaneous fractional starvation mortality
+            rate. [day^-1]
+        J_st: Determines the inflection point of the logistic function describing ratio
+            of the realised mortality rate to the maximum rate. [unitless]
+        zeta_st:The scaling of the logistic function describing the ratio of the
+            realised mortality rate to the maximum rate. [unitless]
+        mass_current: The current mass of the animal cohort [kg].
+        mass_max: The maximum body mass ever achieved by individuals of this type [kg].
+
+    Returns:
+        The rate of mortality from starvation based on current body-mass. [day^-1]
+
+    """
+
+    M_i_t = mass_current
+    M_i_max = mass_max
+
+    u_st = lambda_max / (1 + exp(-(M_i_t - J_st * M_i_max) / (zeta_st * M_i_max)))
+
+    return u_st
 
 
 def alpha_i_k(alpha_0_herb: float, mass: float) -> float:


### PR DESCRIPTION
# Description

This adds a new trait to functional groups, reproductive type, which is broken into two variations, iteroparity (reproducing multiple times) and semelparity (reproducing once and then dying). Iteroparous organisms reproduce as before, semelparous organisms also use some of their non-reproductive mass in the reproductive event and then the cohort dies. 

This PR also expands non-predation mortality to include a fixed background mortality, senescence mortality, and starvation mortality. There were small errors in the Madingley paper for the latter two mortalities so you may notice an excess of diagnostics in the testing from when I was trying to figure out if I had gone mad. I left them in, in case they might be useful later.  Let me know if you think I should remove them. 

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
