### PR TITLE
Turning on single-threaded handling in dask

### DIFF
--- a/virtual_ecosystem/core/data.py
+++ b/virtual_ecosystem/core/data.py
@@ -123,6 +123,7 @@ file.
 from pathlib import Path
 from typing import Any
 
+import dask
 import numpy as np
 from xarray import DataArray, Dataset, open_mfdataset
 
@@ -132,6 +133,16 @@ from virtual_ecosystem.core.grid import Grid
 from virtual_ecosystem.core.logger import LOGGER
 from virtual_ecosystem.core.readers import load_to_dataarray
 from virtual_ecosystem.core.utils import check_outfile
+
+# There are ongoing xarray issues with NetCDF not being thread safe and this causes
+# segfaults on different architectures in testing using `xarray.open_mfdataset`
+# See:
+# - https://github.com/pydata/xarray/issues/7079
+# - https://github.com/pydata/xarray/issues/3961
+#
+# Following advice on both those issues, we currently explicitly stop dask from trying
+# to use parallel file processing and use open_mfdataset(..., lock=False)
+dask.config.set(scheduler="single-threaded")
 
 
 class Data:


### PR DESCRIPTION
# Description

This PR is to fix segfaults in testing and docs building when `xarray.open_mfdataset` is used. This is due to underlying issues with the netCDF code not being thread safe. We previously turned on `lock=False` in that command, following advice here:

https://github.com/pydata/xarray/issues/3961

And that worked, but the issue has started occurring again. Following the advice in this issue thread:

https://github.com/pydata/xarray/issues/7079

this PR now explicitly sets the `dask` scheduler to use single-threading.

Fixes #354

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
