### PR TITLE
Bump version number for September 2024 develop release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ license = "BSD-3-Clause"
 name = "virtual_ecosystem"
 readme = "README.md"
 repository = "https://github.com/ImperialCollegeLondon/virtual_ecosystem"
-version = "0.1.1a5"
+version = "0.1.1a6"
 
 [tool.poetry.scripts]
 ve_run = "virtual_ecosystem.entry_points:ve_run_cli"


### PR DESCRIPTION
Bump release version:

This updates from `0.1.1a5` to `0.1.1a6` for the September 2024 monthly release of the develop code.
