### PR TITLE
Stop bots from running codecov upload step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,15 @@ jobs:
       run: poetry run pytest --cov-report xml
 
     - name: Upload coverage to Codecov
-      if: (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10')
+      if: >- 
+          ${{ ! (
+             github.event.pull_request.user.login == 'dependabot[bot]' || 
+             github.event.pull_request.user.login == 'pre-commit-ci[bot]'
+            ) && (
+             matrix.os == 'ubuntu-latest' && 
+             matrix.python-version == '3.10'
+            )
+          }}
       uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: true


### PR DESCRIPTION
# Description

This is just adding conditionals on the execution of the codecov upload step in CI to stop bots running that step, because they don't seem (or at least `codecov` doesn't) to have access to the required secrets, unlike PRs from actual repo members.

Fixes #589 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
