### PR TITLE
Adding jupytext to pre commit to apply black to myst notebook code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,6 @@ repos:
     - id: jupytext
       args: [--pipe, black]
       files: docs/source
-      exclude: docs/source/conf.py
+      exclude: docs/source/conf.py|docs/source/genindex.md|docs/source/modindex.md
       additional_dependencies:
         - black==24.4.2 # Matches hook

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,4 +19,12 @@ repos:
     rev: v0.42.0
     hooks:
     - id: markdownlint
-
+  - repo: https://github.com/mwouts/jupytext
+    rev: v1.16.4b
+    hooks:
+    - id: jupytext
+      args: [--pipe, black]
+      files: docs/source
+      exclude: docs/source/conf.py
+      additional_dependencies:
+        - black==24.4.2 # Matches hook

--- a/docs/source/api/core.md
+++ b/docs/source/api/core.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API reference for `core` modules

--- a/docs/source/api/core/axes.md
+++ b/docs/source/api/core/axes.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.core.axes` module

--- a/docs/source/api/core/base_model.md
+++ b/docs/source/api/core/base_model.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.core.base_model` module

--- a/docs/source/api/core/config.md
+++ b/docs/source/api/core/config.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.core.config` module

--- a/docs/source/api/core/constants.md
+++ b/docs/source/api/core/constants.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.core.constants` module

--- a/docs/source/api/core/constants_class.md
+++ b/docs/source/api/core/constants_class.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.core.constants_class` module

--- a/docs/source/api/core/constants_loader.md
+++ b/docs/source/api/core/constants_loader.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.core.constants_loader` module

--- a/docs/source/api/core/core_components.md
+++ b/docs/source/api/core/core_components.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.core.core_components` module
@@ -19,7 +29,7 @@ kernelspec:
 ```{eval-rst}
 .. automodule:: virtual_ecosystem.core.core_components
     :autosummary:
-    :members: 
+    :members:
     :special-members: __post_init__
     :private-members: _role_indices_bool, _role_indices_int
 ```

--- a/docs/source/api/core/data.md
+++ b/docs/source/api/core/data.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.core.data` module

--- a/docs/source/api/core/exceptions.md
+++ b/docs/source/api/core/exceptions.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.core.exceptions` module

--- a/docs/source/api/core/grid.md
+++ b/docs/source/api/core/grid.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.core.grid` module

--- a/docs/source/api/core/logger.md
+++ b/docs/source/api/core/logger.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.core.logger` module

--- a/docs/source/api/core/readers.md
+++ b/docs/source/api/core/readers.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.core.readers` module

--- a/docs/source/api/core/registry.md
+++ b/docs/source/api/core/registry.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.core.registry` module

--- a/docs/source/api/core/schema.md
+++ b/docs/source/api/core/schema.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.core.schema` module

--- a/docs/source/api/core/utils.md
+++ b/docs/source/api/core/utils.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.core.utils` module

--- a/docs/source/api/core/variables.md
+++ b/docs/source/api/core/variables.md
@@ -7,7 +7,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: vr_python3
   language: python

--- a/docs/source/api/example_data.md
+++ b/docs/source/api/example_data.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API reference for `example_data` module

--- a/docs/source/api/main.md
+++ b/docs/source/api/main.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API reference for the main Virtual Ecosystem API

--- a/docs/source/api/models.md
+++ b/docs/source/api/models.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # The Virtual Ecosystem models

--- a/docs/source/api/models/abiotic.md
+++ b/docs/source/api/models/abiotic.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API reference for `abiotic` modules

--- a/docs/source/api/models/abiotic/abiotic_constants.md
+++ b/docs/source/api/models/abiotic/abiotic_constants.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 #  API for the {mod}`~virtual_ecosystem.models.abiotic.constants` module

--- a/docs/source/api/models/abiotic/abiotic_model.md
+++ b/docs/source/api/models/abiotic/abiotic_model.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 <!-- markdownlint-disable-next-line  MD013 -->

--- a/docs/source/api/models/abiotic/abiotic_tools.md
+++ b/docs/source/api/models/abiotic/abiotic_tools.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 #  API for the {mod}`~virtual_ecosystem.models.abiotic.abiotic_tools` module

--- a/docs/source/api/models/abiotic/conductivities.md
+++ b/docs/source/api/models/abiotic/conductivities.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 #  API for the {mod}`~virtual_ecosystem.models.abiotic.conductivities` module

--- a/docs/source/api/models/abiotic/energy_balance.md
+++ b/docs/source/api/models/abiotic/energy_balance.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 #  API for the {mod}`~virtual_ecosystem.models.abiotic.energy_balance` module

--- a/docs/source/api/models/abiotic/soil_energy_balance.md
+++ b/docs/source/api/models/abiotic/soil_energy_balance.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 #  API for the {mod}`~virtual_ecosystem.models.abiotic.soil_energy_balance` module

--- a/docs/source/api/models/abiotic/wind.md
+++ b/docs/source/api/models/abiotic/wind.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 #  API for the {mod}`~virtual_ecosystem.models.abiotic.wind` module

--- a/docs/source/api/models/abiotic_simple.md
+++ b/docs/source/api/models/abiotic_simple.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API reference for `abiotic_simple` modules

--- a/docs/source/api/models/abiotic_simple/abiotic_simple_constants.md
+++ b/docs/source/api/models/abiotic_simple/abiotic_simple_constants.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 #  API for the {mod}`~virtual_ecosystem.models.abiotic_simple.constants` module

--- a/docs/source/api/models/abiotic_simple/abiotic_simple_model.md
+++ b/docs/source/api/models/abiotic_simple/abiotic_simple_model.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 <!-- markdownlint-disable-next-line  MD013 -->

--- a/docs/source/api/models/abiotic_simple/microclimate.md
+++ b/docs/source/api/models/abiotic_simple/microclimate.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 #  API for the {mod}`~virtual_ecosystem.models.abiotic_simple.microclimate` module

--- a/docs/source/api/models/animal.md
+++ b/docs/source/api/models/animal.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API reference for `animal` modules

--- a/docs/source/api/models/animal/animal_cohorts.md
+++ b/docs/source/api/models/animal/animal_cohorts.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API for the {mod}`~virtual_ecosystem.models.animal.animal_cohorts` module

--- a/docs/source/api/models/animal/animal_communities.md
+++ b/docs/source/api/models/animal/animal_communities.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API for the {mod}`~virtual_ecosystem.models.animal.animal_communities` module

--- a/docs/source/api/models/animal/animal_model.md
+++ b/docs/source/api/models/animal/animal_model.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API for the {mod}`~virtual_ecosystem.models.animal.animal_model` module

--- a/docs/source/api/models/animal/animal_traits.md
+++ b/docs/source/api/models/animal/animal_traits.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API for the {mod}`~virtual_ecosystem.models.animal.animal_traits` module

--- a/docs/source/api/models/animal/constants.md
+++ b/docs/source/api/models/animal/constants.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API for the {mod}`~virtual_ecosystem.models.animal.constants` module

--- a/docs/source/api/models/animal/decay.md
+++ b/docs/source/api/models/animal/decay.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API for the {mod}`~virtual_ecosystem.models.animal.decay` module

--- a/docs/source/api/models/animal/functional_group.md
+++ b/docs/source/api/models/animal/functional_group.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API for the {mod}`~virtual_ecosystem.models.animal.functional_group` module

--- a/docs/source/api/models/animal/plant_resources.md
+++ b/docs/source/api/models/animal/plant_resources.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API for the {mod}`~virtual_ecosystem.models.animal.plant_resources` module

--- a/docs/source/api/models/animal/protocols.md
+++ b/docs/source/api/models/animal/protocols.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API for the {mod}`~virtual_ecosystem.models.animal.protocols` module

--- a/docs/source/api/models/animal/scaling_functions.md
+++ b/docs/source/api/models/animal/scaling_functions.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API for the {mod}`~virtual_ecosystem.models.animal.scaling_functions` module

--- a/docs/source/api/models/hydrology.md
+++ b/docs/source/api/models/hydrology.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API reference for `hydrology` modules

--- a/docs/source/api/models/hydrology/above_ground.md
+++ b/docs/source/api/models/hydrology/above_ground.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 #  API for the {mod}`~virtual_ecosystem.models.hydrology.above_ground` module

--- a/docs/source/api/models/hydrology/below_ground.md
+++ b/docs/source/api/models/hydrology/below_ground.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 #  API for the {mod}`~virtual_ecosystem.models.hydrology.below_ground` module

--- a/docs/source/api/models/hydrology/constants.md
+++ b/docs/source/api/models/hydrology/constants.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 #  API for the {mod}`~virtual_ecosystem.models.hydrology.constants` module

--- a/docs/source/api/models/hydrology/hydrology_model.md
+++ b/docs/source/api/models/hydrology/hydrology_model.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 <!-- markdownlint-disable-next-line  MD013 -->

--- a/docs/source/api/models/hydrology/hydrology_tools.md
+++ b/docs/source/api/models/hydrology/hydrology_tools.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 #  API for the {mod}`~virtual_ecosystem.models.hydrology.hydrology_tools` module

--- a/docs/source/api/models/litter.md
+++ b/docs/source/api/models/litter.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API reference for `litter` modules

--- a/docs/source/api/models/litter/carbon.md
+++ b/docs/source/api/models/litter/carbon.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.models.litter.carbon` module

--- a/docs/source/api/models/litter/chemistry.md
+++ b/docs/source/api/models/litter/chemistry.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.models.litter.chemistry` module

--- a/docs/source/api/models/litter/constants.md
+++ b/docs/source/api/models/litter/constants.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.models.litter.constants` module

--- a/docs/source/api/models/litter/env_factors.md
+++ b/docs/source/api/models/litter/env_factors.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.models.litter.env_factors` module

--- a/docs/source/api/models/litter/inputs.md
+++ b/docs/source/api/models/litter/inputs.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.models.litter.inputs` module

--- a/docs/source/api/models/litter/litter_model.md
+++ b/docs/source/api/models/litter/litter_model.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.models.litter.litter_model` module

--- a/docs/source/api/models/plants.md
+++ b/docs/source/api/models/plants.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API reference for `plants` modules

--- a/docs/source/api/models/plants/plant_structures.md
+++ b/docs/source/api/models/plants/plant_structures.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # Plant structures for the {mod}`~virtual_ecosystem.models.plants` module

--- a/docs/source/api/models/plants/plants_model.md
+++ b/docs/source/api/models/plants/plants_model.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the plants model

--- a/docs/source/api/models/soil.md
+++ b/docs/source/api/models/soil.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API reference for `soil` modules

--- a/docs/source/api/models/soil/carbon.md
+++ b/docs/source/api/models/soil/carbon.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.models.soil.carbon` module

--- a/docs/source/api/models/soil/constants.md
+++ b/docs/source/api/models/soil/constants.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.models.soil.constants` module

--- a/docs/source/api/models/soil/env_factors.md
+++ b/docs/source/api/models/soil/env_factors.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.models.soil.env_factors` module

--- a/docs/source/api/models/soil/soil_model.md
+++ b/docs/source/api/models/soil/soil_model.md
@@ -7,11 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # API documentation for the {mod}`~virtual_ecosystem.models.soil.soil_model` module

--- a/docs/source/bibliography.md
+++ b/docs/source/bibliography.md
@@ -1,3 +1,16 @@
+---
+jupyter:
+  jupytext:
+    cell_metadata_filter: all,-trusted
+    main_language: python
+    notebook_metadata_filter: settings,mystnb,language_info
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.16.4
+---
+
 # Bibliography
 
 ```{eval-rst}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,15 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: all,-trusted
+#     notebook_metadata_filter: settings,mystnb,language_info
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.16.4
+# ---
+
 """Configuration file for the Sphinx documentation builder.
 
 This file only contains a selection of the most common options. For a full
@@ -27,10 +39,12 @@ from sphinxcontrib.bibtex.style.referencing.author_year import AuthorYearReferen
 import virtual_ecosystem as ve
 from virtual_ecosystem.core import variables
 
+# +
 # Silence sphinx 8 warnings.
 warnings.filterwarnings("ignore", category=RemovedInSphinx80Warning)
 
 
+# +
 # This path is required for automodule to be able to find and render the docstring
 # example in the development section of the documentation. The path to the modules for
 # the virtual_ecosystem package itself do not needed to be included here, providing
@@ -38,18 +52,22 @@ warnings.filterwarnings("ignore", category=RemovedInSphinx80Warning)
 # as this conf.py file, where we currently run it from the parent `docs` folder, so
 # adding an absolute path is more reliable.
 sys.path.append(str(Path(__file__).parent / "development/documentation"))
+# -
 
 
 version = ve.__version__
 release = version
 
+# +
 # Update the variables file
 varfile = Path(__file__).parent / "variables.rst"
 variables.output_known_variables(varfile)
+# -
 
 
 # -- Project information -----------------------------------------------------
 
+# +
 project = "Virtual Ecosystem"
 copyright = (
     "2022, Rob Ewers, David Orme, Olivia Daniels, Jacob Cook, "
@@ -59,10 +77,12 @@ author = (
     "Rob Ewers, David Orme, Olivia Daniels, Jacob Cook, Jaideep Joshi, "
     "Taran Rallings, Vivienne Groner"
 )
+# -
 
 
 # -- General configuration ---------------------------------------------------
 
+# +
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
@@ -83,6 +103,7 @@ extensions = [
 ]
 autodoc_default_flags = ["members"]
 autosummary_generate = True
+# -
 
 
 # Set up the external table of contents file path and configure

--- a/docs/source/development/contributing.md
+++ b/docs/source/development/contributing.md
@@ -1,1 +1,14 @@
+---
+jupyter:
+  jupytext:
+    cell_metadata_filter: all,-trusted
+    main_language: python
+    notebook_metadata_filter: settings,mystnb,language_info
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.16.4
+---
+
 # Contributing to the Virtual Ecosystem

--- a/docs/source/development/contributing/code_qa_and_typing.md
+++ b/docs/source/development/contributing/code_qa_and_typing.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.2
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/development/contributing/code_qa_and_typing.md
+++ b/docs/source/development/contributing/code_qa_and_typing.md
@@ -64,6 +64,10 @@ and we use both the linting (`ruff`) and formatting (`ruff-format`) hooks.
 `markdownlint`
 : Checks all markdown files for common formatting issues.
 
+`jupytext`
+: This tool is used to pass all python code within notebooks through code formatting. At
+present, this still uses the `black` code formatter and not `ruff-format` as above.
+
 ### Output and configuration
 
 When `pre-commit` runs, you may see some lines about package installation and update,
@@ -77,6 +81,7 @@ ruff.................................................................Passed
 ruff-format..........................................................Passed
 mypy.................................................................Passed
 markdownlint.........................................................Passed
+jupytext.............................................................Passed
 ```
 
 ### Updating `pre-commit`

--- a/docs/source/development/contributing/code_testing.md
+++ b/docs/source/development/contributing/code_testing.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.2
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3
   language: python
@@ -35,7 +35,7 @@ Further future tests may include:
 existing implementations of some functionality, such as the `SPLASH` or `microclimc`
 packages
 * profiling
-  
+
 The test suite can be run from repository using:
 
 ```bash
@@ -57,7 +57,7 @@ We have configured `pytest` to automatically also run `doctest`, but you can man
 check the tests in files using, for example:
 
 ```bash
-poetry run python -m doctest virtual_ecosystem/core/constants.py 
+poetry run python -m doctest virtual_ecosystem/core/constants.py
 ```
 
 Normally, `doctest` is just used to test a return value: the value tested is the value

--- a/docs/source/development/contributing/github_actions.md
+++ b/docs/source/development/contributing/github_actions.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.2
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/development/contributing/overview.md
+++ b/docs/source/development/contributing/overview.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.2
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/development/contributing/release_process.md
+++ b/docs/source/development/contributing/release_process.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.2
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/development/design.md
+++ b/docs/source/development/design.md
@@ -1,1 +1,14 @@
+---
+jupyter:
+  jupytext:
+    cell_metadata_filter: all,-trusted
+    main_language: python
+    notebook_metadata_filter: settings,mystnb,language_info
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.16.4
+---
+
 # The design of the Virtual Ecosystem

--- a/docs/source/development/design/core.md
+++ b/docs/source/development/design/core.md
@@ -1,14 +1,26 @@
 ---
-jupyter:
-  jupytext:
-    cell_metadata_filter: all,-trusted
-    main_language: python
-    notebook_metadata_filter: settings,mystnb,language_info
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.16.4
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # Design notes for the `core` module
@@ -194,7 +206,7 @@ present.
 <!-- markdownlint-disable MD012 # jupytext adds a line that markdownlint dislikes -->
 
 
-```{code-cell} ipython3
+```{code-block} ipython3
 class DataGenerator:
 
     def __init__(
@@ -219,7 +231,7 @@ A user could provide a scalar (so a global value) or an array (matching a spatia
 or mapping) that stipulates a method and keyword arguments. So here a DataGenerator
 might be:
 
-```{code-cell} ipython3
+```{code-block} ipython3
 # Global value varying as a normal distribution around 5
 ex1 = DataGenerator(loc=5, scale=2, distribution="normal")
 # A 2x2 grid with lognormal values with mean varying by cell, but constant variation.
@@ -231,7 +243,7 @@ need a time axis giving the temporal location of the sampling points, which coul
 interpolated if necessary. So for example, a 2 x 2 grid with normally distributed values
 that increase in location and scale over a year.
 
-```{code-cell} ipython3
+```{code-block} ipython3
 loc = [[[1, 2], [3, 4]], [[2, 3], [4, 5]]]
 
 scale = [[[1, 1], [1, 1]], [[1.2, 1.2], [1.2, 1.2]]]

--- a/docs/source/development/design/core.md
+++ b/docs/source/development/design/core.md
@@ -1,3 +1,16 @@
+---
+jupyter:
+  jupytext:
+    cell_metadata_filter: all,-trusted
+    main_language: python
+    notebook_metadata_filter: settings,mystnb,language_info
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.16.4
+---
+
 # Design notes for the `core` module
 
 ## Configuration
@@ -30,7 +43,7 @@ reasons make use of the `toml` file format for configuration of the Virtual Ecos
 The config system should provide a way to:
 
 - load a config file into a dictionary:
-  (config\['plant'\]\['functional_types'\]\['max_height'\]
+  config\['plant'\]\['functional_types'\]\['max_height'\]
 - or possibly something like a dataclass for dotted notation:
   (config.plant.functional_types.max_height)
 - validate the config against some kind of template
@@ -178,7 +191,10 @@ I think this can basically just use all the options of `numpy.random`, possibly 
 inclusion of interpolation along a time dimension at a given interval if a time axis is
 present.
 
-```python
+<!-- markdownlint-disable MD012 # jupytext adds a line that markdownlint dislikes -->
+
+
+```{code-cell} ipython3
 class DataGenerator:
 
     def __init__(
@@ -187,11 +203,14 @@ class DataGenerator:
         temporal_axis: str,
         temporal_interpolation: np.timedelta64,
         seed: Optional[int],
-        method: str, # one of the numpy.random.Generator methods
+        method: str,  # one of the numpy.random.Generator methods
         **kwargs
-        ) -> np.ndarray
+    ) -> np.ndarray:
 
+        pass
 ```
+
+<!-- markdownlint-enable MD012 -->
 
 The model I have in my head is based around the `numpy.random` methods
 [](https://numpy.org/doc/stable/reference/random/generator.html).
@@ -200,11 +219,11 @@ A user could provide a scalar (so a global value) or an array (matching a spatia
 or mapping) that stipulates a method and keyword arguments. So here a DataGenerator
 might be:
 
-```python
+```{code-cell} ipython3
 # Global value varying as a normal distribution around 5
-ex1 = DataGenerator(loc=5, scale=2, distribution='normal')
+ex1 = DataGenerator(loc=5, scale=2, distribution="normal")
 # A 2x2 grid with lognormal values with mean varying by cell, but constant variation.
- ex2 = DataGenerator(mean=[[5, 6], [7, 8]], sigma=2, distribution='lognormal')
+ex2 = DataGenerator(mean=[[5, 6], [7, 8]], sigma=2, distribution="lognormal")
 ```
 
 More advanced would be providing a time series of values with variation. Here, you'd
@@ -212,20 +231,14 @@ need a time axis giving the temporal location of the sampling points, which coul
 interpolated if necessary. So for example, a 2 x 2 grid with normally distributed values
 that increase in location and scale over a year.
 
-```python
-loc = [[[1, 2],
-        [3, 4]],
-       [[2, 3],
-        [4, 5]]]
+```{code-cell} ipython3
+loc = [[[1, 2], [3, 4]], [[2, 3], [4, 5]]]
 
-scale = [[[1, 1],
-          [1, 1]],
-         [[1.2, 1.2],
-          [1.2, 1.2]]]
+scale = [[[1, 1], [1, 1]], [[1.2, 1.2], [1.2, 1.2]]]
 
-time = ['2020-01-01', '2020-12-31']
+time = ["2020-01-01", "2020-12-31"]
 
-ex3 = DataGenerator(loc = loc, scale=scale, method='normal', time=time, time_axis=2)
+ex3 = DataGenerator(loc=loc, scale=scale, method="normal", time=time, time_axis=2)
 ```
 
 We could provide ways to provide sequences of generators to provide more complex

--- a/docs/source/development/design/defining_new_models.md
+++ b/docs/source/development/design/defining_new_models.md
@@ -184,15 +184,11 @@ The {attr}`~virtual_ecosystem.core.base_model.BaseModel.vars_required_for_init` 
 new instance of the model. Each entry should provide a variable name and then another
 tuple that sets any required axes for the variable. For example:
 
-```{code-cell} ipython3
-:lines_to_next_cell: 2
-
+```{code-block} ipython3
 ()  # no required variables
 (("temperature", ()),)  # temperature must be present, no core axes
 (("temperature", ("spatial",)),)  # temperature must be present and on the spatial axis
 ```
-
-+++ {"lines_to_next_cell": 2}
 
 The {attr}`~virtual_ecosystem.core.base_model.BaseModel.vars_updated` attribute : This
 is a tuple that provides information about which data object variables are updated by
@@ -213,8 +209,7 @@ into a time period
 These values are set as class attributes by providing them as arguments to the class
 signature. You will end up with something like the following:
 
-```{code-cell} ipython3
-:lines_to_next_cell: 2
+```{code-block} ipython3
 
 class FreshWaterModel(
     BaseModel,
@@ -230,8 +225,6 @@ class FreshWaterModel(
     """
 ```
 
-+++ {"lines_to_next_cell": 2}
-
 ### Defining the model `__init__` method
 
 The next step is to define the `__init__` method for the class. This needs to do a few
@@ -246,9 +239,9 @@ things.
    method of the {meth}`~virtual_ecosystem.core.base_model.BaseModel` parent class,
    also known as the superclass:
 
-   ```{code-cell} ipython3
-   super().__init__(data, update_interval, **kwargs)
-   ```
+```{code-block} ipython3
+super().__init__(data, update_interval, **kwargs)
+```
 
    Calling this method runs all of the shared functionality across models, such as
    setting the update intervals and validating the input data.
@@ -263,7 +256,7 @@ things.
 
 You should end up with something like this:
 
-```{code-cell} ipython3
+```{code-block} ipython3
 def __init__(
     self,
     data: Data,
@@ -427,13 +420,9 @@ configuration process but also provides a dictionary interface to the configurat
 data. So, the example above might result in a `Config` object with the following model
 specific data.
 
-```{code-cell} ipython3
-:lines_to_next_cell: 2
-
+```{code-block} ipython3
 {"freshwater": {"update_interval": "1 month", "no_of_ponds": 3}}
 ```
-
-+++ {"lines_to_next_cell": 2}
 
 The job of the `from_config` method for a model is to take that configuration, along
 with the shared `data` and `start_time` inputs, and then do any processing and
@@ -453,9 +442,7 @@ the config.
 
 As an example:
 
-```{code-cell} ipython3
-:lines_to_next_cell: 2
-
+```{code-block} ipython3
 @classmethod
 def from_config(
     cls, data: Data, config: Config, update_interval: Quantity
@@ -484,8 +471,6 @@ def from_config(
     return cls(data, update_interval, no_pools, constants)
 ```
 
-+++ {"lines_to_next_cell": 2}
-
 ## Other model steps
 
 There are four functions that must be included as part of the model class. The names and
@@ -495,9 +480,7 @@ that kind of API change is something that would require significant discussion. 
 there's no need to include any particular content within them (i.e. they can just be
 function definitions with docstrings).
 
-```{code-cell} ipython3
-:lines_to_next_cell: 2
-
+```{code-block} ipython3
 def setup(self) -> None:
     """Placeholder function to set up the freshwater model."""
 

--- a/docs/source/development/design/defining_new_models.md
+++ b/docs/source/development/design/defining_new_models.md
@@ -5,11 +5,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # Creating new Virtual Ecosystem models
@@ -103,7 +113,7 @@ from virtual_ecosystem.core.constants_class import ConstantsDataclass
 @dataclass(frozen=True)
 class FreshwaterConsts(ConstantsDataclass):
     """Dataclass to store all constants for the `example_model` model."""
-    
+
     # Constants must be typed, to make them configurable instance attributes.
     example_constant_1: float = -1.27
     """Details of source of constant and its units."""
@@ -125,14 +135,14 @@ subclass.
 
 ```{code-block} python
 
-# The BaseModel.from_config factory method returns an instance of the class, and 
+# The BaseModel.from_config factory method returns an instance of the class, and
 # annotations is required to allow typing to understand this return value.
 from __future__ import annotations
 
 # To support the kwargs argument to BaseModel.__init__
 from typing import Any
 
-# Data in the Virtual Ecosystem is stored as xarray.DataArrays and array calculations 
+# Data in the Virtual Ecosystem is stored as xarray.DataArrays and array calculations
 # typically use numpy.
 import numpy as np
 import xarray
@@ -152,7 +162,7 @@ from virtual_ecosystem.core.data import Data
 from virtual_ecosystem.core.exceptions import InitialisationError
 from virtual_ecosystem.core.logger import LOGGER
 
-# You will likely also have a set of imports of model specific code such as constants 
+# You will likely also have a set of imports of model specific code such as constants
 # classes and other classes and functions. For example:
 from virtual_ecosystem.models.freshwater.constants import FreshwaterConsts
 from virtual_ecosystem.models.freshwater.streamflow import calculate_streamflow
@@ -174,11 +184,15 @@ The {attr}`~virtual_ecosystem.core.base_model.BaseModel.vars_required_for_init` 
 new instance of the model. Each entry should provide a variable name and then another
 tuple that sets any required axes for the variable. For example:
 
-```python
+```{code-cell} ipython3
+:lines_to_next_cell: 2
+
 ()  # no required variables
-(('temperature', ()),) # temperature must be present, no core axes
-(('temperature', ('spatial',)),) # temperature must be present and on the spatial axis
+(("temperature", ()),)  # temperature must be present, no core axes
+(("temperature", ("spatial",)),)  # temperature must be present and on the spatial axis
 ```
+
++++ {"lines_to_next_cell": 2}
 
 The {attr}`~virtual_ecosystem.core.base_model.BaseModel.vars_updated` attribute : This
 is a tuple that provides information about which data object variables are updated by
@@ -199,13 +213,15 @@ into a time period
 These values are set as class attributes by providing them as arguments to the class
 signature. You will end up with something like the following:
 
-```python
+```{code-cell} ipython3
+:lines_to_next_cell: 2
+
 class FreshWaterModel(
-    BaseModel, 
-    model_name = "freshwater",
-    model_update_bounds = ("1 day", "1 month"),
-    vars_required_for_init = (('temperature', ('spatial', )), ),
-    vars_updated = ("average_P_concentration",),
+    BaseModel,
+    model_name="freshwater",
+    model_update_bounds=("1 day", "1 month"),
+    vars_required_for_init=(("temperature", ("spatial",)),),
+    vars_updated=("average_P_concentration",),
 ):
     """Docstring describing model.
 
@@ -213,6 +229,8 @@ class FreshWaterModel(
         Describe arguments here
     """
 ```
+
++++ {"lines_to_next_cell": 2}
 
 ### Defining the model `__init__` method
 
@@ -228,7 +246,7 @@ things.
    method of the {meth}`~virtual_ecosystem.core.base_model.BaseModel` parent class,
    also known as the superclass:
 
-   ```python
+   ```{code-cell} ipython3
    super().__init__(data, update_interval, **kwargs)
    ```
 
@@ -245,7 +263,7 @@ things.
 
 You should end up with something like this:
 
-```python
+```{code-cell} ipython3
 def __init__(
     self,
     data: Data,
@@ -254,21 +272,21 @@ def __init__(
     constants: FreshwaterConsts,
     **kwargs: Any,
 ):
-        
+
     # Sanity checking of input variables goes here
     if no_of_ponds < 0:
         to_raise = InitialisationError(
-                "There has to be at least one pond in the freshwater model!"
-            )
+            "There has to be at least one pond in the freshwater model!"
+        )
         LOGGER.error(to_raise)
         raise to_raise
-        
+
     # Call the __init__() method of the base class
     super().__init__(data, update_interval, **kwargs)
 
     # Store model specific details as attributes.
     self.no_of_ponds = int(no_of_ponds)
-    
+
     # Store the constants relevant to the freshwater model
     self.constants = constants
 
@@ -409,9 +427,13 @@ configuration process but also provides a dictionary interface to the configurat
 data. So, the example above might result in a `Config` object with the following model
 specific data.
 
-```python
-{'freshwater': {'update_interval': "1 month",  "no_of_ponds": 3}}
+```{code-cell} ipython3
+:lines_to_next_cell: 2
+
+{"freshwater": {"update_interval": "1 month", "no_of_ponds": 3}}
 ```
+
++++ {"lines_to_next_cell": 2}
 
 The job of the `from_config` method for a model is to take that configuration, along
 with the shared `data` and `start_time` inputs, and then do any processing and
@@ -431,7 +453,9 @@ the config.
 
 As an example:
 
-```python
+```{code-cell} ipython3
+:lines_to_next_cell: 2
+
 @classmethod
 def from_config(
     cls, data: Data, config: Config, update_interval: Quantity
@@ -447,7 +471,7 @@ def from_config(
         config: A validated Virtual Ecosystem model configuration object.
         update_interval: Frequency with which all models are updated
     """
-    
+
     # Non-timing details now extracted
     no_of_pools = config["freshwater"]["no_of_pools"]
 
@@ -458,8 +482,9 @@ def from_config(
         "Information required to initialise the soil model successfully extracted."
     )
     return cls(data, update_interval, no_pools, constants)
-
 ```
+
++++ {"lines_to_next_cell": 2}
 
 ## Other model steps
 
@@ -470,12 +495,16 @@ that kind of API change is something that would require significant discussion. 
 there's no need to include any particular content within them (i.e. they can just be
 function definitions with docstrings).
 
-```python
+```{code-cell} ipython3
+:lines_to_next_cell: 2
+
 def setup(self) -> None:
     """Placeholder function to set up the freshwater model."""
 
+
 def spinup(self) -> None:
     """Placeholder function to spin up the freshwater model."""
+
 
 # While model updates have to take time_index as an argument, they do not necessarily
 # have to use it anywhere
@@ -487,6 +516,7 @@ def update(self, time_index: int) -> None:
     """
 
     # Model simulation + update steps go in here.
+
 
 def cleanup(self) -> None:
     """Placeholder function for freshwater model cleanup."""
@@ -506,14 +536,14 @@ In the Virtual Ecosystem, we use the `__init__.py` file in model submodules to:
 The file will look something like:
 
 ```{code-block} python
-"""This is the freshwater model module. The module level docstring should contain a 
-short description of the overall model design and purpose, and link to key components 
+"""This is the freshwater model module. The module level docstring should contain a
+short description of the overall model design and purpose, and link to key components
 and how they interact.
 """  # noqa: D204, D415
 
 from virtual_ecosystem.models.freshwater.freshwater_model import (  # noqa: F401
     FreshwaterModel,
-)  
+)
 ```
 
 Under the hood, when a given model is used in a simulation, then the configuration

--- a/docs/source/development/documentation.md
+++ b/docs/source/development/documentation.md
@@ -1,1 +1,14 @@
+---
+jupyter:
+  jupytext:
+    cell_metadata_filter: all,-trusted
+    main_language: python
+    notebook_metadata_filter: settings,mystnb,language_info
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.16.4
+---
+
 # Documentation development

--- a/docs/source/development/documentation/api_generation.md
+++ b/docs/source/development/documentation/api_generation.md
@@ -7,7 +7,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 ---
 
 # Generating API documentation from docstrings
@@ -30,7 +30,7 @@ The docstring Markdown file has three components:
 
 * The file will start with the `jupytext` YAML metadata, which just sets the Markdown
   format used in the file.
-  
+
 * A markdown header (`# A header`), which is shown as the page title. It is also used as
   the text for links to this page from the table of contents, unless a shorter name is
   provided in the `index.md` file. Typically, this header is the only markdown content
@@ -64,7 +64,7 @@ Note that we **should not** include `:special-members: __init__` in the `automod
 options: creating a class instance is documented by the class docstring.
 
 ````{admonition} Rendered content
-All of the content below this box is rendered from the example docstring code. 
+All of the content below this box is rendered from the example docstring code.
 ````
 
 ```{eval-rst}

--- a/docs/source/development/documentation/docstring_style.md
+++ b/docs/source/development/documentation/docstring_style.md
@@ -7,9 +7,8 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 ---
-
 
 # Docstring style for the Virtual Ecosystem package
 

--- a/docs/source/development/documentation/docstring_style.py
+++ b/docs/source/development/documentation/docstring_style.py
@@ -1,3 +1,15 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: all,-trusted
+#     notebook_metadata_filter: settings,mystnb,language_info
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.16.4
+# ---
+
 """This is the documentation for the module. It does not start with a header line
 because a header is required at the top of the markdown source page where the API docs
 will be inserted using the ``automodule`` declaration, so we do not repeat it here.

--- a/docs/source/development/documentation/documentation.md
+++ b/docs/source/development/documentation/documentation.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.2
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/development/documentation/jupyter_notebooks.md
+++ b/docs/source/development/documentation/jupyter_notebooks.md
@@ -154,7 +154,8 @@ language_info:
 ```
 
 If you already have a simple Markdown file then the commands below will insert this YAML
-header:
+header, but at present the `language_info` section either needs to be added manually or
+by opening and saving the file in `jupyter`.
 
 ```sh
 % jupytext --set-format md:myst simple.md

--- a/docs/source/development/documentation/jupyter_notebooks.md
+++ b/docs/source/development/documentation/jupyter_notebooks.md
@@ -7,7 +7,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # Dynamic content using `jupyter` notebooks
@@ -35,7 +49,7 @@ the Jupyter extension within VS Code. For this option, you will need to make sur
 VS Code is using the right python environment. The information you will need is
 produced from `poetry`:
 
-```zsh
+```sh
 % poetry env list --full-path
 /Users/dorme/Library/Caches/pypoetry/virtualenvs/virtual-ecosystem-Laomc1u4-py3.10
 /Users/dorme/Library/Caches/pypoetry/virtualenvs/virtual-ecosystem-Laomc1u4-py3.9 (Activated)
@@ -69,7 +83,7 @@ check this by running the following, which shows the `python3` kernel pointing t
 `python3` kernel Virtual Ecosystem virtual environment: that path will vary between
 machines but `poetry` will ensure that the link is set correctly.
 
-```zsh
+```sh
 % poetry run jupyter kernelspec list
 Available kernels:
   ir                 ../Jupyter/kernels/ir
@@ -126,13 +140,23 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 ```
 
 If you already have a simple Markdown file then the commands below will insert this YAML
 header:
 
-```zsh
+```sh
 % jupytext --set-format md:myst simple.md
 % jupytext --set-kernel python3  simple.md
 ```
@@ -170,7 +194,7 @@ tools may be useful:
 Although `jupytext` does not do Markdown validation, it does allow `black` to be run on
 the code cells, so that the format of code in notebooks can be automatically formatted.
 
-```zsh
+```sh
 jupytext --pipe black my_markdown.md
 ```
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -4,6 +4,8 @@ jupytext:
   text_representation:
     extension: .md
     format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/using_the_ve/configuration/axes.md
+++ b/docs/source/using_the_ve/configuration/axes.md
@@ -6,11 +6,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # Core axes
@@ -43,12 +53,12 @@ axis.
 ## The `spatial` core axis
 
 ```{admonition} Array dimensions
-The validators for this axis check for variables with either a `cell_id` dimension or 
-with `x` and `y` dimensions. 
+The validators for this axis check for variables with either a `cell_id` dimension or
+with `x` and `y` dimensions.
 
-Datasets that use `latitude` and `longitude` dimension names - or variants of those 
-names - will not be validated on the `spatial` axis. This is because we expect Virtual 
-Ecosystem to be used exclusively with projected coordinate systems and so spatial data 
+Datasets that use `latitude` and `longitude` dimension names - or variants of those
+names - will not be validated on the `spatial` axis. This is because we expect Virtual
+Ecosystem to be used exclusively with projected coordinate systems and so spatial data
 on geographic coordinates must be projected onto appropriate local projected coordinates
 before use.
 ```

--- a/docs/source/using_the_ve/configuration/config.md
+++ b/docs/source/using_the_ve/configuration/config.md
@@ -1,3 +1,28 @@
+---
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
 # The configuration module
 
 This module is used to configure a `virtual_ecosystem` simulation run. This module

--- a/docs/source/using_the_ve/configuration/constants.md
+++ b/docs/source/using_the_ve/configuration/constants.md
@@ -1,3 +1,28 @@
+---
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
 # Virtual Ecosystem parameterisation
 
 The Virtual Ecosystem contains a very large number of constants. These constants are

--- a/docs/source/using_the_ve/configuration/grid.md
+++ b/docs/source/using_the_ve/configuration/grid.md
@@ -6,11 +6,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # The `core.grid` module
@@ -18,7 +28,7 @@ kernelspec:
 This module is used to define the grid of cells used in a `virtual_ecosystem`
 simulation. Square and hexagon grids are currently supported.
 
-```{code-cell}
+```{code-cell} ipython3
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -30,7 +40,7 @@ from virtual_ecosystem.core.grid import Grid
 A square grid is defined using the cell area, and the number of cells in the X and Y
 directions to include in the simulation.
 
-```{code-cell}
+```{code-cell} ipython3
 square_grid = Grid(grid_type="square", cell_area=100, cell_nx=10, cell_ny=10)
 square_grid
 ```
@@ -40,7 +50,7 @@ square_grid
 A hexagon grid is defined in a very similar way - alternate rows of hexagons are offset
 to correctly tesselate the individual cells.
 
-```{code-cell}
+```{code-cell} ipython3
 hex_grid = Grid(grid_type="hexagon", cell_area=100, cell_nx=9, cell_ny=11)
 hex_grid
 ```
@@ -58,7 +68,7 @@ stored within a `Grid` instance:
 These `Grid` attributes are used in the code below to show the default cell ID numbering
 scheme.
 
-```{code-cell}
+```{code-cell} ipython3
 :tags: [hide-input]
 
 # Side by side plots of the two grid systems
@@ -91,7 +101,7 @@ for this_ax, this_grid in zip(axes, [square_grid, hex_grid]):
 The centroids of the grid cell polygons are available via the `centroids` attribute as a
 `numpy` array of ($x$, $y$) pairs: these can be indexed by cell id:
 
-```{code-cell}
+```{code-cell} ipython3
 square_grid.centroids[0:5]
 ```
 
@@ -102,7 +112,7 @@ the grid. This can be useful for aligning a simulation grid with data in real pr
 coordinate systems, rather than having to move the origin in multiple existing data
 files.
 
-```{code-cell}
+```{code-cell} ipython3
 offset_grid = Grid(
     grid_type="square", cell_area=1000000, cell_nx=9, cell_ny=9, xoff=-4500, yoff=-4500
 )
@@ -110,7 +120,7 @@ offset_grid = Grid(
 offset_grid
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 :tags: [hide-input]
 
 # Plot of the an offset grid
@@ -143,12 +153,12 @@ contains a list of the same length as `cell_id`, containing arrays of the cell i
 neighbouring cells. At present, only a distance-based neighbourhood calculation is used.
 The neighbours of a specific cell can then be retrieved using its cell id as an index.
 
-```{code-cell}
+```{code-cell} ipython3
 square_grid.set_neighbours(distance=10)
 square_grid.neighbours[45]
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 hex_grid.set_neighbours(distance=15)
 hex_grid.neighbours[40]
 ```
@@ -158,11 +168,11 @@ hex_grid.neighbours[40]
 The `get_distance` method can be used to calculate pairwise distances between lists of
 cell ids. A single cell id can also be used.
 
-```{code-cell}
+```{code-cell} ipython3
 square_grid.get_distances(45, square_grid.neighbours[45])
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 hex_grid.get_distances([1, 40], hex_grid.neighbours[40])
 ```
 
@@ -171,7 +181,7 @@ complete pairwise distance matrix scales as the square of the grid size. However
 `populate_distances` method can be used to populate that matrix, and it is then used by
 `get_distance` for faster lookup of distances.
 
-```{code-cell}
+```{code-cell} ipython3
 square_grid.populate_distances()
 square_grid.get_distances(45, square_grid.neighbours[45])
 ```
@@ -188,7 +198,7 @@ cell boundaries will intersect **all** of the cells sharing a boundary.
 
 The method returns a list of lists, giving the cell_ids for each pair of points in turn.
 
-```{code-cell}
+```{code-cell} ipython3
 # A simple small grid
 simple = Grid("square", cell_nx=2, cell_ny=2, cell_area=1, xoff=1, yoff=1)
 
@@ -197,7 +207,7 @@ points_x = np.array([0.75, 1.25, 1.5, 2, 2.25, 3.25])
 points_y = np.array([0.75, 1.25, 2, 2, 2.25, 3.25])
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 :tags: [hide-input]
 
 # Plot the data
@@ -222,7 +232,7 @@ plt.plot(points_x, points_y, "rx")
 plt.gca().set_aspect("equal")
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 # Recover the cells under each pair of points.
 simple.map_xy_to_cell_id(points_x, points_y)
 ```
@@ -244,7 +254,7 @@ from the original X and Y axes that map the 2 dimensional data onto a one dimens
 cell id axis in the correct order. This is primarily used in loading and validating a
 dataset and then coercing it into the standard internal representation.
 
-```{code-cell}
+```{code-cell} ipython3
 # A small dataset with coordinates that covers the grid
 data = np.array([[23, 33], [22, 32]])
 cx = np.array([2.5, 1.5])
@@ -262,11 +272,11 @@ dx, dy = simple.map_xy_to_cell_indexing(points_x, points_y, idx_xf, idx_yf)
 print(dx, dy)
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 data[dx, dy]
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 # A set of points that extend beyond the grid
 data = np.array(
     [[14, 24, 34, 44], [13, 23, 33, 43], [12, 22, 32, 42], [11, 21, 31, 41]]
@@ -282,7 +292,7 @@ points_x = cx[idx_xf]
 points_y = cy[idx_yf]
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 :tags: [raises-exception]
 
 # Fails because points extend outside the grid
@@ -293,7 +303,7 @@ simple.map_xy_to_cell_indexing(points_x, points_y, idx_xf, idx_yf)
 
 A created grid can also be exported as GeoJSON using the `dumps` and `dump` methods:
 
-```{code-cell}
+```{code-cell} ipython3
 simple = Grid("square", cell_nx=2, cell_ny=2, cell_area=1)
 
 simple.dumps()

--- a/docs/source/using_the_ve/data/data.md
+++ b/docs/source/using_the_ve/data/data.md
@@ -109,8 +109,8 @@ two methods:
    a DataArray from supported file formats. This can then be added directly to a Data
    instance:
 
-```{code-cell} ipython3
-data["var_name"] = load_to_dataarray("path/to/file.nc", var="temperature")
+```{code-block} ipython3
+data["var_name"] = load_to_dataarray("path/to/file.nc", var_name="temperature")
 ```
 
 1. The  {meth}`~virtual_ecosystem.core.data.Data.load_data_config` method takes a
@@ -245,14 +245,17 @@ data
 The entire contents of the `Data` object can be output using the
 {meth}`~virtual_ecosystem.core.data.Data.save_to_netcdf` method:
 
-```{code-cell} ipython3
-data.save_to_netcdf(output_file_path)
+```{code-block} ipython3
+data.save_to_netcdf(output_file_path=output_file_path)
 ```
 
 Alternatively, a smaller netCDF can be output containing only variables of interest.
 This is done by providing a list specifying what those variables are to the function.
 
-```{code-cell} ipython3
+```{code-block} ipython3
 variables_to_save = ["variable_a", "variable_b"]
-data.save_to_netcdf(output_file_path, variables_to_save)
+data.save_to_netcdf(
+    output_file_path=output_file_path,
+    variables_to_save=variables_to_save
+)
 ```

--- a/docs/source/using_the_ve/data/data.md
+++ b/docs/source/using_the_ve/data/data.md
@@ -6,11 +6,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # Adding and using data with the Virtual Ecosystem
@@ -67,7 +77,7 @@ A  {class}`~virtual_ecosystem.core.data.Data` instance is created using informat
 that provides information on the core configuration of the simulation. At present, this
 is just the spatial grid being used.
 
-```{code-cell}
+```{code-cell} ipython3
 from pathlib import Path
 
 import numpy as np
@@ -80,7 +90,7 @@ from virtual_ecosystem.core.axes import *
 from virtual_ecosystem.core.readers import load_to_dataarray
 
 # Create a grid with square 100m2 cells in a 10 by 10 lattice and a Data instance
-grid = Grid(grid_type='square', cell_area=100, cell_nx=10, cell_ny=10)
+grid = Grid(grid_type="square", cell_area=100, cell_nx=10, cell_ny=10)
 data = Data(grid=grid)
 
 data
@@ -99,8 +109,8 @@ two methods:
    a DataArray from supported file formats. This can then be added directly to a Data
    instance:
 
-```python
-data['var_name'] = load_to_dataarray('path/to/file.nc', var='temperature')
+```{code-cell} ipython3
+data["var_name"] = load_to_dataarray("path/to/file.nc", var="temperature")
 ```
 
 1. The  {meth}`~virtual_ecosystem.core.data.Data.load_data_config` method takes a
@@ -114,33 +124,33 @@ Adding a  DataArray to a {class}`~virtual_ecosystem.core.data.Data` method takes
 existing DataArray object and then uses the built in validation to match the data onto
 core axes. So, for example, the grid used above has a spatial resolution and size:
 
-```{code-cell}
+```{code-cell} ipython3
 grid
 ```
 
 One of the validation routines for the core spatial axis takes a DataArray with `x` and
 `y` coordinates and checks that the data covers all the cells in a square grid:
 
-```{code-cell}
+```{code-cell} ipython3
 temperature_data = DataArray(
     np.random.normal(loc=20.0, size=(10, 10)),
     name="temperature",
     coords={"y": np.arange(5, 100, 10), "x": np.arange(5, 100, 10)},
 )
 
-temperature_data.plot();
+temperature_data.plot()
 ```
 
 That data array can then be added to the  loaded and validated:
 
-```{code-cell}
+```{code-cell} ipython3
 data["temperature"] = temperature_data
 ```
 
 The representation of the {class}`virtual_ecosystem.core.data.Data` instance now shows
 the loaded variables:
 
-```{code-cell}
+```{code-cell} ipython3
 data
 ```
 
@@ -151,7 +161,7 @@ Note that the `x` and `y` coordinates have been mapped onto the internal `cell_i
 dimension used to label the different grid cells (see the
 [Grid](../configuration/grid.md) documentation for details).
 
-```{code-cell}
+```{code-cell} ipython3
 # Get the temperature data
 loaded_temp = data["temperature"]
 
@@ -161,7 +171,7 @@ print(loaded_temp)
 You can check whether a particular variable has been validated on a given core axis
 using the {meth}`~virtual_ecosystem.core.data.Data.on_core_axis` method:
 
-```{code-cell}
+```{code-cell} ipython3
 data.on_core_axis("temperature", "spatial")
 ```
 
@@ -173,17 +183,17 @@ NetCDF file contains a variable `temp` with dimensions `x` and `y`, both of whic
 are of length 10: it contains a 10 by 10 grid that maps onto the shape of the
 configured grid.
 
-```{code-cell}
+```{code-cell} ipython3
 # Load data from a file
 file_path = Path("../../data/xy_dim.nc")
-data['temp'] = load_to_dataarray(file_path, var_name="temp")
+data["temp"] = load_to_dataarray(file_path, var_name="temp")
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 data
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 data.on_core_axis("temp", "spatial")
 ```
 
@@ -211,22 +221,22 @@ to pass one or more TOML formatted configuration files to create a
 containing TOML formatted text or a list of TOML strings to create a configuration
 object:
 
-```{code-cell}
-data_toml = '''[[core.data.variable]]
+```{code-cell} ipython3
+data_toml = """[[core.data.variable]]
 file="../../data/xy_dim.nc"
 var_name="temp"
-'''
+"""
 
 config = Config(cfg_strings=data_toml)
 ```
 
 The `Config` object can then be passed to the `load_data_config` method:
 
-```{code-cell}
+```{code-cell} ipython3
 data.load_data_config(config)
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 data
 ```
 
@@ -235,14 +245,14 @@ data
 The entire contents of the `Data` object can be output using the
 {meth}`~virtual_ecosystem.core.data.Data.save_to_netcdf` method:
 
-```python
+```{code-cell} ipython3
 data.save_to_netcdf(output_file_path)
 ```
 
 Alternatively, a smaller netCDF can be output containing only variables of interest.
 This is done by providing a list specifying what those variables are to the function.
 
-```python
+```{code-cell} ipython3
 variables_to_save = ["variable_a", "variable_b"]
 data.save_to_netcdf(output_file_path, variables_to_save)
 ```

--- a/docs/source/using_the_ve/data/notes_preprocessing.md
+++ b/docs/source/using_the_ve/data/notes_preprocessing.md
@@ -1,3 +1,16 @@
+---
+jupyter:
+  jupytext:
+    cell_metadata_filter: all,-trusted
+    main_language: python
+    notebook_metadata_filter: settings,mystnb,language_info
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.16.4
+---
+
 # Notes on climate data pre-processing
 
 The atmospheric variables from regional climate models, observations, or reanalysis are

--- a/docs/source/using_the_ve/example_data.md
+++ b/docs/source/using_the_ve/example_data.md
@@ -1,3 +1,16 @@
+---
+jupyter:
+  jupytext:
+    cell_metadata_filter: all,-trusted
+    main_language: python
+    notebook_metadata_filter: settings,mystnb,language_info
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.16.4
+---
+
 # Virtual Ecosystem example data
 
 Example data is included with Virtual Ecosystem to provide an introduction to the file
@@ -220,39 +233,39 @@ The `example_soil_data.nc` file provides:
   - Unit
   - Dims
 * - pH
-  - `pH` 
+  - `pH`
   - unitless
   - XY
 * - Bulk soil density
-  - `bulk_density` 
+  - `bulk_density`
   - kg $\textrm{m}^{-3}$
   - XY
 * - Soil clay fraction
-  - `clay_fraction` 
+  - `clay_fraction`
   - unitless
   - XY
 * - Soil low molecular weight carbon pool
-  - `soil_c_pool_lmwc` 
+  - `soil_c_pool_lmwc`
   - kg C $\textrm{m}^{-3}$
   - XY
 * - Soil mineral associated organic matter carbon pool
-  - `soil_c_pool_maom` 
+  - `soil_c_pool_maom`
   - kg C $\textrm{m}^{-3}$
   - XY
 * - Soil microbial carbon pool
-  - `soil_c_pool_microbe` 
+  - `soil_c_pool_microbe`
   - kg C $\textrm{m}^{-3}$
   - XY
 * - Soil particulate organic matter carbon pool
-  - `soil_c_pool_pom` 
+  - `soil_c_pool_pom`
   - kg C $\textrm{m}^{-3}$
   - XY
 * - Soil particulate organic matter enzyme pool
-  - `soil_enzyme_pom` 
+  - `soil_enzyme_pom`
   - kg C $\textrm{m}^{-3}$
   - XY
 * - Soil mineral associated organic matter enzyme pool
-  - `soil_enzyme_maom` 
+  - `soil_enzyme_maom`
   - kg C $\textrm{m}^{-3}$
   - XY
 ```
@@ -279,23 +292,23 @@ The `example_litter_data.nc` file provides:
   - Dims
 * - above ground metabolic litter pools
   - `litter_pool_above_metabolic`
-  - kg C $\textrm{m}^{-2}$ 
+  - kg C $\textrm{m}^{-2}$
   - XY
 * - above ground structural litter pools
   - `litter_pool_above_structural`
-  - kg C $\textrm{m}^{-2}$ 
+  - kg C $\textrm{m}^{-2}$
   - XY
 * - woody litter pools
   - `litter_pool_woody`
-  - kg C $\textrm{m}^{-2}$ 
+  - kg C $\textrm{m}^{-2}$
   - XY
 * - below ground metabolic litter pools
   - `litter_pool_below_metabolic`
-  - kg C $\textrm{m}^{-2}$ 
+  - kg C $\textrm{m}^{-2}$
   - XY
 * - below ground structural litter pools
   - `litter_pool_below_structural`
-  - kg C $\textrm{m}^{-2}$ 
+  - kg C $\textrm{m}^{-2}$
   - XY
 * - lignin proportion of above ground structural litter
   - `lignin_above_structural`

--- a/docs/source/using_the_ve/getting_started.md
+++ b/docs/source/using_the_ve/getting_started.md
@@ -1,3 +1,28 @@
+---
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
 # Getting started
 
 ## Installing the Virtual Ecosystem model
@@ -34,8 +59,8 @@ ve_run --install-example /path/
 You can then run the model itself:
 
 ```shell
-ve_run /path/ve_example/config \ 
-    --outpath /path/ve_example/config/out \ 
+ve_run /path/ve_example/config \
+    --outpath /path/ve_example/config/out \
     --logfile /path/ve_example/out/ve_example.log
 ```
 

--- a/docs/source/using_the_ve/ve_run.md
+++ b/docs/source/using_the_ve/ve_run.md
@@ -1,3 +1,28 @@
+---
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
 # Command line tools overview
 
 The `virtual_ecosystem` package currently provides a single command line tool `ve_run`.

--- a/docs/source/using_the_ve/virtual_ecosystem_in_use.md
+++ b/docs/source/using_the_ve/virtual_ecosystem_in_use.md
@@ -5,11 +5,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.2
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # Using the Virtual Ecosystem
@@ -39,7 +49,6 @@ can prevent the example simulation from running successfully. That can be done a
 follows.
 
 ```{code-cell} ipython3
-
 %%bash
 # Remove any existing VE data directory in the /tmp/ directory
 if [ -d /tmp/ve_example ]; then
@@ -155,7 +164,7 @@ im2 = ax2.imshow(initial_state["pH"].to_numpy().reshape((9, 9)), extent=extent)
 ax2.set_title("Soil pH (-)")
 fig.colorbar(im2, ax=ax2, shrink=0.7)
 
-plt.tight_layout();
+plt.tight_layout()
 ```
 
 For some variables, it may be useful to visualise spatial structure in 3 dimensions.
@@ -181,7 +190,7 @@ ax.set_title("Elevation (m)")
 
 cell_bounds = range(0, 811, 90)
 ax.set_xticks(cell_bounds)
-ax.set_yticks(cell_bounds);
+ax.set_yticks(cell_bounds)
 ```
 
 For other variables, such as air temperature and precipitation, the initial data
@@ -206,7 +215,7 @@ ax1.set_xlabel("Time step (months)")
 ax2.plot(initial_state["time_index"], initial_state["precipitation"])
 ax2.set_title("Precipitation forcing across grid cells")
 ax2.set_ylabel("Total monthly precipitation (mm)")
-ax2.set_xlabel("Time step (months)");
+ax2.set_xlabel("Time step (months)")
 ```
 
 ### Model outputs
@@ -239,7 +248,7 @@ for idx, ax in zip([0, 10, 23], axes):
     ax.set_title(f"Time step: {idx}")
 
 fig.colorbar(im, ax=axes, orientation="vertical", shrink=0.5)
-plt.suptitle("Soil carbon: mineral-associated organic matter", y=0.78, x=0.45);
+plt.suptitle("Soil carbon: mineral-associated organic matter", y=0.78, x=0.45)
 ```
 
 #### Temporal data
@@ -250,7 +259,7 @@ showing the values in each cell across time.
 ```{code-cell} ipython3
 plt.plot(continuous_data["time_index"], continuous_data["soil_c_pool_maom"])
 plt.xlabel("Time step")
-plt.ylabel("Soil carbon as MAOM");
+plt.ylabel("Soil carbon as MAOM")
 ```
 
 #### Vertical structure
@@ -305,5 +314,5 @@ ax.set_ylabel("Northing (m)")
 ax.set_zlabel("Layer height (m)")
 
 ax.set_xticks(cell_bounds)
-ax.set_yticks(cell_bounds);
+ax.set_yticks(cell_bounds)
 ```

--- a/docs/source/virtual_ecosystem/implementation/abiotic_implementation.md
+++ b/docs/source/virtual_ecosystem/implementation/abiotic_implementation.md
@@ -5,11 +5,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.2
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # The abiotic model implementation
@@ -29,20 +39,18 @@ and then update it at each time step. Please check also the
 
 ```{code-cell} ipython3
 ---
-tags: [remove-input]
 mystnb:
   markdown_format: myst
+tags: [remove-input]
 ---
-
 from IPython.display import display_markdown
 from var_generator import generate_variable_table
 
 display_markdown(
     generate_variable_table(
-        'AbioticModel', 
-        ['vars_required_for_init', 'vars_required_for_update']
-    ), 
-    raw=True
+        "AbioticModel", ["vars_required_for_init", "vars_required_for_update"]
+    ),
+    raw=True,
 )
 ```
 
@@ -239,16 +247,9 @@ step.
 
 ```{code-cell} ipython3
 ---
-tags: [remove-input]
 mystnb:
   markdown_format: myst
+tags: [remove-input]
 ---
-
-display_markdown(
-    generate_variable_table(
-        'AbioticModel',
-        ['vars_updated']
-    ),
-    raw=True
-)
+display_markdown(generate_variable_table("AbioticModel", ["vars_updated"]), raw=True)
 ```

--- a/docs/source/virtual_ecosystem/implementation/abiotic_simple_implementation.md
+++ b/docs/source/virtual_ecosystem/implementation/abiotic_simple_implementation.md
@@ -5,11 +5,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.2
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # The abiotic simple model implementation
@@ -27,20 +37,18 @@ initialise and update the model. Please check also the
 
 ```{code-cell} ipython3
 ---
-tags: [remove-input]
 mystnb:
   markdown_format: myst
+tags: [remove-input]
 ---
-
 from IPython.display import display_markdown
 from var_generator import generate_variable_table
 
 display_markdown(
     generate_variable_table(
-        'AbioticSimpleModel', 
-        ['vars_required_for_init', 'vars_required_for_update']
-    ), 
-    raw=True
+        "AbioticSimpleModel", ["vars_required_for_init", "vars_required_for_update"]
+    ),
+    raw=True,
 )
 ```
 
@@ -120,17 +128,16 @@ variables. When the model first updates, it then sets further variables.
 
 ```{code-cell} ipython3
 ---
-tags: [remove-input]
 mystnb:
   markdown_format: myst
+tags: [remove-input]
 ---
-
 display_markdown(
     generate_variable_table(
-        'AbioticSimpleModel', 
-        ['vars_populated_by_init', 'vars_populated_by_first_update']
-    ), 
-    raw=True
+        "AbioticSimpleModel",
+        ["vars_populated_by_init", "vars_populated_by_first_update"],
+    ),
+    raw=True,
 )
 ```
 
@@ -141,16 +148,11 @@ step.
 
 ```{code-cell} ipython3
 ---
-tags: [remove-input]
 mystnb:
   markdown_format: myst
+tags: [remove-input]
 ---
-
 display_markdown(
-    generate_variable_table(
-        'AbioticSimpleModel', 
-        ['vars_updated']
-    ), 
-    raw=True
+    generate_variable_table("AbioticSimpleModel", ["vars_updated"]), raw=True
 )
 ```

--- a/docs/source/virtual_ecosystem/implementation/animal_implementation.md
+++ b/docs/source/virtual_ecosystem/implementation/animal_implementation.md
@@ -1,2 +1,15 @@
+---
+jupyter:
+  jupytext:
+    cell_metadata_filter: all,-trusted
+    main_language: python
+    notebook_metadata_filter: settings,mystnb,language_info
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.16.4
+---
+
 
 # The Animal Model implementation

--- a/docs/source/virtual_ecosystem/implementation/core_components_overview.md
+++ b/docs/source/virtual_ecosystem/implementation/core_components_overview.md
@@ -1,3 +1,27 @@
+---
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
 
 # Implementation of the core components
 

--- a/docs/source/virtual_ecosystem/implementation/hydrology_implementation.md
+++ b/docs/source/virtual_ecosystem/implementation/hydrology_implementation.md
@@ -5,11 +5,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.2
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # The hydrology model implementation
@@ -49,20 +59,18 @@ and then update it at each time step.
 
 ```{code-cell} ipython3
 ---
-tags: [remove-input]
 mystnb:
   markdown_format: myst
+tags: [remove-input]
 ---
-
 from IPython.display import display_markdown
 from var_generator import generate_variable_table
 
 display_markdown(
     generate_variable_table(
-        'HydrologyModel', 
-        ['vars_required_for_init', 'vars_required_for_update']
-    ), 
-    raw=True
+        "HydrologyModel", ["vars_required_for_init", "vars_required_for_update"]
+    ),
+    raw=True,
 )
 ```
 
@@ -299,7 +307,7 @@ from xarray import DataArray
 
 input_file = "../../../../virtual_ecosystem/example_data/data/example_elevation_data.nc"
 digital_elevation_model = xr.open_dataset(input_file)
-elevation = digital_elevation_model['elevation']
+elevation = digital_elevation_model["elevation"]
 ```
 
 ```{code-cell} ipython3
@@ -308,10 +316,10 @@ import matplotlib.pyplot as plt
 from matplotlib import colors
 
 plt.figure(figsize=(10, 6))
-elevation.plot(cmap='terrain')
-plt.title('Elevation, m')
-plt.xlabel('x')
-plt.ylabel('y')
+elevation.plot(cmap="terrain")
+plt.title("Elevation, m")
+plt.xlabel("x")
+plt.ylabel("y")
 plt.show()
 ```
 
@@ -320,9 +328,11 @@ plt.show()
 from virtual_ecosystem.core.grid import Grid
 from virtual_ecosystem.core.data import Data
 
-grid = Grid(grid_type="square", cell_area=8100, cell_nx=9, cell_ny=9, xoff=-45, yoff=-45)
+grid = Grid(
+    grid_type="square", cell_area=8100, cell_nx=9, cell_ny=9, xoff=-45, yoff=-45
+)
 data = Data(grid=grid)
-data['elevation'] = elevation
+data["elevation"] = elevation
 ```
 
 The initialisation step of the hydrology model finds all the neighbours for each grid
@@ -343,8 +353,8 @@ with the indices `[47, 56, 57, 65]`.
 from virtual_ecosystem.models.hydrology.above_ground import calculate_drainage_map
 
 drainage_map = calculate_drainage_map(
-  grid=grid,
-  elevation=np.array(data["elevation"]),
+    grid=grid,
+    elevation=np.array(data["elevation"]),
 )
 ```
 
@@ -354,22 +364,22 @@ runoff and the runoff from upstream cells at the previous time step.
 ```{code-cell} ipython3
 from virtual_ecosystem.models.hydrology.above_ground import accumulate_horizontal_flow
 
-previous_accumulated_runoff = DataArray(np.full(81, 10), dims='cell_id')
-surface_runoff = DataArray(np.full(81, 1), dims='cell_id')
+previous_accumulated_runoff = DataArray(np.full(81, 10), dims="cell_id")
+surface_runoff = DataArray(np.full(81, 1), dims="cell_id")
 
 accumulated_runoff = accumulate_horizontal_flow(
-  drainage_map=drainage_map,
-  current_flow=surface_runoff,
-  previous_accumulated_flow=previous_accumulated_runoff,
+    drainage_map=drainage_map,
+    current_flow=surface_runoff,
+    previous_accumulated_flow=previous_accumulated_runoff,
 )
 
 # Plot accumulated runoff map
-reshaped_data = DataArray(accumulated_runoff.to_numpy().reshape(9,9))
+reshaped_data = DataArray(accumulated_runoff.to_numpy().reshape(9, 9))
 plt.figure(figsize=(10, 6))
-reshaped_data.plot(cmap='Blues')
-plt.title('Accumulated runoff, mm')
-plt.xlabel('x')
-plt.ylabel('y')
+reshaped_data.plot(cmap="Blues")
+plt.title("Accumulated runoff, mm")
+plt.xlabel("x")
+plt.ylabel("y")
 plt.show()
 ```
 
@@ -392,17 +402,15 @@ variables. When the model first updates, it then sets further variables.
 
 ```{code-cell} ipython3
 ---
-tags: [remove-input]
 mystnb:
   markdown_format: myst
+tags: [remove-input]
 ---
-
 display_markdown(
     generate_variable_table(
-        'HydrologyModel', 
-        ['vars_populated_by_init', 'vars_populated_by_first_update']
-    ), 
-    raw=True
+        "HydrologyModel", ["vars_populated_by_init", "vars_populated_by_first_update"]
+    ),
+    raw=True,
 )
 ```
 
@@ -413,16 +421,9 @@ step.
 
 ```{code-cell} ipython3
 ---
-tags: [remove-input]
 mystnb:
   markdown_format: myst
+tags: [remove-input]
 ---
-
-display_markdown(
-    generate_variable_table(
-        'HydrologyModel', 
-        ['vars_updated']
-    ), 
-    raw=True
-)
+display_markdown(generate_variable_table("HydrologyModel", ["vars_updated"]), raw=True)
 ```

--- a/docs/source/virtual_ecosystem/implementation/implementation.md
+++ b/docs/source/virtual_ecosystem/implementation/implementation.md
@@ -1,17 +1,26 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: pandoc
-      format_version: 3.2
-      jupytext_version: 1.16.2
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
-  nbformat: 4
-  nbformat_minor: 5
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # The implementation of the Virtual Ecosystem
@@ -20,27 +29,27 @@ The main workflow of the Virtual Ecosystem ({numref}`fig_simulation_flow`) has t
 following steps:
 
 - Users provide a set of **configuration files** that define how a particular simulation
-  should run.
+    should run.
 - That configuration is validated and compiled into **configuration object** that is
-  shared across the rest of the simulation.
+    shared across the rest of the simulation.
 - The configuration is then used to create several **core components**: the spatial
-  grid, the core constants, the vertical layer structure and the model timing. These
-  components are also shared across the simulation.
+    grid, the core constants, the vertical layer structure and the model timing. These
+    components are also shared across the simulation.
 - The configuration also sets the locations of the **initial input data**. These
-  variables are then loaded into the core **data store**, with validation to check that
-  the data are compatible with the model configuration.
+    variables are then loaded into the core **data store**, with validation to check that
+    the data are compatible with the model configuration.
 - The configuration also defines a set of **science models** that should be used in the
-  simulation. These are now configured, checking that any configurations settings
-  specific to each science model are valid.
+    simulation. These are now configured, checking that any configurations settings
+    specific to each science model are valid.
 - The configured models are then **initialised**, checking that the data store contains
-  all required initial data for the model and carrying out any calculations for the
-  initial model state.
+    all required initial data for the model and carrying out any calculations for the
+    initial model state.
 - The system now iterates forward over the configured time steps. At each time step,
-  there is an **update** step for each science model. The model execution order is
-  defined by the set of variables required for each model, to ensure that all required
-  variables are updated before being used.
+    there is an **update** step for each science model. The model execution order is
+    defined by the set of variables required for each model, to ensure that all required
+    variables are updated before being used.
 
-:::{figure} ../../_static/images/simulation_flow.svg
+:::{figure} ../../\_static/images/simulation_flow.svg
 :name: fig_simulation_flow
 :alt: Simulation workflow
 :width: 650px
@@ -85,7 +94,7 @@ arrays (e.g. space and time), and the NetCDF format supports this kind of data,
 as providing critical metadata for data validation.
 
 <!-- TODO: fix this link to the variables.rst file
- when the variables system gets merged -->
+when the variables system gets merged -->
 
 The Virtual Ecosystem has a long list of the
 [variables](../../../../virtual_ecosystem/data_variables.toml) that are used to set up
@@ -113,3 +122,4 @@ The current suite of science models are:
 
 New models [can be added](../../development/design/defining_new_models.md) to the
 Virtual Ecosystem, although this requires reasonable programming expertise.
+:::

--- a/docs/source/virtual_ecosystem/implementation/litter_implementation.md
+++ b/docs/source/virtual_ecosystem/implementation/litter_implementation.md
@@ -1,1 +1,26 @@
+---
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
 # The Litter Model implementation

--- a/docs/source/virtual_ecosystem/implementation/main_simulation.md
+++ b/docs/source/virtual_ecosystem/implementation/main_simulation.md
@@ -1,3 +1,28 @@
+---
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
 # Virtual Ecosystem simulation flow
 
 :::{warning}

--- a/docs/source/virtual_ecosystem/implementation/plants_implementation.md
+++ b/docs/source/virtual_ecosystem/implementation/plants_implementation.md
@@ -5,11 +5,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.2
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # The Plants Model implementation
@@ -19,22 +29,20 @@ kernelspec:
 The tables below show the variables that are required to initialise the plants model and
 then update it at each time step.
 
-```{code-cell}
+```{code-cell} ipython3
 ---
-tags: [remove-input]
 mystnb:
   markdown_format: myst
+tags: [remove-input]
 ---
-
 from IPython.display import display_markdown
 from var_generator import generate_variable_table
 
 display_markdown(
     generate_variable_table(
-        'PlantsModel', 
-        ['vars_required_for_init', 'vars_required_for_update']
-    ), 
-    raw=True
+        "PlantsModel", ["vars_required_for_init", "vars_required_for_update"]
+    ),
+    raw=True,
 )
 ```
 
@@ -89,19 +97,17 @@ Mortality and reproduction have not yet been implemented.
 The calculations described above result in the following variables being calculated and
 saved within the model data store, and then updated
 
-```{code-cell}
+```{code-cell} ipython3
 ---
-tags: [remove-input]
 mystnb:
   markdown_format: myst
+tags: [remove-input]
 ---
-
 display_markdown(
     generate_variable_table(
-        'PlantsModel', 
-        ['vars_populated_by_init', 'vars_populated_by_first_update']
-    ), 
-    raw=True
+        "PlantsModel", ["vars_populated_by_init", "vars_populated_by_first_update"]
+    ),
+    raw=True,
 )
 ```
 
@@ -110,18 +116,11 @@ display_markdown(
 The table below shows the complete set of model variables that are updated at each model
 step.
 
-```{code-cell}
+```{code-cell} ipython3
 ---
-tags: [remove-input]
 mystnb:
   markdown_format: myst
+tags: [remove-input]
 ---
-
-display_markdown(
-    generate_variable_table(
-        'PlantsModel', 
-        ['vars_updated']
-    ), 
-    raw=True
-)
+display_markdown(generate_variable_table("PlantsModel", ["vars_updated"]), raw=True)
 ```

--- a/docs/source/virtual_ecosystem/implementation/science_model_overview.md
+++ b/docs/source/virtual_ecosystem/implementation/science_model_overview.md
@@ -1,3 +1,28 @@
+---
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
 # The Virtual Ecosystem science models
 
 This page provides an overview of the implementations of each science model. These

--- a/docs/source/virtual_ecosystem/implementation/soil_implementation.md
+++ b/docs/source/virtual_ecosystem/implementation/soil_implementation.md
@@ -1,2 +1,26 @@
+---
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
 
 # The Soil Model implementation

--- a/docs/source/virtual_ecosystem/implementation/var_generator.py
+++ b/docs/source/virtual_ecosystem/implementation/var_generator.py
@@ -1,11 +1,25 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: all,-trusted
+#     notebook_metadata_filter: settings,mystnb,language_info
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.16.4
+# ---
+
 """Utility functions to generate model variable listings."""
 
 from dataclasses import fields
 
 from virtual_ecosystem.core import variables
 
+# + [markdown]
 # TODO - merge these into a single generate_model_variable_markdown and probably move it
 #        inside the variables submodule.
+# -
 
 
 def generate_variable_listing(model_name: str, var_attributes: list[str]) -> str:

--- a/docs/source/virtual_ecosystem/implementation/variables.md
+++ b/docs/source/virtual_ecosystem/implementation/variables.md
@@ -5,11 +5,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.2
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # Virtual Ecosystem variables
@@ -28,19 +38,19 @@ documentation](../../api/core/variables.md) section.
 
 ```{code-cell} ipython3
 ---
-tags: [remove-input]
 mystnb:
   markdown_format: myst
+tags: [remove-input]
 ---
 from IPython.display import display_markdown
 from var_generator import generate_all_variable_markdown
 
 display_markdown(
     generate_all_variable_markdown(
-        fields_to_display= ["name", "description", "unit", "axis"],
-        widths = [30, 40, 15, 15],
-    ), 
-    raw=True
+        fields_to_display=["name", "description", "unit", "axis"],
+        widths=[30, 40, 15, 15],
+    ),
+    raw=True,
 )
 ```
 

--- a/docs/source/virtual_ecosystem/theory/abiotic_theory.md
+++ b/docs/source/virtual_ecosystem/theory/abiotic_theory.md
@@ -1,3 +1,28 @@
+---
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
 # The abiotic environment
 
 The abiotic component of the Virtual Ecosystem focuses on non-living environmental

--- a/docs/source/virtual_ecosystem/theory/animal_theory.md
+++ b/docs/source/virtual_ecosystem/theory/animal_theory.md
@@ -1,1 +1,26 @@
+---
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
 # Theory of the animals

--- a/docs/source/virtual_ecosystem/theory/hydrology_theory.md
+++ b/docs/source/virtual_ecosystem/theory/hydrology_theory.md
@@ -1,3 +1,28 @@
+---
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
 # Hydrology
 
 This page provides an overview of the [key factors](#factors-affecting-hydrology)
@@ -126,7 +151,7 @@ loss.
 Infiltration rates depend on soil type, soil moisture, land cover, and land management
 practices. Enhanced infiltration reduces surface runoff and recharges groundwater.
 * **Bypass flow**: Some of the water that infiltarted into the soil bypasses the soil
-matrix and drains directly to the groundwater, for example through soil pipes.  
+matrix and drains directly to the groundwater, for example through soil pipes.
 * **Groundwater flow**: Water that infiltrates the soil can percolate down to recharge
 groundwater aquifers. Groundwater flow contributes to maintaining base flow in rivers
 and streams during dry periods. The rate of groundwater flow is determined by the

--- a/docs/source/virtual_ecosystem/theory/microclimate_theory.md
+++ b/docs/source/virtual_ecosystem/theory/microclimate_theory.md
@@ -1,3 +1,28 @@
+---
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
 # Microclimate
 
 This page provides an overview of the [key factors](#factors-affecting-microclimate)

--- a/docs/source/virtual_ecosystem/theory/plant_theory.md
+++ b/docs/source/virtual_ecosystem/theory/plant_theory.md
@@ -1,1 +1,26 @@
+---
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
 # Theory of the plants

--- a/docs/source/virtual_ecosystem/theory/soil_theory.md
+++ b/docs/source/virtual_ecosystem/theory/soil_theory.md
@@ -1,3 +1,28 @@
+---
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
 # Theory of the soil and litter
 
 This page provides an overview of the theory underlying the soil module.

--- a/docs/source/virtual_ecosystem/theory/theory.md
+++ b/docs/source/virtual_ecosystem/theory/theory.md
@@ -1,3 +1,28 @@
+---
+jupytext:
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
 # The theory of the Virtual Ecosystem
 
 Ecosystems are complex systems that arise from the interplay between

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,4 +133,6 @@ plugins = "numpy.typing.mypy_plugin"
 
 [tool.jupytext]
 # Stop jupytext from removing mystnb and other settings in MyST Notebook YAML headers
-notebook_metadata_filter = "-jupytext.text_representation.jupytext_version,settings,mystnb"
+notebook_metadata_filter = "settings,mystnb,language_info"
+# Also stop it from stripping cell metadata.
+cell_metadata_filter = "all,-trusted"


### PR DESCRIPTION
# Description

This PR:

* Adds `jupytext --pipe black` as a `pre-commit` step for the markdown files in `docs/source`, which auto-formats any Python in `{code-cell}` directives.
* Updates markdown files to set the notebook language where needed and add Python3 to code cells.
* Updates the metadata retained in markdown files (pyproject.toml: `[tool.jupytext]`)

This is a little finicky and the implementation is being looked at:
https://github.com/mwouts/jupytext/issues/1267

It is possible that we might be able to use `ruff` here but at present only the `.ipynb` format for notebooks is supported by `ruff-format`.

https://github.com/astral-sh/ruff/issues/8800#issuecomment-2232647927


Fixes #154

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
