### PR TITLE
Update poetry version ready for 0.1.1 alpha release 7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ license = "BSD-3-Clause"
 name = "virtual_ecosystem"
 readme = "README.md"
 repository = "https://github.com/ImperialCollegeLondon/virtual_ecosystem"
-version = "0.1.1a6"
+version = "0.1.1a7"
 
 [tool.poetry.scripts]
 ve_run = "virtual_ecosystem.entry_points:ve_run_cli"


### PR DESCRIPTION
# Description

This PR bumps the poetry version so that it can be used to generate the next pre-release version (0.1.1 alpha release 7)

Once this is merged we can go through the process of releasing the new version
