### PR TITLE
681 setup skipped improperly

### DIFF
--- a/tests/core/test_base_model.py
+++ b/tests/core/test_base_model.py
@@ -575,7 +575,7 @@ def test_check_update_speed(
             True,
             ("var1", "var2"),
             {},
-            True,
+            False,
             does_not_raise(),
             None,
             id="static_no_vars_present",

--- a/virtual_ecosystem/core/base_model.py
+++ b/virtual_ecosystem/core/base_model.py
@@ -292,7 +292,11 @@ class BaseModel(ABC):
                     f"all to be absent. {found} out of {expected} found: "
                     f"{', '.join(present)}."
                 )
+            elif found == 0:
+                # The case when static is true and no init vars provided
+                return False
             else:
+                # The case when static is true and all init vars provideed
                 return True
 
         return False


### PR DESCRIPTION
# Description

Fixed the bug where `_setup` skipped in static model when none of the init vars are provided. 

Fixes #681 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
