### PR TITLE
Adds the spin-up step

### DIFF
--- a/virtual_ecosystem/core/module_schema.json
+++ b/virtual_ecosystem/core/module_schema.json
@@ -257,6 +257,7 @@
                      },
                      "variables": {
                         "type": "array",
+                        "description": "Variables to be carried over to the next step.",
                         "items": {
                            "type": "string"
                         }

--- a/virtual_ecosystem/core/module_schema.json
+++ b/virtual_ecosystem/core/module_schema.json
@@ -250,15 +250,22 @@
                      },
                      "timing": {
                         "type": "object",
-                        "description": "Timing options for this spin_up step",
+                        "description": "Timing options for this spin-up step",
                         "allOf": [
                           { "$ref": "#/properties/core/properties/timing" }
                         ]
+                     },
+                     "variables": {
+                        "type": "array",
+                        "items": {
+                           "type": "string"
+                        }
                      }
                   },
                   "required": [
                      "models",
-                     "timing"
+                     "timing",
+                     "variables"
                   ]
                },
                "default": []

--- a/virtual_ecosystem/core/module_schema.json
+++ b/virtual_ecosystem/core/module_schema.json
@@ -233,6 +233,35 @@
                   "surface_layer_height",
                   "subcanopy_layer_height"
                ]
+            },
+            "spin_up": {
+               "description": "A sequence of spin-up steps to run before the normal run.",
+               "type": "array",
+               "items": {
+                  "type": "object",
+                  "properties": {
+                     "models": {
+                        "description": "List of models to spin-up together in this step.",
+                        "type": "array",
+                        "items":{
+                           "type": "string"
+                        }
+                        
+                     },
+                     "timing": {
+                        "type": "object",
+                        "description": "Timing options for this spin_up step",
+                        "allOf": [
+                          { "$ref": "#/properties/core/properties/timing" }
+                        ]
+                     }
+                  },
+                  "required": [
+                     "models",
+                     "timing"
+                  ]
+               },
+               "default": []
             }
          },
          "default": {},

--- a/virtual_ecosystem/core/variables.py
+++ b/virtual_ecosystem/core/variables.py
@@ -478,6 +478,15 @@ def get_variable(name: str) -> Variable:
         raise KeyError(f"Variable '{name}' is not a known variable.")
 
 
+def clear_run_variables() -> None:
+    """Clear the RUN_VARIABLES_REGISTRY, in preparation for another run.
+
+    Typically, this will be used between steps of a spin up process, so each new run
+    starts fresh.
+    """
+    RUN_VARIABLES_REGISTRY.clear()
+
+
 def get_model_order(stage: str) -> list[str]:
     """Get the order of running the models during init or update.
 

--- a/virtual_ecosystem/main.py
+++ b/virtual_ecosystem/main.py
@@ -314,13 +314,28 @@ def _spin_up_run(config: Config, progress: bool) -> None:
 def extract_spin_up_data(config: Config, step: int) -> None:
     """Extract the relevant data from the previous step and updates the config.
 
-    This function extracts the variables indicated in the configuration for the chosen
-    step, picks the last time entry for each of them from the output continous file
-    and puts them into a new file, saving it in that step subfolder. Then, it updates
-    the 'core.data.variable' configuration to use those variables instead of the ones
-    configured.
+    Updates the 'core.data.variable' configuration to use the variables indicated in the
+    step configuration but contained in the final state output file from the step.
 
     Args:
         config: A fully formed and validated Config object.
         step: The index of the step to extract the variables from.
     """
+    root_path = config["core"]["data_output_options"]["out_path"].split("\\spin_up")[0]
+    new_source = (
+        root_path
+        + f"\\spin_up\\{step + 1}\\"
+        + config["core"]["data_output_options"]["out_final_file_name"]
+    )
+
+    variables = copy.deepcopy(config["core"]["spin_up"][step]["variables"])
+    for i, var_data in enumerate(config["core"]["data"]["variable"]):
+        if var_data["var_name"] in variables:
+            config["core"]["data"]["variable"][i]["file"] = new_source
+            variables.remove(var_data["var_name"])
+
+    if variables:
+        ConfigurationError(
+            "Some variables from a spin up step expected to be used are not. These "
+            f"are: {variables}"
+        )

--- a/virtual_ecosystem/main.py
+++ b/virtual_ecosystem/main.py
@@ -3,6 +3,7 @@ simulation of the model, along with helper functions to validate and configure t
 model.
 """  # noqa: D205
 
+import copy
 import os
 from collections.abc import Sequence
 from itertools import chain
@@ -124,6 +125,9 @@ def _simple_run(config: Config, progress: bool) -> None:
         progress: A logical switch to turn on simple progress reporting, mostly for
             visual confirmation of progress when the log is not printed to the console.
     """
+    # Create output folder if it does not exist
+    out_path = Path(config["core"]["data_output_options"]["out_path"])
+    os.makedirs(out_path, exist_ok=True)
 
     # Save the merged config if requested
     data_opt = config["core"]["data_output_options"]
@@ -172,10 +176,6 @@ def _simple_run(config: Config, progress: bool) -> None:
     LOGGER.info("All models successfully intialised.")
 
     # TODO - A model spin up might be needed here in future
-
-    # Create output folder if it does not exist
-    out_path = Path(config["core"]["data_output_options"]["out_path"])
-    os.makedirs(out_path, exist_ok=True)
 
     # Save the initial state of the model
     if config["core"]["data_output_options"]["save_initial_state"]:
@@ -276,3 +276,51 @@ def _spin_up_run(config: Config, progress: bool) -> None:
             "Some models in a spin-up step have not been included in the simulation! "
             f"The valid models are: {', '.join(requested_models)}"
         )
+
+    for i, step in enumerate(steps):
+        LOGGER.info(f"Starting spin-up step {i + 1}...")
+
+        cfg = copy.deepcopy(config)
+
+        # Replace the core timing of the simulation
+        cfg["core"]["timing"] = step["timing"]
+
+        # Set all the models not to spin up as static
+        for model in set(requested_models).difference(step["models"]):
+            cfg[model]["static"] = True
+
+        # Put all the spin-up data in a dedicated location
+        cfg["core"]["data_output_options"]["out_path"] = (
+            cfg["core"]["data_output_options"]["out_path"] + f"\\spin_up\\{i + 1}"
+        )
+
+        # Update data sources with those from previous run
+        if i > 0:
+            extract_spin_up_data(cfg, i - 1)
+
+        # Finally, run the simulation for the spin-up step
+        _simple_run(cfg, progress)
+
+        # Reset relevant global variables in preparation for the next steps
+        variables.clear_run_variables()
+
+        LOGGER.info(f"Spin-up step {i + 1} done!")
+
+    # After the spin up, run the actual simulation
+    extract_spin_up_data(config, i)
+    _simple_run(config, progress)
+
+
+def extract_spin_up_data(config: Config, step: int) -> None:
+    """Extract the relevant data from the previous step and updates the config.
+
+    This function extracts the variables indicated in the configuration for the chosen
+    step, picks the last time entry for each of them from the output continous file
+    and puts them into a new file, saving it in that step subfolder. Then, it updates
+    the 'core.data.variable' configuration to use those variables instead of the ones
+    configured.
+
+    Args:
+        config: A fully formed and validated Config object.
+        step: The index of the step to extract the variables from.
+    """

--- a/virtual_ecosystem/main.py
+++ b/virtual_ecosystem/main.py
@@ -102,6 +102,26 @@ def ve_run(
         cfg_paths=cfg_paths, cfg_strings=cfg_strings, override_params=override_params
     )
 
+    # Run the simulation
+    _simple_run(config, progress)
+
+    # Restore default logging settings
+    if logfile is not None:
+        remove_file_logger()
+
+    if progress:
+        print("Virtual Ecosystem run complete.")
+
+
+def _simple_run(config: Config, progress: bool) -> None:
+    """Runs a VE simulation out of a Config object.
+
+    Args:
+        config: A fully formed and validated Config object.
+        progress: A logical switch to turn on simple progress reporting, mostly for
+            visual confirmation of progress when the log is not printed to the console.
+    """
+
     # Save the merged config if requested
     data_opt = config["core"]["data_output_options"]
     if data_opt["save_merged_config"]:
@@ -231,10 +251,3 @@ def ve_run(
             print("* Saved final model state")
 
     LOGGER.info("Virtual Ecosystem model run completed!")
-
-    # Restore default logging settings
-    if logfile is not None:
-        remove_file_logger()
-
-    if progress:
-        print("Virtual Ecosystem run complete.")

--- a/virtual_ecosystem/main.py
+++ b/virtual_ecosystem/main.py
@@ -296,7 +296,7 @@ def _spin_up_run(config: Config, progress: bool) -> None:
 
         # Update data sources with those from previous run
         if i > 0:
-            extract_spin_up_data(cfg, i - 1)
+            update_data_sources(cfg, i - 1)
 
         # Finally, run the simulation for the spin-up step
         _simple_run(cfg, progress)
@@ -307,20 +307,23 @@ def _spin_up_run(config: Config, progress: bool) -> None:
         LOGGER.info(f"Spin-up step {i + 1} done!")
 
     # After the spin up, run the actual simulation
-    extract_spin_up_data(config, i)
+    update_data_sources(config, i)
     _simple_run(config, progress)
 
 
-def extract_spin_up_data(config: Config, step: int) -> None:
-    """Extract the relevant data from the previous step and updates the config.
+def update_data_sources(config: Config, step: int) -> None:
+    """Update the data sources of the current step based in the previous one outputs.
 
     Updates the 'core.data.variable' configuration to use the variables indicated in the
-    step configuration but contained in the final state output file from the step.
+    step configuration contained in final state output file from the step.
 
     Args:
         config: A fully formed and validated Config object.
         step: The index of the step to extract the variables from.
     """
+    import xarray as xr
+
+    # Get the path for tne new source for the data
     root_path = config["core"]["data_output_options"]["out_path"].split("\\spin_up")[0]
     new_source = (
         root_path
@@ -328,14 +331,18 @@ def extract_spin_up_data(config: Config, step: int) -> None:
         + config["core"]["data_output_options"]["out_final_file_name"]
     )
 
+    # Check if the requested variables exist in the new source
     variables = copy.deepcopy(config["core"]["spin_up"][step]["variables"])
+    source_data = xr.open_dataset(new_source)
+    if not all(var in source_data.data_vars for var in variables):
+        raise ConfigurationError(f"Variables {variables} not found in {new_source}.")
+
+    # Update the existing data sources in the configuration
     for i, var_data in enumerate(config["core"]["data"]["variable"]):
         if var_data["var_name"] in variables:
             config["core"]["data"]["variable"][i]["file"] = new_source
             variables.remove(var_data["var_name"])
 
-    if variables:
-        ConfigurationError(
-            "Some variables from a spin up step expected to be used are not. These "
-            f"are: {variables}"
-        )
+    # Adds new variables to the configuration
+    for var in variables:
+        config["core"]["data"]["variable"].append({"file": new_source, "var_name": var})

--- a/virtual_ecosystem/main.py
+++ b/virtual_ecosystem/main.py
@@ -103,7 +103,10 @@ def ve_run(
     )
 
     # Run the simulation
-    _simple_run(config, progress)
+    if config["core"]["spin_up"]:
+        _spin_up_run(config, progress)
+    else:
+        _simple_run(config, progress)
 
     # Restore default logging settings
     if logfile is not None:
@@ -251,3 +254,14 @@ def _simple_run(config: Config, progress: bool) -> None:
             print("* Saved final model state")
 
     LOGGER.info("Virtual Ecosystem model run completed!")
+
+
+def _spin_up_run(config: Config, progress: bool) -> None:
+    """Runs a VE simulation including spin-up steps.
+
+    Args:
+        config: A fully formed and validated Config object.
+        progress: A logical switch to turn on simple progress reporting, mostly for
+            visual confirmation of progress when the log is not printed to the console.
+    """
+    LOGGER.info("Running a spin-up simulation.")

--- a/virtual_ecosystem/main.py
+++ b/virtual_ecosystem/main.py
@@ -265,3 +265,14 @@ def _spin_up_run(config: Config, progress: bool) -> None:
             visual confirmation of progress when the log is not printed to the console.
     """
     LOGGER.info("Running a spin-up simulation.")
+
+    steps = config["core"]["spin_up"]
+
+    # Check that the models to spin-up actually have been included in the simulation
+    requested_models: list[str] = list(config.keys())
+    requested_models.remove("core")
+    if not all(set(step["models"]).issubset(requested_models) for step in steps):
+        raise ConfigurationError(
+            "Some models in a spin-up step have not been included in the simulation! "
+            f"The valid models are: {', '.join(requested_models)}"
+        )


### PR DESCRIPTION
# Description

Adds the possibility to run spin-up steps before the actual simulation. 

Details of PR TBC

Fixes #581 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
