### PR TITLE
704 the plantsmodel is pretending to calculate evapotranspiration

### DIFF
--- a/docs/source/virtual_ecosystem/implementation/hydrology_implementation.md
+++ b/docs/source/virtual_ecosystem/implementation/hydrology_implementation.md
@@ -48,7 +48,7 @@ enters and leaves the plant model.
 ```{note}
 Many of the underlying processes are problematic at a monthly timestep, which is
 currently the only supported update interval. As a short-term work around, the input
-precipitation is randomly distributed over 30 days and input evapotranspiration is
+precipitation is randomly distributed over 30 days and input canopy transpiration is
 divided by 30, and the return variables are monthly means or monthly accumulated values.
 ```
 
@@ -273,7 +273,7 @@ model and this can only be treated as a very rough approximation!
 
 Soil moisture is updated for each layer by removing the vertical flow
 of the current layer and adding it to the layer below. The implementation is based
-on {cite:t}`van_der_knijff_lisflood_2010`. Additionally, the evapotranspiration is
+on {cite:t}`van_der_knijff_lisflood_2010`. Additionally, the canopy transpiration is
 removed from the second soil layer.
 
 ### Subsurface flow and groundwater storage

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -733,6 +733,9 @@ def dummy_climate_data(fixture_core_components):
     data["canopy_temperature"] = from_template()
     data["canopy_temperature"][lyr_str.index_filled_canopy] = 25.0
 
+    data["canopy_evaporation"] = from_template()
+    data["canopy_evaporation"][lyr_str.index_filled_canopy] = 10.0
+
     data["leaf_air_heat_conductivity"] = from_template()
     data["leaf_air_heat_conductivity"][lyr_str.index_filled_canopy] = 0.13
 
@@ -858,6 +861,12 @@ def dummy_climate_data_varying_canopy(fixture_core_components, dummy_climate_dat
         [25.0, 25.0, 25.0, 25.0],
         [25.0, 25.0, np.nan, np.nan],
         [25.0, np.nan, np.nan, np.nan],
+    ]
+
+    dummy_climate_data["canopy_evaporation"][index_filled_canopy] = [
+        [10.0, 10.0, 10.0, 10.0],
+        [10.0, 10.0, np.nan, np.nan],
+        [10.0, np.nan, np.nan, np.nan],
     ]
 
     dummy_climate_data["leaf_air_heat_conductivity"][index_filled_canopy] = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -748,8 +748,8 @@ def dummy_climate_data(fixture_core_components):
     data["stomatal_conductance"][lyr_str.index_filled_canopy] = 15.0
 
     # Hydrology
-    data["evapotranspiration"] = from_template()
-    data["evapotranspiration"][lyr_str.index_filled_canopy] = 20.0
+    data["transpiration"] = from_template()
+    data["transpiration"][lyr_str.index_filled_canopy] = 20.0
 
     data["soil_moisture"] = from_template()
     data["soil_moisture"][lyr_str.index_all_soil] = np.array([5.0, 500.0])[:, None]
@@ -885,7 +885,7 @@ def dummy_climate_data_varying_canopy(fixture_core_components, dummy_climate_dat
     ]
 
     # Hydrology
-    dummy_climate_data["evapotranspiration"][index_filled_canopy] = [
+    dummy_climate_data["transpiration"][index_filled_canopy] = [
         [20.0, 20.0, 20.0, 20.0],
         [20.0, 20.0, np.nan, np.nan],
         [20.0, np.nan, np.nan, np.nan],

--- a/tests/models/hydrology/test_below_ground.py
+++ b/tests/models/hydrology/test_below_ground.py
@@ -69,20 +69,17 @@ def test_update_soil_moisture():
 
     from virtual_ecosystem.models.hydrology.below_ground import update_soil_moisture
 
-    soil_moisture = np.array([[30, 60, 50], [300, 600, 500], [300, 600, 500]])
-    vertical_flow = np.array([[10, 2, 3], [10, 2, 3], [15, 25, 35]])
-    evapotranspiration = np.array([10, 2, 3])
     layer_thickness = np.array([[100, 100, 100], [900, 900, 900], [900, 900, 900]])
     exp_result = np.array(
         [[20.0, 50.0, 47.0], [290.0, 450.0, 450.0], [300.0, 450.0, 450.0]]
     )
 
     result = update_soil_moisture(
-        soil_moisture,
-        vertical_flow,
-        evapotranspiration,
-        CoreConsts.soil_moisture_capacity * layer_thickness,
-        HydroConsts.soil_moisture_residual * layer_thickness,
+        soil_moisture=np.array([[30, 60, 50], [300, 600, 500], [300, 600, 500]]),
+        vertical_flow=np.array([[10, 2, 3], [10, 2, 3], [15, 25, 35]]),
+        transpiration=np.array([10, 2, 3]),
+        soil_moisture_capacity=CoreConsts.soil_moisture_capacity * layer_thickness,
+        soil_moisture_residual=HydroConsts.soil_moisture_residual * layer_thickness,
     )
 
     np.testing.assert_allclose(result, exp_result, rtol=0.001)

--- a/tests/models/hydrology/test_hydrology_tools.py
+++ b/tests/models/hydrology/test_hydrology_tools.py
@@ -70,7 +70,7 @@ def test_setup_hydrology_input_current_timestep(
         "surface_pressure",
         "surface_wind_speed",
         "leaf_area_index_sum",
-        "current_evapotranspiration",
+        "current_transpiration",
         "top_soil_moisture_capacity",
         "top_soil_moisture_residual",
         "previous_accumulated_runoff",

--- a/tests/models/plants/test_plants_model.py
+++ b/tests/models/plants/test_plants_model.py
@@ -223,9 +223,9 @@ def test_PlantsModel_estimate_gpp(fxt_plants_model):
         cid: len(vals) for cid, vals in fxt_plants_model.per_stem_transpiration.items()
     }
 
-    # Check the evapotranspiration shape
+    # Check the transpiration shape
 
-    assert fxt_plants_model.data["evapotranspiration"].shape == (
+    assert fxt_plants_model.data["transpiration"].shape == (
         fxt_plants_model.layer_structure.n_layers,
         fxt_plants_model.grid.n_cells,
     )

--- a/virtual_ecosystem/data_variables.toml
+++ b/virtual_ecosystem/data_variables.toml
@@ -154,8 +154,15 @@ variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
-description = "Evapotranspiration"
-name = "evapotranspiration"
+description = "Evaporation"
+name = "evaporation"
+unit = "mm"
+variable_type = "float"
+
+[[variable]]
+axis = ["spatial"]
+description = "Transpiration"
+name = "Transpiration"
 unit = "mm"
 variable_type = "float"
 

--- a/virtual_ecosystem/data_variables.toml
+++ b/virtual_ecosystem/data_variables.toml
@@ -154,15 +154,8 @@ variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
-description = "Evaporation"
-name = "evaporation"
-unit = "mm"
-variable_type = "float"
-
-[[variable]]
-axis = ["spatial"]
-description = "Transpiration"
-name = "Transpiration"
+description = "Transpiration from canopy"
+name = "transpiration"
 unit = "mm"
 variable_type = "float"
 

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -269,13 +269,10 @@ def run_microclimate(
         # The current implementation converts outputs from plant and hydrology model to
         # ensure energy conservation between modules for now.
         # TODO cross-check with plant model, time step currently month to second
-        # TODO also there is a split between evaporation and transpiration, needs to be
-        # fixed in #493 - hydrology and evaporation
-        # also canopy_evaporation is 2D, check that this matches
-        # evapotranspiration = data['canopy_evaporation'] + data['transpiration']
+
+        evapotranspiration = data["canopy_evaporation"] + data["transpiration"]
         latent_heat_flux_canopy = (
-            data["evapotranspiration"][layer_structure.index_filled_canopy].to_numpy()
-            / 2.628e6
+            evapotranspiration[layer_structure.index_filled_canopy].to_numpy() / 2.628e6
         ) * latent_heat_vapourisation[1:-1]
 
         # Latent heat flux topsoil, [W m-2]
@@ -357,7 +354,7 @@ def run_microclimate(
 
         # TODO dimensions -  Update atmospheric humidity/VPD
         new_atmospheric_humidity_vars = energy_balance.update_humidity_vpd(
-            evapotranspiration=data["evapotranspiration"][
+            evapotranspiration=evapotranspiration[
                 layer_structure.index_filled_canopy
             ].to_numpy(),
             soil_evaporation=data["soil_evaporation"].to_numpy(),

--- a/virtual_ecosystem/models/hydrology/below_ground.py
+++ b/virtual_ecosystem/models/hydrology/below_ground.py
@@ -149,7 +149,7 @@ def calculate_vertical_flow(
 def update_soil_moisture(
     soil_moisture: NDArray[np.float32],
     vertical_flow: NDArray[np.float32],
-    evapotranspiration: NDArray[np.float32],
+    transpiration: NDArray[np.float32],
     soil_moisture_capacity: NDArray[np.float32],
     soil_moisture_residual: NDArray[np.float32],
 ) -> NDArray[np.float32]:
@@ -157,13 +157,13 @@ def update_soil_moisture(
 
     This function calculates soil moisture for each layer by removing the vertical flow
     of the current layer and adding it to the layer below. The implementation is based
-    on :cite:t:`van_der_knijff_lisflood_2010`. Additionally, the evapotranspiration is
+    on :cite:t:`van_der_knijff_lisflood_2010`. Additionally, the canopy transpiration is
     removed from the second soil layer.
 
     Args:
         soil_moisture: Soil moisture after infiltration and surface evaporation, [mm]
         vertical_flow: Vertical flow between all layers, [mm]
-        evapotranspiration: Canopy evaporation, [mm]
+        transpiration: Canopy transpiration, [mm]
         soil_moisture_capacity: Soil moisture capacity for each layer, [mm]
         soil_moisture_residual: Residual soil moisture for each layer, [mm]
 
@@ -179,9 +179,9 @@ def update_soil_moisture(
     )
 
     # Add topsoil vertical flow to layer below and remove that layers flow as well as
-    # evapotranspiration = root water uptake, and ensure it is within capacity
+    # canopy transpiration = root water uptake, and ensure it is within capacity
     root_soil_moisture = np.clip(
-        soil_moisture[1] + vertical_flow[0] - vertical_flow[1] - evapotranspiration,
+        soil_moisture[1] + vertical_flow[0] - vertical_flow[1] - transpiration,
         soil_moisture_residual[1],
         soil_moisture_capacity[1],
     )

--- a/virtual_ecosystem/models/hydrology/hydrology_model.py
+++ b/virtual_ecosystem/models/hydrology/hydrology_model.py
@@ -350,8 +350,8 @@ class HydrologyModel(
 
         Many of the underlying processes are problematic at a monthly timestep, which is
         currently the only supported update interval. As a short-term work around, the
-        input precipitation is randomly distributed over 30 days and input soil
-        evaporation and canopy transpiration is divided by 30, and the return variables
+        input precipitation is randomly distributed over 30 days and input canopy
+        transpiration is divided by 30, and the return variables
         are monthly means or monthly accumulated values.
 
         Precipitation that reaches the surface is defined as incoming precipitation

--- a/virtual_ecosystem/models/hydrology/hydrology_model.py
+++ b/virtual_ecosystem/models/hydrology/hydrology_model.py
@@ -23,7 +23,6 @@ There are still a number of open TODOs related to process implementation and imp
 .. TODO:: units and module coordination
 
     * change temperature to Kelvin
-    * plants need to return transpiration only
 
 """  # noqa: D205
 
@@ -90,7 +89,7 @@ class HydrologyModel(
         "leaf_area_index",
         "layer_heights",
         "soil_moisture",
-        "evapotranspiration",  # TODO this needs to be transpiration
+        "transpiration",
         "surface_runoff_accumulated",
         "subsurface_flow_accumulated",
         "density_air",
@@ -351,9 +350,9 @@ class HydrologyModel(
 
         Many of the underlying processes are problematic at a monthly timestep, which is
         currently the only supported update interval. As a short-term work around, the
-        input precipitation is randomly distributed over 30 days and input
-        evapotranspiration is divided by 30, and the return variables are monthly means
-        or monthly accumulated values.
+        input precipitation is randomly distributed over 30 days and input soil
+        evaporation and canopy transpiration is divided by 30, and the return variables
+        are monthly means or monthly accumulated values.
 
         Precipitation that reaches the surface is defined as incoming precipitation
         minus canopy interception, which is estimated using a stroage-based approach,
@@ -411,7 +410,7 @@ class HydrologyModel(
         * leaf area index, [m m-1]
         * layer heights, [m]
         * Soil moisture (previous time step), [mm]
-        * evapotranspiration (current time step), [mm]
+        * transpiration (current time step), [mm]
         * accumulated surface runoff (previous time step), [mm]
         * accumulated subsurface flow (previous time step), [mm]
         * aerodynamic_resistance_canopy, [s m-1]
@@ -637,11 +636,10 @@ class HydrologyModel(
 
             # Update soil moisture by +/- vertical flow to each layer and remove root
             # water uptake by plants (transpiration), [mm]
-            # TODO combined input from evaporation and transpiration
             soil_moisture_updated = below_ground.update_soil_moisture(
                 soil_moisture=soil_moisture_evap_mm,  # mm
                 vertical_flow=vertical_flow["vertical_flow"],  # mm day-1
-                evapotranspiration=hydro_input["current_evapotranspiration"],  # mm
+                transpiration=hydro_input["current_transpiration"],  # mm
                 soil_moisture_capacity=(  # mm
                     self.core_constants.soil_moisture_capacity
                     * self.soil_layer_thickness_mm

--- a/virtual_ecosystem/models/hydrology/hydrology_tools.py
+++ b/virtual_ecosystem/models/hydrology/hydrology_tools.py
@@ -114,7 +114,7 @@ def setup_hydrology_input_current_timestep(
     The hydrology model currently loops over 30 days per month. Atmospheric variables in
     the canopy and
     near the surface are selected here and kept constant for the whole month. Daily
-    timeseries of precipitation and evapotranspiration are generated from monthly
+    timeseries of precipitation and canopy transpiration are generated from monthly
     values in `data` to be used in the daily loop. States of other hydrology variables
     are selected and updated in the daily loop.
 
@@ -131,7 +131,7 @@ def setup_hydrology_input_current_timestep(
 
     * leaf_area_index_sum
     * current_precipitation
-    * current_evapotranspiration
+    * current_transpiration
     * current_soil_moisture
     * top_soil_moisture_capacity
     * top_soil_moisture_residual
@@ -178,8 +178,8 @@ def setup_hydrology_input_current_timestep(
     output["leaf_area_index_sum"] = np.nansum(
         data["leaf_area_index"].to_numpy(), axis=0
     )
-    output["current_evapotranspiration"] = np.nansum(
-        data["evapotranspiration"].to_numpy() / days, axis=0
+    output["current_transpiration"] = np.nansum(
+        data["transpiration"].to_numpy() / days, axis=0
     )
 
     # Select soil variables

--- a/virtual_ecosystem/models/plants/plants_model.py
+++ b/virtual_ecosystem/models/plants/plants_model.py
@@ -77,7 +77,7 @@ class PlantsModel(
         "layer_fapar",
         "layer_leaf_mass",  # NOTE - placeholder resource for herbivory
         "shortwave_absorption",
-        "evapotranspiration",
+        "transpiration",
         "deadwood_production",
         "leaf_turnover",
         "fallen_non_propagule_c_mass",
@@ -107,7 +107,7 @@ class PlantsModel(
         "subcanopy_seedbank_biomass",
     ),
     vars_populated_by_first_update=(
-        "evapotranspiration",
+        "transpiration",
         "deadwood_production",
         "leaf_turnover",
         "fallen_non_propagule_c_mass",
@@ -552,9 +552,6 @@ class PlantsModel(
 
         .. TODO:
 
-            * This function populates evapotranspiration but the calculation is
-              currently only estimating _transpiration_
-              `#704 <https://github.com/ImperialCollegeLondon/virtual_ecosystem/issues/704>`_
             * Conversion of transpiration from `µmol m-2` to `mm m-2` currently ignores
               density changes with conditions:
               `#723 <https://github.com/ImperialCollegeLondon/virtual_ecosystem/issues/723>`_
@@ -576,9 +573,7 @@ class PlantsModel(
         )
 
         # Initialise transpiration array to collect per grid cell values
-        # NOTE - #704, this is _not_ evapotranspiration, but we'll pretend it is for
-        #        the moment.
-        transpiration = self.layer_structure.from_template("evapotranspiration")
+        transpiration = self.layer_structure.from_template("transpiration")
 
         # Now calculate the gross primary productivity and transpiration across cohorts
         # and canopy layers over the time period.
@@ -647,11 +642,7 @@ class PlantsModel(
             ).sum(axis=1)
 
         # Pass values to data object
-        #
-        # - #704, this is _not_ evapotranspiration, but we'll pretend it is for
-        #        the moment.
-        #
-        self.data["evapotranspiration"] = transpiration
+        self.data["transpiration"] = transpiration
 
     def allocate_gpp(self) -> None:
         """Calculate the allocation of GPP to growth and respiration.
@@ -1031,9 +1022,7 @@ class PlantsModel(
             new_seedbank - subcanopy_sprouting_mass
         )
 
-        # - #704, this is _not_ evapotranspiration, but we'll pretend it is for
-        #        the moment.
-        self.data["evapotranspiration"] += subcanopy_transpiration
+        self.data["transpiration"] += subcanopy_transpiration
 
     def partition_reproductive_tissue(
         self, reproductive_tissue_mass: NDArray[np.float64]


### PR DESCRIPTION
This PR changes the variable name `evapotranspiration` to `transpiration`. This affects plants, hydrology and abiotic model.

Fixes #704 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
