### PR TITLE
Convert plant variables into units used by the soil and litter model

### DIFF
--- a/tests/models/plants/test_plants_model.py
+++ b/tests/models/plants/test_plants_model.py
@@ -478,3 +478,16 @@ def test_partition_reproductive_tissue(fxt_plants_model):
         n_propagules * fxt_plants_model.model_constants.carbon_mass_per_propagule
         + mass_non_propagules
     )
+
+
+def test_convert_to_litter_units(fxt_plants_model):
+    """Tests the helper function that converts to litter unit."""
+
+    input_mass = np.array([1e5, 3.4e2, 123.7, 0.007])
+    expected_input_density = [12.345679, 0.0419753, 0.0152716, 8.64198e-7]
+
+    actual_input_density = fxt_plants_model.convert_to_litter_units(
+        input_mass=input_mass
+    )
+
+    assert np.allclose(expected_input_density, actual_input_density)

--- a/tests/models/plants/test_plants_model.py
+++ b/tests/models/plants/test_plants_model.py
@@ -410,7 +410,10 @@ def test_PlantsModel_apply_mortality(fxt_plants_model):
             original_population[cell_id]
             - fxt_plants_model.communities[cell_id].cohorts.n_individuals
         )
-        deadwood_mass = np.sum(mortality * community.stem_allometry.stem_mass)
+        deadwood_mass = (
+            np.sum(mortality * community.stem_allometry.stem_mass)
+            / fxt_plants_model.grid.cell_area
+        )
 
         assert np.all(
             original_population[cell_id]

--- a/tests/models/plants/test_plants_model.py
+++ b/tests/models/plants/test_plants_model.py
@@ -481,7 +481,7 @@ def test_partition_reproductive_tissue(fxt_plants_model):
 
 
 def test_convert_to_litter_units(fxt_plants_model):
-    """Tests the helper function that converts to litter unit."""
+    """Tests the helper function that converts to litter model units."""
 
     input_mass = np.array([1e5, 3.4e2, 123.7, 0.007])
     expected_input_density = [12.345679, 0.0419753, 0.0152716, 8.64198e-7]
@@ -489,5 +489,18 @@ def test_convert_to_litter_units(fxt_plants_model):
     actual_input_density = fxt_plants_model.convert_to_litter_units(
         input_mass=input_mass
     )
+
+    assert np.allclose(expected_input_density, actual_input_density)
+
+
+def test_convert_to_soil_units(fxt_plants_model):
+    """Tests the helper function that converts to soil model units."""
+
+    print(fxt_plants_model.model_timing.update_interval_quantity)
+
+    input_mass = np.array([1e6, 3.4e3, 1237.0, 0.07])
+    expected_input_density = [0.008818342, 2.998236e-5, 1.090829e-5, 6.17284e-10]
+
+    actual_input_density = fxt_plants_model.convert_to_soil_units(input_mass=input_mass)
 
     assert np.allclose(expected_input_density, actual_input_density)

--- a/virtual_ecosystem/models/plants/plants_model.py
+++ b/virtual_ecosystem/models/plants/plants_model.py
@@ -771,24 +771,24 @@ class PlantsModel(
 
             # Allocate the topsliced GPP to root exudates with remainder as active
             # nutrient pathways
-            self.data["root_carbohydrate_exudation"][cell_id] = np.sum(
-                stem_allocation.gpp_topslice
-                * self.model_constants.root_exudates
-                * cohorts.n_individuals
-            ) / (
-                1000.0
-                * (self.model_timing.update_interval_seconds / 86400)
-                * self.grid.cell_area
-            )  # TODO - Soil helper function
-            self.data["plant_symbiote_carbon_supply"][cell_id] = np.sum(
-                stem_allocation.gpp_topslice
-                * (1 - self.model_constants.root_exudates)
-                * cohorts.n_individuals
-            ) / (
-                1000.0
-                * (self.model_timing.update_interval_seconds / 86400)
-                * self.grid.cell_area
-            )  # TODO - Soil helper function
+            self.data["root_carbohydrate_exudation"][cell_id] = (
+                self.convert_to_soil_units(
+                    input_mass=np.sum(
+                        stem_allocation.gpp_topslice
+                        * self.model_constants.root_exudates
+                        * cohorts.n_individuals
+                    )
+                )
+            )
+            self.data["plant_symbiote_carbon_supply"][cell_id] = (
+                self.convert_to_soil_units(
+                    input_mass=np.sum(
+                        stem_allocation.gpp_topslice
+                        * (1 - self.model_constants.root_exudates)
+                        * cohorts.n_individuals
+                    )
+                )
+            )
 
             # Update community allometry with new dbh values
             community.stem_allometry = StemAllometry(
@@ -1068,8 +1068,8 @@ class PlantsModel(
     ) -> NDArray[np.float64]:
         """Helper function to convert plant quantities into litter model units.
 
-        The plant model records the amount of trees in terms of masses (kg) per grid
-        square, whereas the litter model expects litter inputs as kg per m^2.
+        The plant model records the plant biomass in units of mass (kg) per grid square,
+        whereas the litter model expects litter inputs as kg per m^2.
 
         Args:
             input_mass: The mass (of carbon) being passed from the plant model to the
@@ -1081,3 +1081,26 @@ class PlantsModel(
         """
 
         return input_mass / self.grid.cell_area
+
+    def convert_to_soil_units(
+        self, input_mass: NDArray[np.float64]
+    ) -> NDArray[np.float64]:
+        """Helper function to convert plant quantities into soil model units.
+
+        The plant model records the GPP allocations (summed over stems) in units of mass
+        (g), whereas the soil model expects inputs into the soil to be expressed as rate
+        per area units (i.e. kg m^-2 day^-1). As well as converting to per area and rate
+        units this function also converts from g to kg.
+
+        Args:
+            input_mass: The mass (of carbon) being passed from the plant model to the
+                soil model [g]
+
+        Returns:
+            The input mass converted to the density rate units that the soil model uses
+            [kg m^-2 day^-1]
+        """
+
+        time_interval_in_days = self.model_timing.update_interval_seconds / 86400
+
+        return input_mass / (1000.0 * time_interval_in_days * self.grid.cell_area)

--- a/virtual_ecosystem/models/plants/plants_model.py
+++ b/virtual_ecosystem/models/plants/plants_model.py
@@ -703,10 +703,10 @@ class PlantsModel(
             # Sum of turnover from all cohorts in a grid cell
             self.data["leaf_turnover"][cell_id] = np.sum(
                 stem_allocation.foliage_turnover * cohorts.n_individuals
-            )
+            ) / (1000.0 * self.grid.cell_area)
             self.data["root_turnover"][cell_id] = np.sum(
                 stem_allocation.fine_root_turnover * cohorts.n_individuals
-            )
+            ) / (1000.0 * self.grid.cell_area)
 
             # Partition reproductive tissue into propagule and non-propagule masses and
             # convert the propagule mass to number of propagules
@@ -731,7 +731,9 @@ class PlantsModel(
             # Add those partitions to pools
             #  - Merge fallen non-propagule mass into a single pool
             self.data["fallen_non_propagule_c_mass"][cell_id] = (
-                stem_fallen_non_propagule_c_mass * cohorts.n_individuals
+                stem_fallen_non_propagule_c_mass
+                * cohorts.n_individuals
+                / (1000.0 * self.grid.cell_area)
             ).sum()
 
             # Allocate fallen propagules, and canopy propagules and non-propagule mass
@@ -767,11 +769,19 @@ class PlantsModel(
                 stem_allocation.gpp_topslice
                 * self.model_constants.root_exudates
                 * cohorts.n_individuals
+            ) / (
+                1000.0
+                * (self.model_timing.update_interval_seconds / 86400)
+                * self.grid.cell_area
             )
             self.data["plant_symbiote_carbon_supply"][cell_id] = np.sum(
                 stem_allocation.gpp_topslice
                 * (1 - self.model_constants.root_exudates)
                 * cohorts.n_individuals
+            ) / (
+                1000.0
+                * (self.model_timing.update_interval_seconds / 86400)
+                * self.grid.cell_area
             )
 
             # Update community allometry with new dbh values
@@ -808,7 +818,7 @@ class PlantsModel(
             # Update deadwood production
             self.data["deadwood_production"][cell_id] = np.sum(
                 mortality * community.stem_allometry.stem_mass
-            )
+            ) / (self.grid.cell_area)
 
     def calculate_turnover(self) -> None:
         """Calculate turnover of each plant biomass pool.

--- a/virtual_ecosystem/models/plants/plants_model.py
+++ b/virtual_ecosystem/models/plants/plants_model.py
@@ -701,12 +701,16 @@ class PlantsModel(
             cohorts.dbh_values = cohorts.dbh_values + stem_allocation.delta_dbh
 
             # Sum of turnover from all cohorts in a grid cell
-            self.data["leaf_turnover"][cell_id] = np.sum(
-                stem_allocation.foliage_turnover * cohorts.n_individuals
-            ) / (1000.0 * self.grid.cell_area)
-            self.data["root_turnover"][cell_id] = np.sum(
-                stem_allocation.fine_root_turnover * cohorts.n_individuals
-            ) / (1000.0 * self.grid.cell_area)
+            self.data["leaf_turnover"][cell_id] = self.convert_to_litter_units(
+                input_mass=np.sum(
+                    stem_allocation.foliage_turnover * cohorts.n_individuals
+                ),
+            )
+            self.data["root_turnover"][cell_id] = self.convert_to_litter_units(
+                input_mass=np.sum(
+                    stem_allocation.fine_root_turnover * cohorts.n_individuals
+                ),
+            )
 
             # Partition reproductive tissue into propagule and non-propagule masses and
             # convert the propagule mass to number of propagules
@@ -731,10 +735,12 @@ class PlantsModel(
             # Add those partitions to pools
             #  - Merge fallen non-propagule mass into a single pool
             self.data["fallen_non_propagule_c_mass"][cell_id] = (
-                stem_fallen_non_propagule_c_mass
-                * cohorts.n_individuals
-                / (1000.0 * self.grid.cell_area)
-            ).sum()
+                self.convert_to_litter_units(
+                    input_mass=(
+                        stem_fallen_non_propagule_c_mass * cohorts.n_individuals
+                    ).sum(),
+                )
+            )
 
             # Allocate fallen propagules, and canopy propagules and non-propagule mass
             # into PFT specific pools by iterating over cohort PFTs.
@@ -773,7 +779,7 @@ class PlantsModel(
                 1000.0
                 * (self.model_timing.update_interval_seconds / 86400)
                 * self.grid.cell_area
-            )
+            )  # TODO - Soil helper function
             self.data["plant_symbiote_carbon_supply"][cell_id] = np.sum(
                 stem_allocation.gpp_topslice
                 * (1 - self.model_constants.root_exudates)
@@ -782,7 +788,7 @@ class PlantsModel(
                 1000.0
                 * (self.model_timing.update_interval_seconds / 86400)
                 * self.grid.cell_area
-            )
+            )  # TODO - Soil helper function
 
             # Update community allometry with new dbh values
             community.stem_allometry = StemAllometry(
@@ -816,9 +822,9 @@ class PlantsModel(
             cohorts.n_individuals = cohorts.n_individuals - mortality
 
             # Update deadwood production
-            self.data["deadwood_production"][cell_id] = np.sum(
-                mortality * community.stem_allometry.stem_mass
-            ) / (self.grid.cell_area)
+            self.data["deadwood_production"][cell_id] = self.convert_to_litter_units(
+                input_mass=np.sum(mortality * community.stem_allometry.stem_mass),
+            )
 
     def calculate_turnover(self) -> None:
         """Calculate turnover of each plant biomass pool.
@@ -1056,3 +1062,22 @@ class PlantsModel(
         )
 
         return n_propagules, non_propagule_mass
+
+    def convert_to_litter_units(
+        self, input_mass: NDArray[np.float64]
+    ) -> NDArray[np.float64]:
+        """Helper function to convert plant quantities into litter model units.
+
+        The plant model records the amount of trees in terms of masses (kg) per grid
+        square, whereas the litter model expects litter inputs as kg per m^2.
+
+        Args:
+            input_mass: The mass (of carbon) being passed from the plant model to the
+                litter model [kg/g]
+
+        Returns:
+            The input mass converted to the density units that the litter model uses [kg
+            m^-2]
+        """
+
+        return input_mass / self.grid.cell_area


### PR DESCRIPTION
# Description

This changes the calculation of the variables that pass from the plant model to the soil and litter models so that they use the expected units (I probably should have noticed that they didn't when I reviewed this code before 🫠)

@sallymatson, this changes code that you originally wrote so let me know if you are happy with the changes. I also considered making helper functions for `to_litter_units` and `to_soil_units`. If you think those would be useful let me know and I can write them.

Fixes #863

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
