### PR TITLE
added conditional statement to avoid division by zero

### DIFF
--- a/virtual_ecosystem/models/hydrology/above_ground.py
+++ b/virtual_ecosystem/models/hydrology/above_ground.py
@@ -537,7 +537,10 @@ def distribute_monthly_rainfall(
             day = rng.integers(0, num_days, seed)  # Randomly select a day
             daily_rainfall[day] += 1.0  # Add 1.0 mm of rainfall to the selected day
 
-        daily_rainfall *= rainfall / np.sum(daily_rainfall)
+        if np.sum(daily_rainfall > 0):
+            daily_rainfall *= rainfall / np.sum(daily_rainfall)
+        else:
+            daily_rainfall[:] = 0
         daily_rainfall_data.append(daily_rainfall)
 
     return np.nan_to_num(np.array(daily_rainfall_data), nan=0.0)


### PR DESCRIPTION
Some experiments returned this warning, which is hopefully fixed here:

```
RuntimeWarning: invalid value encountered in scalar divide
  daily_rainfall *= rainfall / np.sum(daily_rainfall)
```

Fixes #869 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`
