### PR TITLE
Add effective saturation calculation to hydrology tools

### DIFF
--- a/docs/source/glossary.md
+++ b/docs/source/glossary.md
@@ -65,6 +65,12 @@ effective soil moisture
   The portion of soil water available for plant uptake, typically the range between
   residual moisture and field capacity. Expressed in m3/m3, %, or mm.
 
+effective saturation
+  Rescaled soil water saturation so that it takes a value of zero at the physical
+  minimum ({term}`soil moisture residual`) and a value of one at the physical maximum
+  ({term}`soil moisture saturation`). This can also be referred to as the normalised
+  water content.
+
 relative soil moisture
   A ratio expressing the amount of water in soil, as a percentage, compared to the total
   water-holding capacity between the wilting point (very dry) and saturation (very wet)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -497,90 +497,81 @@ def fixture_core_components(fixture_config):
 
 
 @pytest.fixture
-def dummy_carbon_data(fixture_core_components):
-    """Creates a dummy carbon data object for use in tests."""
+def dummy_litter_data(fixture_core_components):
+    """Creates a dummy litter data object for use in tests."""
 
     from virtual_ecosystem.core.data import Data
+
+    lyr_strct = fixture_core_components.layer_structure
 
     # Setup the data object with four cells.
     data = Data(fixture_core_components.grid)
 
-    # The required data is now added. This includes the five carbon pools: mineral
-    # associated organic matter, low molecular weight carbon, microbial biomass and
-    # necromass carbon and particulate organic matter. It also includes various factors
-    # of the physical environment: pH, bulk density, soil moisture, soil temperature,
-    # percentage clay in soil.
-    data_values = {
-        "soil_c_pool_lmwc": [0.05, 0.02, 0.1, 0.005],
-        "soil_c_pool_maom": [2.5, 1.7, 4.5, 0.5],
-        "soil_c_pool_bacteria": [5.8, 2.3, 11.3, 1.0],
-        "soil_c_pool_saprotrophic_fungi": [0.89, 8.55, 2.21, 4.54],
-        "soil_c_pool_arbuscular_mycorrhiza": [0.65, 1.47, 3.92, 9.04],
-        "soil_c_pool_ectomycorrhiza": [0.47, 1.32, 4.2, 3.77],
-        "soil_c_pool_pom": [0.1, 1.0, 0.7, 0.35],
-        "soil_c_pool_necromass": [0.058, 0.015, 0.093, 0.105],
-        "soil_enzyme_pom_bacteria": [0.022679, 0.009576, 0.050051, 0.003010],
-        "soil_enzyme_maom_bacteria": [0.0356, 0.0117, 0.02509, 0.00456],
-        "soil_enzyme_pom_fungi": [0.02607, 0.00575, 0.00646, 0.00441],
-        "soil_enzyme_maom_fungi": [0.008669, 0.006826, 0.003807, 0.002163],
-        "soil_n_pool_don": [0.000571428, 0.00142857, 0.00014285, 0.002857142],
-        "soil_n_pool_particulate": [0.00714285, 0.00071425, 0.00285714, 0.01428571],
-        "soil_n_pool_necromass": [0.00288462, 0.01788462, 0.02019231, 0.01115385],
-        "soil_n_pool_maom": [0.86538462, 0.48076923, 0.32692308, 0.09615385],
-        "soil_n_pool_ammonium": [6.9619638e-5, 0.0049914624, 0.000229067, 0.0051955339],
-        "soil_n_pool_nitrate": [0.0024219014, 0.0044442996, 0.0003428348, 0.0131405173],
-        "soil_p_pool_dop": [5.714e-6, 2.2857120e-5, 5.7142800e-5, 1.1428568e-4],
-        "soil_p_pool_particulate": [2.857e-5, 2.85714e-4, 1.142856e-4, 5.714284e-4],
-        "soil_p_pool_necromass": [0.00080769, 0.00011538, 0.00071538, 0.00044615],
-        "soil_p_pool_maom": [0.01307692, 0.03461538, 0.01923077, 0.00384615],
-        "soil_p_pool_primary": [0.0019594, 0.00535662, 0.00277434, 0.00059892],
-        "soil_p_pool_secondary": [0.00705668, 0.03816896, 0.01152589, 0.00733107],
-        "soil_p_pool_labile": [1.0582393e-5, 3.252961e-5, 6.806745e-5, 1.945635e-4],
-        "pH": [3.0, 7.5, 9.0, 5.7],
-        "bulk_density": [1350.0, 1800.0, 1000.0, 1500.0],
-        "clay_fraction": [0.8, 0.3, 0.1, 0.9],
-        "litter_C_mineralisation_rate": [0.00212106, 0.00106053, 0.00049000, 0.0055],
-        "litter_N_mineralisation_rate": [3.5351e-5, 7.0702e-5, 0.000183, 1.63333e-5],
-        "litter_P_mineralisation_rate": [7.32e-6, 1.41404e-6, 2.82808e-6, 6.53332e-7],
-        "vertical_flow": [0.1, 0.5, 2.5, 1.59],
-        "plant_symbiote_carbon_supply": [0.01, 0.25, 0.0075, 0.0047],
-        "root_carbohydrate_exudation": [0.025, 0.01, 0.05, 0.0025],
-        "plant_ammonium_uptake": [5.0e-5, 2.5e-5, 1.0e-5, 1.0e-4],
-        "plant_nitrate_uptake": [7.5e-4, 1.0e-3, 2.5e-4, 1.0e-4],
-        "plant_phosphorus_uptake": [3.0e-6, 5e-5, 2.0e-6, 1.0e-6],
-        "plant_n_uptake_arbuscular": [2.07e-5, 3.12e-5, 3.57e-6, 6.98e-5],
-        "plant_n_uptake_ecto": [3.07e-5, 4.20e-5, 4.02e-6, 2.98e-5],
-        "plant_p_uptake_arbuscular": [1.57e-6, 5.07e-5, 2.13e-6, 1.81e-6],
-        "plant_p_uptake_ecto": [1.78e-6, 5.64e-5, 1.07e-6, 9.90e-7],
+    # These values are taken from SAFE Project data, albeit in a very unsystematic
+    # manner. The repeated fourth value is simply to adapt three hand validated examples
+    # to the shared fixture core components grid
+    pool_values = {
+        "litter_pool_above_metabolic": [0.319785, 0.161631, 0.086129, 0.093456],
+        "litter_pool_above_structural": [0.52097, 0.26609, 0.10019, 0.09988],
+        "litter_pool_woody": [5.1773833, 12.185701, 7.673456, 7.462192],
+        "litter_pool_below_metabolic": [0.410373, 0.375794, 0.080181, 0.083494],
+        "litter_pool_below_structural": [0.613547, 0.321674, 0.032738, 0.029168],
+        "lignin_above_structural": [0.5, 0.1, 0.7, 0.7],
+        "lignin_woody": [0.5, 0.8, 0.35, 0.35],
+        "lignin_below_structural": [0.5, 0.25, 0.75, 0.75],
+        "c_n_ratio_above_metabolic": [7.3, 8.7, 10.1, 9.8],
+        "c_n_ratio_above_structural": [37.5, 43.2, 45.8, 50.2],
+        "c_n_ratio_woody": [55.5, 63.3, 47.3, 59.1],
+        "c_n_ratio_below_metabolic": [10.7, 11.3, 15.2, 12.4],
+        "c_n_ratio_below_structural": [50.5, 55.6, 73.1, 61.2],
+        "c_p_ratio_above_metabolic": [57.3, 68.7, 100.1, 95.8],
+        "c_p_ratio_above_structural": [337.5, 473.2, 415.8, 570.2],
+        "c_p_ratio_woody": [555.5, 763.3, 847.3, 599.1],
+        "c_p_ratio_below_metabolic": [310.7, 411.3, 315.2, 412.4],
+        "c_p_ratio_below_structural": [550.5, 595.6, 773.1, 651.2],
+        "deadwood_production": [0.075, 0.099, 0.063, 0.033],
+        "leaf_turnover": [0.027, 0.0003, 0.021, 0.0285],
+        "fallen_non_propagule_c_mass": [0.003, 0.0075, 0.00255, 0.00375],
+        "root_turnover": [0.027, 0.021, 0.0003, 0.0249],
+        "stem_lignin": [0.233, 0.545, 0.612, 0.378],
+        "senesced_leaf_lignin": [0.05, 0.25, 0.3, 0.57],
+        "plant_reproductive_tissue_lignin": [0.01, 0.03, 0.04, 0.02],
+        "root_lignin": [0.2, 0.35, 0.27, 0.4],
+        "deadwood_c_n_ratio": [60.7, 57.9, 73.1, 55.1],
+        "leaf_turnover_c_n_ratio": [15.0, 25.5, 43.1, 57.4],
+        "plant_reproductive_tissue_turnover_c_n_ratio": [12.5, 23.8, 15.7, 18.2],
+        "root_turnover_c_n_ratio": [30.3, 45.6, 43.3, 37.1],
+        "deadwood_c_p_ratio": [856.5, 675.4, 933.2, 888.8],
+        "leaf_turnover_c_p_ratio": [415.0, 327.4, 554.5, 380.9],
+        "plant_reproductive_tissue_turnover_c_p_ratio": [125.5, 105.0, 145.0, 189.2],
+        "root_turnover_c_p_ratio": [656.7, 450.6, 437.3, 371.9],
+        "litter_consumption_above_metabolic": [0.019785, 0.011631, 0.016129, 0.023456],
+        "litter_consumption_above_structural": [0.02097, 0.01609, 0.01019, 0.00988],
+        "litter_consumption_woody": [0.4773833, 0.385701, 0.373456, 0.162192],
+        "litter_consumption_below_metabolic": [0.010373, 0.005794, 0.010181, 0.013494],
+        "litter_consumption_below_structural": [0.013547, 0.011674, 0.012738, 0.009168],
+        "herbivory_waste_leaf_carbon": [3e-5, 2.1e-3, 2.85e-3, 2.7e-3],
+        "herbivory_waste_leaf_nitrogen": [23.1, 33.5, 23.1, 17.3],
+        "herbivory_waste_leaf_phosphorus": [212.5, 344.8, 334.8, 420.1],
+        "herbivory_waste_leaf_lignin": [0.13, 0.08, 0.27, 0.22],
     }
 
-    for var_name, var_values in data_values.items():
-        data[var_name] = DataArray(var_values, dims=["cell_id"])
+    for var, vals in pool_values.items():
+        data[var] = DataArray(vals, dims=["cell_id"])
 
-    # The layer dependent data has to be handled separately - at present all of these
-    # are defined only for the topsoil layer
-    lyr_str = fixture_core_components.layer_structure
+    # Vertically structured variables
+    data["soil_temperature"] = lyr_strct.from_template()
+    data["soil_temperature"][lyr_strct.index_topsoil] = 20
+    data["soil_temperature"][lyr_strct.index_subsoil] = [19.5, 18.7, 18.7, 17.6]
 
-    data["soil_moisture"] = lyr_str.from_template()
-    data["soil_moisture"][lyr_str.index_all_soil] = np.array(
-        [
-            [232.61550125, 196.88733175, 126.065797, 75.63195175],
-            [66.248474, 194.91137, 121.29988, 52.04422],
-        ]
-    )
+    # At present the soil model only uses the top soil layer, so this is the
+    # only one with real test values in
+    data["matric_potential"] = lyr_strct.from_template()
+    data["matric_potential"][lyr_strct.index_topsoil] = [-10.0, -25.0, -100.0, -100.0]
+    data["matric_potential"][lyr_strct.index_subsoil] = [-11.0, -29.5, -123.0, -154.1]
 
-    data["matric_potential"] = lyr_str.from_template()
-    data["matric_potential"][lyr_str.index_all_soil] = np.array(
-        [[-3.0, -10.0, -250.0, -10000.0], [-2.8625, -8.978, -137.8, -8553.25]]
-    )
-
-    data["soil_temperature"] = lyr_str.from_template()
-    data["soil_temperature"][lyr_str.index_all_soil] = np.array(
-        [[35.0, 37.5, 40.0, 25.0], [22.5, 22.5, 22.5, 22.5]]
-    )
-
-    data["air_temperature"] = lyr_str.from_template()
-    data["air_temperature"][lyr_str.index_filled_atmosphere] = np.array(
+    data["air_temperature"] = lyr_strct.from_template()
+    data["air_temperature"][lyr_strct.index_filled_atmosphere] = np.array(
         [30.0, 29.844995, 28.87117, 27.206405, 16.145945]
     )[:, None]
 

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -740,7 +740,7 @@ def test_on_core_axis(
 def test_save_to_netcdf(
     shared_datadir,
     caplog,
-    dummy_carbon_data,
+    dummy_litter_data,
     folder,
     file_name,
     save_specific,
@@ -756,22 +756,22 @@ def test_save_to_netcdf(
 
     with raises:
         if save_specific:
-            dummy_carbon_data.save_to_netcdf(
-                out_path, variables_to_save=["soil_c_pool_lmwc"]
+            dummy_litter_data.save_to_netcdf(
+                out_path, variables_to_save=["litter_pool_woody"]
             )
         else:
-            dummy_carbon_data.save_to_netcdf(out_path)
+            dummy_litter_data.save_to_netcdf(out_path)
 
         # Load in netcdf data to check the contents
         saved_data = xr.open_dataset(out_path)
 
         # Then check that expected keys are in it
         if save_specific:
-            assert "soil_c_pool_lmwc" in saved_data
-            assert "soil_c_pool_maom" not in saved_data
+            assert "litter_pool_woody" in saved_data
+            assert "litter_pool_above_metabolic" not in saved_data
         else:
-            assert "soil_c_pool_lmwc" in saved_data
-            assert "soil_c_pool_maom" in saved_data
+            assert "litter_pool_woody" in saved_data
+            assert "litter_pool_above_metabolic" in saved_data
 
         # Close the dataset (otherwise windows has a problem)
         saved_data.close()
@@ -787,7 +787,7 @@ def test_save_to_netcdf(
             "initial.nc",
             pytest.raises(ConfigurationError),
             (
-                (INFO, "Replacing data array for 'soil_c_pool_lmwc'"),
+                (INFO, "Replacing data array for 'litter_pool_woody'"),
                 (
                     CRITICAL,
                     "The user specified output directory (bad_folder) doesn't exist!",
@@ -799,7 +799,7 @@ def test_save_to_netcdf(
             "initial.nc",
             pytest.raises(ConfigurationError),
             (
-                (INFO, "Replacing data array for 'soil_c_pool_lmwc'"),
+                (INFO, "Replacing data array for 'litter_pool_woody'"),
                 (
                     CRITICAL,
                     "The user specified output folder (pyproject.toml) isn't a "
@@ -812,7 +812,7 @@ def test_save_to_netcdf(
             "already_exists.nc",
             pytest.raises(ConfigurationError),
             (
-                (INFO, "Replacing data array for 'soil_c_pool_lmwc'"),
+                (INFO, "Replacing data array for 'litter_pool_woody'"),
                 (CRITICAL, "A file in the user specified output folder ("),
             ),
         ),
@@ -825,7 +825,7 @@ def test_save_to_netcdf(
     ],
 )
 def test_save_timeslice_to_netcdf(
-    caplog, shared_datadir, dummy_carbon_data, folder, file_name, raises, expected_log
+    caplog, shared_datadir, dummy_litter_data, folder, file_name, raises, expected_log
 ):
     """Test that data object can append to an existing NetCDF file."""
 
@@ -836,21 +836,21 @@ def test_save_timeslice_to_netcdf(
 
     with raises:
         # Change data to check that appending works
-        dummy_carbon_data["soil_c_pool_lmwc"] = DataArray(
+        dummy_litter_data["litter_pool_woody"] = DataArray(
             [0.1, 0.05, 0.2, 0.01], dims=["cell_id"], coords={"cell_id": [0, 1, 2, 3]}
         )
-        dummy_carbon_data["soil_temperature"][12][0] = 15.0
+        dummy_litter_data["soil_temperature"][12][0] = 15.0
         # Append data to netcdf file
-        dummy_carbon_data.save_timeslice_to_netcdf(
+        dummy_litter_data.save_timeslice_to_netcdf(
             out_path,
-            variables_to_save=["soil_c_pool_lmwc", "soil_temperature"],
+            variables_to_save=["litter_pool_woody", "soil_temperature"],
             time_index=1,
         )
 
         # Load file, and then check that contents meet expectation
         saved_data = xr.open_dataset(out_path)
         xr.testing.assert_allclose(
-            saved_data["soil_c_pool_lmwc"],
+            saved_data["litter_pool_woody"],
             DataArray(
                 [[0.1, 0.05, 0.2, 0.01]],
                 dims=["time_index", "cell_id"],
@@ -863,8 +863,8 @@ def test_save_timeslice_to_netcdf(
                 [
                     [
                         [np.nan, np.nan, np.nan, np.nan],
-                        [15.0, 37.5, 40.0, 25.0],
-                        [22.5, 22.5, 22.5, 22.5],
+                        [15.0, 20, 20, 20],
+                        [19.5, 18.7, 18.7, 17.6],
                     ],
                 ],
                 dims=["time_index", "layers", "cell_id"],
@@ -879,7 +879,7 @@ def test_save_timeslice_to_netcdf(
 
         # Check that only expected variables were added
         assert (
-            set(saved_data.keys()) - {"soil_c_pool_lmwc", "soil_temperature"} == set()
+            set(saved_data.keys()) - {"litter_pool_woody", "soil_temperature"} == set()
         )
         # Finally, close the dataset
         saved_data.close()
@@ -932,13 +932,13 @@ def test_Data_add_from_dict(fixture_core_components, dummy_climate_data):
 
 
 @pytest.mark.parametrize("time_index", [0, 1])
-def test_output_current_state(mocker, dummy_carbon_data, time_index):
+def test_output_current_state(mocker, dummy_litter_data, time_index):
     """Test that function to output the current data state works as intended."""
 
-    # Set up the registry with the soil model
+    # Set up the registry with the litter model
     from virtual_ecosystem.core.registry import MODULE_REGISTRY, register_module
 
-    register_module("virtual_ecosystem.models.soil")
+    register_module("virtual_ecosystem.models.litter")
 
     data_options = {"out_folder_continuous": "."}
 
@@ -946,7 +946,7 @@ def test_output_current_state(mocker, dummy_carbon_data, time_index):
     mock_save = mocker.patch("virtual_ecosystem.main.Data.save_timeslice_to_netcdf")
 
     # Extract model from registry and put into expected dictionary format
-    models_cfd = {"soil": MODULE_REGISTRY["soil"].model}
+    models_cfd = {"litter": MODULE_REGISTRY["litter"].model}
 
     # Only variables in the data object that are updated by a model should be output
     all_variables = [
@@ -956,7 +956,7 @@ def test_output_current_state(mocker, dummy_carbon_data, time_index):
     variables_to_save = [item for sublist in all_variables for item in sublist]
 
     # Then call the top level function
-    outpath = dummy_carbon_data.output_current_state(
+    outpath = dummy_litter_data.output_current_state(
         variables_to_save, data_options, time_index
     )
 
@@ -966,70 +966,59 @@ def test_output_current_state(mocker, dummy_carbon_data, time_index):
     assert mock_save.call_args == mocker.call(
         Path(f"./continuous_state{time_index:05}.nc"),
         [
-            "soil_c_pool_maom",
-            "soil_c_pool_lmwc",
-            "soil_c_pool_bacteria",
-            "soil_c_pool_saprotrophic_fungi",
-            "soil_c_pool_arbuscular_mycorrhiza",
-            "soil_c_pool_ectomycorrhiza",
-            "soil_c_pool_pom",
-            "soil_c_pool_necromass",
-            "soil_enzyme_pom_bacteria",
-            "soil_enzyme_maom_bacteria",
-            "soil_enzyme_pom_fungi",
-            "soil_enzyme_maom_fungi",
-            "soil_n_pool_don",
-            "soil_n_pool_particulate",
-            "soil_n_pool_necromass",
-            "soil_n_pool_maom",
-            "soil_n_pool_ammonium",
-            "soil_n_pool_nitrate",
-            "soil_p_pool_dop",
-            "soil_p_pool_particulate",
-            "soil_p_pool_necromass",
-            "soil_p_pool_maom",
-            "soil_p_pool_primary",
-            "soil_p_pool_secondary",
-            "soil_p_pool_labile",
-            "dissolved_nitrate",
-            "dissolved_ammonium",
-            "dissolved_phosphorus",
-            "ecto_supply_limit_n",
-            "ecto_supply_limit_p",
-            "arbuscular_supply_limit_n",
-            "arbuscular_supply_limit_p",
+            "litter_pool_above_metabolic",
+            "litter_pool_above_structural",
+            "litter_pool_woody",
+            "litter_pool_below_metabolic",
+            "litter_pool_below_structural",
+            "lignin_above_structural",
+            "lignin_woody",
+            "lignin_below_structural",
+            "c_n_ratio_above_metabolic",
+            "c_n_ratio_above_structural",
+            "c_n_ratio_woody",
+            "c_n_ratio_below_metabolic",
+            "c_n_ratio_below_structural",
+            "c_p_ratio_above_metabolic",
+            "c_p_ratio_above_structural",
+            "c_p_ratio_woody",
+            "c_p_ratio_below_metabolic",
+            "c_p_ratio_below_structural",
+            "litter_C_mineralisation_rate",
+            "litter_N_mineralisation_rate",
+            "litter_P_mineralisation_rate",
         ],
         time_index,
     )
     assert outpath == Path(f"./continuous_state{time_index:05}.nc")
 
 
-def test_merge_continuous_data_files(shared_datadir, dummy_carbon_data):
+def test_merge_continuous_data_files(shared_datadir, dummy_litter_data):
     """Test that function to merge the continuous data files works as intended."""
     from virtual_ecosystem.core.data import merge_continuous_data_files
 
     # Simple and slightly more complex data for the file
-    variables_to_save = ["soil_c_pool_lmwc", "soil_temperature"]
+    variables_to_save = ["litter_pool_woody", "soil_temperature"]
     data_options = {
         "out_folder_continuous": str(shared_datadir),
         "out_continuous_file_name": "all_continuous_data.nc",
     }
 
     # Save first data file
-    dummy_carbon_data.save_timeslice_to_netcdf(
+    dummy_litter_data.save_timeslice_to_netcdf(
         shared_datadir / "continuous_state1.nc",
         variables_to_save,
         1,
     )
 
     # Alter data so that files differ (slightly)
-    dummy_carbon_data["soil_c_pool_lmwc"] = DataArray(
+    dummy_litter_data["litter_pool_woody"] = DataArray(
         [0.1, 0.05, 0.2, 0.01], dims=["cell_id"], coords={"cell_id": [0, 1, 2, 3]}
     )
-    dummy_carbon_data["soil_temperature"][12][0] = 15.0
+    dummy_litter_data["soil_temperature"][12][0] = 15.0
 
     # Save second data file
-    dummy_carbon_data.save_timeslice_to_netcdf(
+    dummy_litter_data.save_timeslice_to_netcdf(
         shared_datadir / "continuous_state2.nc",
         variables_to_save,
         2,
@@ -1052,9 +1041,9 @@ def test_merge_continuous_data_files(shared_datadir, dummy_carbon_data):
 
     # Check that data file is as expected
     testing.assert_allclose(
-        full_data["soil_c_pool_lmwc"],
+        full_data["litter_pool_woody"],
         DataArray(
-            [[0.05, 0.02, 0.1, 0.005], [0.1, 0.05, 0.2, 0.01]],
+            [[5.1773833, 12.185701, 7.673456, 7.462192], [0.1, 0.05, 0.2, 0.01]],
             dims=["time_index", "cell_id"],
             coords={"cell_id": [0, 1, 2, 3], "time_index": [1, 2]},
         ),
@@ -1065,13 +1054,13 @@ def test_merge_continuous_data_files(shared_datadir, dummy_carbon_data):
             [
                 [
                     [np.nan, np.nan, np.nan, np.nan],
-                    [35.0, 37.5, 40.0, 25.0],
-                    [22.5, 22.5, 22.5, 22.5],
+                    [20, 20, 20, 20],
+                    [19.5, 18.7, 18.7, 17.6],
                 ],
                 [
                     [np.nan, np.nan, np.nan, np.nan],
-                    [15.0, 37.5, 40.0, 25.0],
-                    [22.5, 22.5, 22.5, 22.5],
+                    [15.0, 20, 20, 20],
+                    [19.5, 18.7, 18.7, 17.6],
                 ],
             ],
             dims=["time_index", "layers", "cell_id"],
@@ -1090,20 +1079,20 @@ def test_merge_continuous_data_files(shared_datadir, dummy_carbon_data):
 
 
 def test_merge_continuous_file_already_exists(
-    shared_datadir, caplog, dummy_carbon_data
+    shared_datadir, caplog, dummy_litter_data
 ):
     """Test that the merge continuous function fails if file name already used."""
     from virtual_ecosystem.core.data import merge_continuous_data_files
 
     # Simple and slightly more complex data for the file
-    variables_to_save = ["soil_c_pool_lmwc", "soil_temperature"]
+    variables_to_save = ["litter_pool_woody", "soil_temperature"]
     data_options = {
         "out_folder_continuous": str(shared_datadir),
         "out_continuous_file_name": "already_exists.nc",
     }
 
     # Save first data file
-    dummy_carbon_data.save_timeslice_to_netcdf(
+    dummy_litter_data.save_timeslice_to_netcdf(
         shared_datadir / "continuous_state1.nc",
         variables_to_save,
         1,

--- a/tests/models/hydrology/test_hydrology_tools.py
+++ b/tests/models/hydrology/test_hydrology_tools.py
@@ -176,3 +176,22 @@ def test_check_precipitation_surface_raises_error():
         " canopy water balance is correct.",
     ):
         check_precipitation_surface(test_array)
+
+
+def test_calculate_effective_saturation(dummy_climate_data):
+    """Test that the calculation the effective saturation works correctly."""
+    from virtual_ecosystem.models.hydrology.hydrology_tools import (
+        calculate_effective_saturation,
+    )
+
+    soil_moistures = np.array([0.178, 0.25, 0.333, 0.5])
+
+    expected_sats = [0.00895522, 0.22388060, 0.47164179, 0.97014925]
+
+    actual_sats = calculate_effective_saturation(
+        soil_moisture=soil_moistures,
+        soil_moisture_saturation=HydroConsts.soil_moisture_saturation,
+        soil_moisture_residual=HydroConsts.soil_moisture_residual,
+    )
+
+    assert np.allclose(actual_sats, expected_sats)

--- a/tests/models/litter/conftest.py
+++ b/tests/models/litter/conftest.py
@@ -1,14 +1,12 @@
 """Collection of fixtures to assist the testing of the litter model."""
 
-import numpy as np
 import pytest
-from xarray import DataArray
 
 from virtual_ecosystem.models.litter.constants import LitterConsts
 
 
 @pytest.fixture
-def fixture_litter_model(dummy_litter_data, fixture_core_components):
+def fixture_litter_model(dummy_litter_data):
     """Create a litter model fixture based on the dummy litter data."""
     from tests.conftest import patch_bypass_setup, patch_run_update
     from virtual_ecosystem.core.config import Config
@@ -29,88 +27,6 @@ def fixture_litter_model(dummy_litter_data, fixture_core_components):
         return LitterModel.from_config(
             data=dummy_litter_data, core_components=core_components, config=config
         )
-
-
-@pytest.fixture
-def dummy_litter_data(fixture_core_components):
-    """Creates a dummy litter data object for use in tests."""
-
-    from virtual_ecosystem.core.data import Data
-
-    lyr_strct = fixture_core_components.layer_structure
-
-    # Setup the data object with four cells.
-    data = Data(fixture_core_components.grid)
-
-    # These values are taken from SAFE Project data, albeit in a very unsystematic
-    # manner. The repeated fourth value is simply to adapt three hand validated examples
-    # to the shared fixture core components grid
-    pool_values = {
-        "litter_pool_above_metabolic": [0.319785, 0.161631, 0.086129, 0.093456],
-        "litter_pool_above_structural": [0.52097, 0.26609, 0.10019, 0.09988],
-        "litter_pool_woody": [5.1773833, 12.185701, 7.673456, 7.462192],
-        "litter_pool_below_metabolic": [0.410373, 0.375794, 0.080181, 0.083494],
-        "litter_pool_below_structural": [0.613547, 0.321674, 0.032738, 0.029168],
-        "lignin_above_structural": [0.5, 0.1, 0.7, 0.7],
-        "lignin_woody": [0.5, 0.8, 0.35, 0.35],
-        "lignin_below_structural": [0.5, 0.25, 0.75, 0.75],
-        "c_n_ratio_above_metabolic": [7.3, 8.7, 10.1, 9.8],
-        "c_n_ratio_above_structural": [37.5, 43.2, 45.8, 50.2],
-        "c_n_ratio_woody": [55.5, 63.3, 47.3, 59.1],
-        "c_n_ratio_below_metabolic": [10.7, 11.3, 15.2, 12.4],
-        "c_n_ratio_below_structural": [50.5, 55.6, 73.1, 61.2],
-        "c_p_ratio_above_metabolic": [57.3, 68.7, 100.1, 95.8],
-        "c_p_ratio_above_structural": [337.5, 473.2, 415.8, 570.2],
-        "c_p_ratio_woody": [555.5, 763.3, 847.3, 599.1],
-        "c_p_ratio_below_metabolic": [310.7, 411.3, 315.2, 412.4],
-        "c_p_ratio_below_structural": [550.5, 595.6, 773.1, 651.2],
-        "deadwood_production": [0.075, 0.099, 0.063, 0.033],
-        "leaf_turnover": [0.027, 0.0003, 0.021, 0.0285],
-        "fallen_non_propagule_c_mass": [0.003, 0.0075, 0.00255, 0.00375],
-        "root_turnover": [0.027, 0.021, 0.0003, 0.0249],
-        "stem_lignin": [0.233, 0.545, 0.612, 0.378],
-        "senesced_leaf_lignin": [0.05, 0.25, 0.3, 0.57],
-        "plant_reproductive_tissue_lignin": [0.01, 0.03, 0.04, 0.02],
-        "root_lignin": [0.2, 0.35, 0.27, 0.4],
-        "deadwood_c_n_ratio": [60.7, 57.9, 73.1, 55.1],
-        "leaf_turnover_c_n_ratio": [15.0, 25.5, 43.1, 57.4],
-        "plant_reproductive_tissue_turnover_c_n_ratio": [12.5, 23.8, 15.7, 18.2],
-        "root_turnover_c_n_ratio": [30.3, 45.6, 43.3, 37.1],
-        "deadwood_c_p_ratio": [856.5, 675.4, 933.2, 888.8],
-        "leaf_turnover_c_p_ratio": [415.0, 327.4, 554.5, 380.9],
-        "plant_reproductive_tissue_turnover_c_p_ratio": [125.5, 105.0, 145.0, 189.2],
-        "root_turnover_c_p_ratio": [656.7, 450.6, 437.3, 371.9],
-        "litter_consumption_above_metabolic": [0.019785, 0.011631, 0.016129, 0.023456],
-        "litter_consumption_above_structural": [0.02097, 0.01609, 0.01019, 0.00988],
-        "litter_consumption_woody": [0.4773833, 0.385701, 0.373456, 0.162192],
-        "litter_consumption_below_metabolic": [0.010373, 0.005794, 0.010181, 0.013494],
-        "litter_consumption_below_structural": [0.013547, 0.011674, 0.012738, 0.009168],
-        "herbivory_waste_leaf_carbon": [3e-5, 2.1e-3, 2.85e-3, 2.7e-3],
-        "herbivory_waste_leaf_nitrogen": [23.1, 33.5, 23.1, 17.3],
-        "herbivory_waste_leaf_phosphorus": [212.5, 344.8, 334.8, 420.1],
-        "herbivory_waste_leaf_lignin": [0.13, 0.08, 0.27, 0.22],
-    }
-
-    for var, vals in pool_values.items():
-        data[var] = DataArray(vals, dims=["cell_id"])
-
-    # Vertically structured variables
-    data["soil_temperature"] = lyr_strct.from_template()
-    data["soil_temperature"][lyr_strct.index_topsoil] = 20
-    data["soil_temperature"][lyr_strct.index_subsoil] = [19.5, 18.7, 18.7, 17.6]
-
-    # At present the soil model only uses the top soil layer, so this is the
-    # only one with real test values in
-    data["matric_potential"] = lyr_strct.from_template()
-    data["matric_potential"][lyr_strct.index_topsoil] = [-10.0, -25.0, -100.0, -100.0]
-    data["matric_potential"][lyr_strct.index_subsoil] = [-11.0, -29.5, -123.0, -154.1]
-
-    data["air_temperature"] = lyr_strct.from_template()
-    data["air_temperature"][lyr_strct.index_filled_atmosphere] = np.array(
-        [30.0, 29.844995, 28.87117, 27.206405, 16.145945]
-    )[:, None]
-
-    return data
 
 
 @pytest.fixture

--- a/tests/models/soil/conftest.py
+++ b/tests/models/soil/conftest.py
@@ -1,6 +1,99 @@
 """Collection of fixtures to assist the testing of the soil model."""
 
+import numpy as np
 import pytest
+
+
+@pytest.fixture
+def dummy_carbon_data(fixture_core_components):
+    """Creates a dummy carbon data object for use in tests."""
+    from xarray import DataArray
+
+    from virtual_ecosystem.core.data import Data
+
+    # Setup the data object with four cells.
+    data = Data(fixture_core_components.grid)
+
+    # The required data is now added. This includes the five carbon pools: mineral
+    # associated organic matter, low molecular weight carbon, microbial biomass and
+    # necromass carbon and particulate organic matter. It also includes various factors
+    # of the physical environment: pH, bulk density, soil moisture, soil temperature,
+    # percentage clay in soil.
+    data_values = {
+        "soil_c_pool_lmwc": [0.05, 0.02, 0.1, 0.005],
+        "soil_c_pool_maom": [2.5, 1.7, 4.5, 0.5],
+        "soil_c_pool_bacteria": [5.8, 2.3, 11.3, 1.0],
+        "soil_c_pool_saprotrophic_fungi": [0.89, 8.55, 2.21, 4.54],
+        "soil_c_pool_arbuscular_mycorrhiza": [0.65, 1.47, 3.92, 9.04],
+        "soil_c_pool_ectomycorrhiza": [0.47, 1.32, 4.2, 3.77],
+        "soil_c_pool_pom": [0.1, 1.0, 0.7, 0.35],
+        "soil_c_pool_necromass": [0.058, 0.015, 0.093, 0.105],
+        "soil_enzyme_pom_bacteria": [0.022679, 0.009576, 0.050051, 0.003010],
+        "soil_enzyme_maom_bacteria": [0.0356, 0.0117, 0.02509, 0.00456],
+        "soil_enzyme_pom_fungi": [0.02607, 0.00575, 0.00646, 0.00441],
+        "soil_enzyme_maom_fungi": [0.008669, 0.006826, 0.003807, 0.002163],
+        "soil_n_pool_don": [0.000571428, 0.00142857, 0.00014285, 0.002857142],
+        "soil_n_pool_particulate": [0.00714285, 0.00071425, 0.00285714, 0.01428571],
+        "soil_n_pool_necromass": [0.00288462, 0.01788462, 0.02019231, 0.01115385],
+        "soil_n_pool_maom": [0.86538462, 0.48076923, 0.32692308, 0.09615385],
+        "soil_n_pool_ammonium": [6.9619638e-5, 0.0049914624, 0.000229067, 0.0051955339],
+        "soil_n_pool_nitrate": [0.0024219014, 0.0044442996, 0.0003428348, 0.0131405173],
+        "soil_p_pool_dop": [5.714e-6, 2.2857120e-5, 5.7142800e-5, 1.1428568e-4],
+        "soil_p_pool_particulate": [2.857e-5, 2.85714e-4, 1.142856e-4, 5.714284e-4],
+        "soil_p_pool_necromass": [0.00080769, 0.00011538, 0.00071538, 0.00044615],
+        "soil_p_pool_maom": [0.01307692, 0.03461538, 0.01923077, 0.00384615],
+        "soil_p_pool_primary": [0.0019594, 0.00535662, 0.00277434, 0.00059892],
+        "soil_p_pool_secondary": [0.00705668, 0.03816896, 0.01152589, 0.00733107],
+        "soil_p_pool_labile": [1.0582393e-5, 3.252961e-5, 6.806745e-5, 1.945635e-4],
+        "pH": [3.0, 7.5, 9.0, 5.7],
+        "bulk_density": [1350.0, 1800.0, 1000.0, 1500.0],
+        "clay_fraction": [0.8, 0.3, 0.1, 0.9],
+        "litter_C_mineralisation_rate": [0.00212106, 0.00106053, 0.00049000, 0.0055],
+        "litter_N_mineralisation_rate": [3.5351e-5, 7.0702e-5, 0.000183, 1.63333e-5],
+        "litter_P_mineralisation_rate": [7.32e-6, 1.41404e-6, 2.82808e-6, 6.53332e-7],
+        "vertical_flow": [0.1, 0.5, 2.5, 1.59],
+        "plant_symbiote_carbon_supply": [0.01, 0.25, 0.0075, 0.0047],
+        "root_carbohydrate_exudation": [0.025, 0.01, 0.05, 0.0025],
+        "plant_ammonium_uptake": [5.0e-5, 2.5e-5, 1.0e-5, 1.0e-4],
+        "plant_nitrate_uptake": [7.5e-4, 1.0e-3, 2.5e-4, 1.0e-4],
+        "plant_phosphorus_uptake": [3.0e-6, 5e-5, 2.0e-6, 1.0e-6],
+        "plant_n_uptake_arbuscular": [2.07e-5, 3.12e-5, 3.57e-6, 6.98e-5],
+        "plant_n_uptake_ecto": [3.07e-5, 4.20e-5, 4.02e-6, 2.98e-5],
+        "plant_p_uptake_arbuscular": [1.57e-6, 5.07e-5, 2.13e-6, 1.81e-6],
+        "plant_p_uptake_ecto": [1.78e-6, 5.64e-5, 1.07e-6, 9.90e-7],
+    }
+
+    for var_name, var_values in data_values.items():
+        data[var_name] = DataArray(var_values, dims=["cell_id"])
+
+    # The layer dependent data has to be handled separately - at present all of these
+    # are defined only for the topsoil layer
+    lyr_str = fixture_core_components.layer_structure
+
+    data["soil_moisture"] = lyr_str.from_template()
+    data["soil_moisture"][lyr_str.index_all_soil] = np.array(
+        [
+            [232.61550125, 196.88733175, 126.065797, 75.63195175],
+            [66.248474, 194.91137, 121.29988, 52.04422],
+        ]
+    )
+
+    data["matric_potential"] = lyr_str.from_template()
+    data["matric_potential"][lyr_str.index_all_soil] = np.array(
+        [[-3.0, -10.0, -250.0, -10000.0], [-2.8625, -8.978, -137.8, -8553.25]]
+    )
+
+    data["soil_temperature"] = lyr_str.from_template()
+    data["soil_temperature"][lyr_str.index_all_soil] = np.array(
+        [[35.0, 37.5, 40.0, 25.0], [22.5, 22.5, 22.5, 22.5]]
+    )
+
+    data["air_temperature"] = lyr_str.from_template()
+    data["air_temperature"][lyr_str.index_filled_atmosphere] = np.array(
+        [30.0, 29.844995, 28.87117, 27.206405, 16.145945]
+    )[:, None]
+
+    return data
 
 
 @pytest.fixture
@@ -11,6 +104,7 @@ def fixture_soil_config(microbial_groups_cfg):
     return Config(
         cfg_strings=[
             "[core]\n[core.timing]\nupdate_interval = '12 hours'",
+            "[hydrology]",
             microbial_groups_cfg,
         ]
     )

--- a/tests/models/soil/test_pools.py
+++ b/tests/models/soil/test_pools.py
@@ -14,6 +14,7 @@ def test_calculate_all_pool_updates(
 ):
     """Test that the two pool update functions work correctly."""
     from virtual_ecosystem.core.constants import CoreConsts
+    from virtual_ecosystem.models.hydrology.constants import HydroConsts
     from virtual_ecosystem.models.soil.pools import SoilPools
     from virtual_ecosystem.models.soil.soil_model import SoilModel, make_slices
 
@@ -92,8 +93,8 @@ def test_calculate_all_pool_updates(
         "soil_n_pool_particulate": [-8.93041e-5, 5.105645e-5, 9.035108e-5, 5.212779e-6],
         "soil_n_pool_necromass": [7.37406e-3, -1.87488e-3, 4.96976e-3, -1.53633e-7],
         "soil_n_pool_maom": [1.183733e-3, 1.082948e-2, 1.343197e-2, 7.72882e-3],
-        "soil_n_pool_ammonium": [0.00015706, 0.00827393, -0.00015937, -0.00036155],
-        "soil_n_pool_nitrate": [-0.00316048, -0.00395995, -0.00106993, -0.00097339],
+        "soil_n_pool_ammonium": [0.00015831, 0.00844271, -0.00014193, -0.00011499],
+        "soil_n_pool_nitrate": [-0.00303913, -0.00393326, -0.00108282, -0.00138761],
         "soil_p_pool_dop": [2.08332995e-4, 1.02602825e-4, 1.39943896e-4, 8.15796967e-5],
         "soil_p_pool_particulate": [6.820884e-6, -6.40228e-6, -8.6718e-7, 2.094258e-7],
         "soil_p_pool_necromass": [0.00225261, 0.00282114, 0.00596048, 0.0014114],
@@ -116,7 +117,8 @@ def test_calculate_all_pool_updates(
     delta_pools = soil_pools.calculate_all_pool_updates(
         delta_pools_ordered=pool_order,
         layer_structure=fixture_core_components.layer_structure,
-        soil_moisture_capacity=CoreConsts.soil_moisture_capacity,
+        soil_moisture_saturation=HydroConsts.soil_moisture_saturation,
+        soil_moisture_residual=HydroConsts.soil_moisture_residual,
         top_soil_layer_thickness=fixture_core_components.layer_structure.soil_layer_thickness[
             0
         ],

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -64,7 +64,7 @@ def test_soil_model_initialization(
 ):
     """Test `SoilModel` initialization with good data."""
     from virtual_ecosystem.core.base_model import BaseModel
-    from virtual_ecosystem.core.constants import CoreConsts
+    from virtual_ecosystem.models.hydrology.constants import HydroConsts
     from virtual_ecosystem.models.soil.constants import SoilConsts
     from virtual_ecosystem.models.soil.soil_model import SoilModel
 
@@ -74,7 +74,8 @@ def test_soil_model_initialization(
         model_constants=SoilConsts(),
         microbial_groups=functional_groups,
         enzyme_classes=enzyme_classes,
-        soil_moisture_capacity=CoreConsts.soil_moisture_capacity,
+        soil_moisture_saturation=HydroConsts.soil_moisture_saturation,
+        soil_moisture_residual=HydroConsts.soil_moisture_residual,
     )
 
     # In cases where it passes then checks that the object has the right properties
@@ -93,9 +94,9 @@ def test_soil_model_initialization(
 
 def test_soil_model_initialization_no_data(caplog, fixture_core_components):
     """Test `SoilModel` initialization with no data."""
-    from virtual_ecosystem.core.constants import CoreConsts
     from virtual_ecosystem.core.data import Data
     from virtual_ecosystem.core.grid import Grid
+    from virtual_ecosystem.models.hydrology.constants import HydroConsts
     from virtual_ecosystem.models.soil.constants import SoilConsts
     from virtual_ecosystem.models.soil.soil_model import SoilModel
 
@@ -109,7 +110,8 @@ def test_soil_model_initialization_no_data(caplog, fixture_core_components):
             data=empty_data,
             core_components=fixture_core_components,
             model_constants=SoilConsts(),
-            soil_moisture_capacity=CoreConsts.soil_moisture_capacity,
+            soil_moisture_saturation=HydroConsts.soil_moisture_saturation,
+            soil_moisture_residual=HydroConsts.soil_moisture_residual,
         )
 
     # Final check that expected logging entries are produced: modify shared
@@ -141,7 +143,7 @@ def test_soil_model_initialization_bounds_error(
     enzyme_classes,
 ):
     """Test `SoilModel` initialization."""
-    from virtual_ecosystem.core.constants import CoreConsts
+    from virtual_ecosystem.models.hydrology.constants import HydroConsts
     from virtual_ecosystem.models.soil.constants import SoilConsts
     from virtual_ecosystem.models.soil.soil_model import SoilModel
 
@@ -158,7 +160,8 @@ def test_soil_model_initialization_bounds_error(
             model_constants=SoilConsts(),
             microbial_groups=functional_groups,
             enzyme_classes=enzyme_classes,
-            soil_moisture_capacity=CoreConsts.soil_moisture_capacity,
+            soil_moisture_saturation=HydroConsts.soil_moisture_saturation,
+            soil_moisture_residual=HydroConsts.soil_moisture_residual,
         )
 
     # Final check that expected logging entries are produced
@@ -176,7 +179,7 @@ def test_soil_model_all_pools_positive(
     dummy_carbon_data, fixture_core_components, functional_groups, enzyme_classes
 ):
     """Test `SoilModel` initialization."""
-    from virtual_ecosystem.core.constants import CoreConsts
+    from virtual_ecosystem.models.hydrology.constants import HydroConsts
     from virtual_ecosystem.models.soil.constants import SoilConsts
     from virtual_ecosystem.models.soil.soil_model import SoilModel
 
@@ -187,7 +190,8 @@ def test_soil_model_all_pools_positive(
         model_constants=SoilConsts(),
         microbial_groups=functional_groups,
         enzyme_classes=enzyme_classes,
-        soil_moisture_capacity=CoreConsts.soil_moisture_capacity,
+        soil_moisture_saturation=HydroConsts.soil_moisture_saturation,
+        soil_moisture_residual=HydroConsts.soil_moisture_residual,
     )
 
     assert soil_model._all_pools_positive()
@@ -214,6 +218,7 @@ def test_soil_model_all_pools_positive(
                     "Information required to initialise the soil model successfully "
                     "extracted.",
                 ),
+                (INFO, "Initialised hydrology.HydroConsts from config"),
                 *POST_SETUP_LOG,
             ),
             id="default_config",
@@ -229,6 +234,7 @@ def test_soil_model_all_pools_positive(
                     "Information required to initialise the soil model successfully "
                     "extracted.",
                 ),
+                (INFO, "Initialised hydrology.HydroConsts from config"),
                 *POST_SETUP_LOG,
             ),
             id="modified_config_correct",
@@ -269,6 +275,7 @@ def test_generate_soil_model(
     config = Config(
         cfg_strings=[
             "[core]\n[core.timing]\nupdate_interval = '12 hours'",
+            "[hydrology]",
             microbial_groups_cfg,
             cfg_string,
         ]
@@ -351,32 +358,32 @@ def test_update(mocker, fixture_soil_model, dummy_carbon_data):
             Dataset(
                 data_vars=dict(
                     soil_c_pool_lmwc=DataArray(
-                        [0.1097977, 0.08066918, 0.22770166, 0.02521316], dims="cell_id"
+                        [0.10980402, 0.08066933, 0.22770165, 0.02521316], dims="cell_id"
                     ),
                     soil_c_pool_maom=DataArray(
-                        [2.51940048, 1.70920048, 4.53481807, 0.53791779], dims="cell_id"
+                        [2.51940049, 1.70920048, 4.53481807, 0.53791779], dims="cell_id"
                     ),
                     soil_c_pool_bacteria=DataArray(
-                        [5.77889239, 2.29145764, 11.25657168, 0.99683277],
+                        [5.77889242, 2.29145764, 11.25657168, 0.99683277],
                         dims="cell_id",
                     ),
                     soil_c_pool_saprotrophic_fungi=DataArray(
-                        [0.88679018, 8.51916395, 2.20173925, 4.52568296],
+                        [0.88679019, 8.51916391, 2.20173925, 4.52568296],
                         dims="cell_id",
                     ),
                     soil_c_pool_arbuscular_mycorrhiza=DataArray(
-                        [0.64718162, 1.45308446, 3.90621243, 9.0125375],
+                        [0.6471779, 1.45308443, 3.90621243, 9.0125375],
                         dims="cell_id",
                     ),
                     soil_c_pool_ectomycorrhiza=DataArray(
-                        [0.46739663, 1.30220503, 4.18541771, 3.75846664],
+                        [0.46739394, 1.30220501, 4.18541771, 3.75846664],
                         dims="cell_id",
                     ),
                     soil_c_pool_pom=DataArray(
                         [0.10019111, 0.98701477, 0.68907143, 0.35261003], dims="cell_id"
                     ),
                     soil_c_pool_necromass=DataArray(
-                        [0.06031719, 0.05107949, 0.12718561, 0.11319461], dims="cell_id"
+                        [0.06031718, 0.05107949, 0.12718561, 0.11319461], dims="cell_id"
                     ),
                     soil_enzyme_pom_bacteria=DataArray(
                         [0.02240911, 0.0094626, 0.04945794, 0.00297422], dims="cell_id"
@@ -391,7 +398,7 @@ def test_update(mocker, fixture_soil_model, dummy_carbon_data):
                         [0.00856584, 0.00675221, 0.00380823, 0.00215509], dims="cell_id"
                     ),
                     soil_n_pool_don=DataArray(
-                        [0.00150075, 0.00495466, 0.00250708, 0.00384036], dims="cell_id"
+                        [0.00150074, 0.00495467, 0.00250707, 0.00384036], dims="cell_id"
                     ),
                     soil_n_pool_particulate=DataArray(
                         [0.00709876, 0.00073966, 0.00290218, 0.01428834], dims="cell_id"
@@ -403,15 +410,15 @@ def test_update(mocker, fixture_soil_model, dummy_carbon_data):
                         [0.86652874, 0.48604323, 0.33400667, 0.10001761], dims="cell_id"
                     ),
                     soil_n_pool_ammonium=DataArray(
-                        [0.0001654, 0.00990519, 0.00034459, 0.00499734],
+                        [0.00017846, 0.01036292, 0.00034387, 0.00499818],
                         dims="cell_id",
                     ),
                     soil_n_pool_nitrate=DataArray(
-                        [0.00030108, 0.00088655, -0.00017664, 0.0123951],
+                        [0.00010727, 0.00026967, -0.0001751, 0.01266751],
                         dims="cell_id",
                     ),
                     soil_p_pool_dop=DataArray(
-                        [0.00015749, 0.00010922, 0.00024066, 0.00018748], dims="cell_id"
+                        [0.00015754, 0.00010922, 0.00024066, 0.00018748], dims="cell_id"
                     ),
                     soil_p_pool_particulate=DataArray(
                         [3.19672137e-5, 2.82555855e-4, 1.13864329e-4, 5.71534052e-4],
@@ -636,6 +643,7 @@ def test_construct_full_soil_model(
 ):
     """Test that the function that creates the object to integrate exists and works."""
     from virtual_ecosystem.core.constants import CoreConsts
+    from virtual_ecosystem.models.hydrology.constants import HydroConsts
     from virtual_ecosystem.models.soil.constants import SoilConsts
     from virtual_ecosystem.models.soil.soil_model import (
         SoilModel,
@@ -707,14 +715,14 @@ def test_construct_full_soil_model(
         1.082948e-2,
         1.343197e-2,
         7.72882e-3,
-        0.00015706,
-        0.00827393,
-        -0.00015937,
-        -0.00036155,
-        -0.00316048,
-        -0.00395995,
-        -0.00106993,
-        -0.00097339,
+        0.00015831,
+        0.00844271,
+        -0.00014193,
+        -0.00011499,
+        -0.00303913,
+        -0.00393326,
+        -0.00108282,
+        -0.00138761,
         2.08332995e-4,
         1.02602825e-4,
         1.39943896e-4,
@@ -772,7 +780,8 @@ def test_construct_full_soil_model(
         functional_groups=functional_groups,
         enzyme_classes=enzyme_classes,
         max_depth_of_microbial_activity=CoreConsts.max_depth_of_microbial_activity,
-        soil_moisture_capacity=CoreConsts.soil_moisture_capacity,
+        soil_moisture_saturation=HydroConsts.soil_moisture_saturation,
+        soil_moisture_residual=HydroConsts.soil_moisture_residual,
         top_soil_layer_thickness=fixture_core_components.layer_structure.soil_layer_thickness[
             0
         ],

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,40 +15,30 @@ from virtual_ecosystem.main import ve_run
 from .conftest import log_check
 
 INITIALISATION_LOG = [
-    (INFO, "Initialising models: soil"),
-    (INFO, "Initialised soil.SoilConsts from config"),
+    (INFO, "Initialising models: litter"),
+    (INFO, "Initialised litter.LitterConsts from config"),
     (
         INFO,
-        "Information required to initialise the soil model successfully extracted.",
+        "Information required to initialise the litter model successfully extracted.",
     ),
-    (DEBUG, "soil model: required var 'soil_c_pool_maom' checked"),
-    (DEBUG, "soil model: required var 'soil_c_pool_lmwc' checked"),
-    (DEBUG, "soil model: required var 'soil_c_pool_bacteria' checked"),
-    (DEBUG, "soil model: required var 'soil_c_pool_saprotrophic_fungi' checked"),
-    (DEBUG, "soil model: required var 'soil_c_pool_arbuscular_mycorrhiza' checked"),
-    (DEBUG, "soil model: required var 'soil_c_pool_ectomycorrhiza' checked"),
-    (DEBUG, "soil model: required var 'soil_c_pool_pom' checked"),
-    (DEBUG, "soil model: required var 'soil_c_pool_necromass' checked"),
-    (DEBUG, "soil model: required var 'soil_enzyme_pom_bacteria' checked"),
-    (DEBUG, "soil model: required var 'soil_enzyme_maom_bacteria' checked"),
-    (DEBUG, "soil model: required var 'soil_enzyme_pom_fungi' checked"),
-    (DEBUG, "soil model: required var 'soil_enzyme_maom_fungi' checked"),
-    (DEBUG, "soil model: required var 'soil_n_pool_don' checked"),
-    (DEBUG, "soil model: required var 'soil_n_pool_particulate' checked"),
-    (DEBUG, "soil model: required var 'soil_n_pool_necromass' checked"),
-    (DEBUG, "soil model: required var 'soil_n_pool_maom' checked"),
-    (DEBUG, "soil model: required var 'soil_n_pool_ammonium' checked"),
-    (DEBUG, "soil model: required var 'soil_n_pool_nitrate' checked"),
-    (DEBUG, "soil model: required var 'soil_p_pool_dop' checked"),
-    (DEBUG, "soil model: required var 'soil_p_pool_particulate' checked"),
-    (DEBUG, "soil model: required var 'soil_p_pool_necromass' checked"),
-    (DEBUG, "soil model: required var 'soil_p_pool_maom' checked"),
-    (DEBUG, "soil model: required var 'soil_p_pool_primary' checked"),
-    (DEBUG, "soil model: required var 'soil_p_pool_secondary' checked"),
-    (DEBUG, "soil model: required var 'soil_p_pool_labile' checked"),
-    (DEBUG, "soil model: required var 'pH' checked"),
-    (DEBUG, "soil model: required var 'bulk_density' checked"),
-    (DEBUG, "soil model: required var 'clay_fraction' checked"),
+    (DEBUG, "litter model: required var 'litter_pool_above_metabolic' checked"),
+    (DEBUG, "litter model: required var 'litter_pool_above_structural' checked"),
+    (DEBUG, "litter model: required var 'litter_pool_woody' checked"),
+    (DEBUG, "litter model: required var 'litter_pool_below_metabolic' checked"),
+    (DEBUG, "litter model: required var 'litter_pool_below_structural' checked"),
+    (DEBUG, "litter model: required var 'lignin_above_structural' checked"),
+    (DEBUG, "litter model: required var 'lignin_woody' checked"),
+    (DEBUG, "litter model: required var 'lignin_below_structural' checked"),
+    (DEBUG, "litter model: required var 'c_n_ratio_above_metabolic' checked"),
+    (DEBUG, "litter model: required var 'c_n_ratio_above_structural' checked"),
+    (DEBUG, "litter model: required var 'c_n_ratio_woody' checked"),
+    (DEBUG, "litter model: required var 'c_n_ratio_below_metabolic' checked"),
+    (DEBUG, "litter model: required var 'c_n_ratio_below_structural' checked"),
+    (DEBUG, "litter model: required var 'c_p_ratio_above_metabolic' checked"),
+    (DEBUG, "litter model: required var 'c_p_ratio_above_structural' checked"),
+    (DEBUG, "litter model: required var 'c_p_ratio_woody' checked"),
+    (DEBUG, "litter model: required var 'c_p_ratio_below_metabolic' checked"),
+    (DEBUG, "litter model: required var 'c_p_ratio_below_structural' checked"),
 ]
 
 
@@ -56,25 +46,18 @@ INITIALISATION_LOG = [
     "cfg_strings,output,raises,expected_log_entries",
     [
         pytest.param(
-            '[core.timing]\nupdate_interval = "7 days"\n[soil]\n',
-            "SoilModel(update_interval=604800 seconds)",
+            '[core.timing]\nupdate_interval = "7 days"\n[litter]\n',
+            "LitterModel(update_interval=604800 seconds)",
             does_not_raise(),
             tuple(
                 [
                     *INITIALISATION_LOG,
-                    (INFO, "Adding data array for 'dissolved_nitrate'"),
-                    (INFO, "Adding data array for 'dissolved_ammonium'"),
-                    (INFO, "Adding data array for 'dissolved_phosphorus'"),
-                    (INFO, "Adding data array for 'ecto_supply_limit_n'"),
-                    (INFO, "Adding data array for 'ecto_supply_limit_p'"),
-                    (INFO, "Adding data array for 'arbuscular_supply_limit_n'"),
-                    (INFO, "Adding data array for 'arbuscular_supply_limit_p'"),
                 ],
             ),
             id="valid config",
         ),
         pytest.param(
-            '[core.timing]\nupdate_interval = "1 minute"\n[soil]\n',
+            '[core.timing]\nupdate_interval = "1 minute"\n[litter]\n',
             None,
             pytest.raises(InitialisationError),
             tuple(
@@ -82,16 +65,16 @@ INITIALISATION_LOG = [
                     *INITIALISATION_LOG,
                     (
                         ERROR,
-                        "The update interval is faster than the soil "
+                        "The update interval is faster than the litter "
                         "lower bound of 30 minute.",
                     ),
-                    (CRITICAL, "Configuration failed for models: soil"),
+                    (CRITICAL, "Configuration failed for models: litter"),
                 ],
             ),
             id="update interval too short",
         ),
         pytest.param(
-            '[core.timing]\nupdate_interval = "1 year"\n[soil]\n',
+            '[core.timing]\nupdate_interval = "1 year"\n[litter]\n',
             None,
             pytest.raises(InitialisationError),
             tuple(
@@ -99,10 +82,10 @@ INITIALISATION_LOG = [
                     *INITIALISATION_LOG,
                     (
                         ERROR,
-                        "The update interval is slower than the soil "
+                        "The update interval is slower than the litter "
                         "upper bound of 3 month.",
                     ),
-                    (CRITICAL, "Configuration failed for models: soil"),
+                    (CRITICAL, "Configuration failed for models: litter"),
                 ],
             ),
             id="update interval too long",
@@ -111,8 +94,7 @@ INITIALISATION_LOG = [
 )
 def test_initialise_models(
     caplog,
-    dummy_carbon_data,
-    microbial_groups_cfg,
+    dummy_litter_data,
     cfg_strings,
     output,
     raises,
@@ -126,14 +108,14 @@ def test_initialise_models(
 
     # Generate a configuration to use, using simple inputs to populate most from
     # defaults. Then clear the caplog to isolate the logging for the function,
-    config = Config(cfg_strings=[cfg_strings, microbial_groups_cfg])
+    config = Config(cfg_strings=cfg_strings)
     core_components = CoreComponents(config)
     caplog.clear()
 
     with raises:
         models = initialise_models(
             config=config,
-            data=dummy_carbon_data,
+            data=dummy_litter_data,
             core_components=core_components,
             models=config.model_classes,
         )
@@ -141,7 +123,7 @@ def test_initialise_models(
         if output is None:
             assert models == [None]
         else:
-            assert repr(models["soil"]) == output
+            assert repr(models["litter"]) == output
 
     log_check(caplog, expected_log_entries)
 

--- a/virtual_ecosystem/models/hydrology/below_ground.py
+++ b/virtual_ecosystem/models/hydrology/below_ground.py
@@ -6,6 +6,10 @@ matric potential, groundwater storage, and subsurface horizontal flow.
 import numpy as np
 from numpy.typing import NDArray
 
+from virtual_ecosystem.models.hydrology.hydrology_tools import (
+    calculate_effective_saturation,
+)
+
 
 def calculate_vertical_flow(
     soil_moisture: NDArray[np.float32],
@@ -92,9 +96,10 @@ def calculate_vertical_flow(
     shape_parameter = 1 - 1 / van_genuchten_nonlinearily_parameter
 
     # Calculate soil effective saturation in rel. vol. water content for each layer:
-    # TODO make this function a tool
-    effective_saturation = (soil_moisture - soil_moisture_residual) / (
-        soil_moisture_saturation - soil_moisture_residual
+    effective_saturation = calculate_effective_saturation(
+        soil_moisture=soil_moisture,
+        soil_moisture_saturation=soil_moisture_saturation,
+        soil_moisture_residual=soil_moisture_residual,
     )
 
     # Calculate matric potential for each grid point and depth

--- a/virtual_ecosystem/models/hydrology/hydrology_tools.py
+++ b/virtual_ecosystem/models/hydrology/hydrology_tools.py
@@ -281,3 +281,27 @@ def check_precipitation_surface(precipitation_surface: NDArray[np.float32]) -> N
             "Surface precipitation should not be negative! Consider checking that the"
             " canopy water balance is correct."
         )
+
+
+def calculate_effective_saturation(
+    soil_moisture: NDArray[np.float32],
+    soil_moisture_saturation: float | NDArray[np.float32],
+    soil_moisture_residual: float | NDArray[np.float32],
+) -> NDArray[np.float32]:
+    """Calculate the effective soil saturation based on the soil moisture.
+
+    This is kept as a separate function because the soil model also needs to use this
+    quantity.
+
+    Args:
+        soil_moisture: Volumetric relative water content in top soil, [unitless]
+        soil_moisture_saturation: Soil moisture saturation, [unitless]
+        soil_moisture_residual: Residual soil moisture, [unitless]
+
+    Returns:
+        The :term:`effective saturation` of the soil [unitless]
+    """
+
+    return (soil_moisture - soil_moisture_residual) / (
+        soil_moisture_saturation - soil_moisture_residual
+    )

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -14,6 +14,9 @@ from scipy.constants import convert_temperature
 
 from virtual_ecosystem.core.core_components import LayerStructure
 from virtual_ecosystem.core.data import Data
+from virtual_ecosystem.models.hydrology.hydrology_tools import (
+    calculate_effective_saturation,
+)
 from virtual_ecosystem.models.litter.env_factors import (
     average_temperature_over_microbially_active_layers,
     average_water_potential_over_microbially_active_layers,
@@ -395,7 +398,8 @@ class SoilPools:
         self,
         delta_pools_ordered: dict[str, NDArray[np.float32]],
         layer_structure: LayerStructure,
-        soil_moisture_capacity: float,
+        soil_moisture_saturation: float,
+        soil_moisture_residual: float,
         top_soil_layer_thickness: float,
     ) -> NDArray[np.float32]:
         """Calculate net change for all soil pools.
@@ -419,9 +423,9 @@ class SoilPools:
                 pools are stored in the initial condition vector.
             layer_structure: The details of the layer structure used across the Virtual
                 Ecosystem.
-            soil_moisture_capacity: Soil moisture capacity, i.e. the maximum
-                (volumetric) moisture the soil can hold [unitless].
-            top_soil_layer_thickness: Thickness of the topsoil layer [mm].
+            soil_moisture_saturation: The :term:`soil moisture saturation` [unitless].
+            soil_moisture_residual: The :term:`soil moisture residual` [unitless].
+            top_soil_layer_thickness: Thickness of the topsoil layer [m].
 
         Returns:
             A vector containing net changes to each pool. Order [lmwc, maom].
@@ -443,11 +447,12 @@ class SoilPools:
         soil_moisture = find_total_soil_moisture_for_microbially_active_depth(
             soil_moistures=self.data["soil_moisture"], layer_structure=layer_structure
         )
-        # Calculate the effective saturation of the soil (soil layer thickness needs to
-        # be converted from m to mm here to be consistent with soil moisture units)
-        # TODO - This needs to be reviewed as part of the soil abiotic links review
-        effective_saturation = soil_moisture / (
-            soil_moisture_capacity * top_soil_layer_thickness * 1e3
+        # Calculate the effective saturation of the soil (soil moistures need to be
+        # converted from mm to a unitless measure for this to work).
+        effective_saturation = calculate_effective_saturation(
+            soil_moisture=soil_moisture / (top_soil_layer_thickness * 1e3),
+            soil_moisture_saturation=soil_moisture_saturation,
+            soil_moisture_residual=soil_moisture_residual,
         )
         # Find supply rate to each plant symbiotic group
         carbon_supply = calculate_symbiotic_carbon_supply(

--- a/virtual_ecosystem/models/soil/soil_model.py
+++ b/virtual_ecosystem/models/soil/soil_model.py
@@ -234,6 +234,9 @@ class SoilModel(
             config, enzyme_classes=enzyme_classes
         )
 
+        # Load hydrology constants
+        hydro_constants = load_constants(config, "hydrology", "HydroConsts")
+
         return cls(
             data=data,
             core_components=core_components,
@@ -241,6 +244,8 @@ class SoilModel(
             model_constants=model_constants,
             microbial_groups=microbial_groups,
             enzyme_classes=enzyme_classes,
+            soil_moisture_saturation=hydro_constants.soil_moisture_saturation,
+            soil_moisture_residual=hydro_constants.soil_moisture_residual,
         )
 
     def _setup(
@@ -248,6 +253,8 @@ class SoilModel(
         model_constants: SoilConsts,
         microbial_groups: dict[str, MicrobialGroupConstants],
         enzyme_classes: dict[str, EnzymeConstants],
+        soil_moisture_saturation: float,
+        soil_moisture_residual: float,
         **kwargs: Any,
     ) -> None:
         """Function to setup up the soil model."""
@@ -257,6 +264,10 @@ class SoilModel(
         # Store microbial functional groups and enzyme classes needed by the model
         self.microbial_groups = microbial_groups
         self.enzyme_classes = enzyme_classes
+
+        # Store the two required hydrology constants
+        self.soil_moisture_saturation = soil_moisture_saturation
+        self.soil_moisture_residual = soil_moisture_residual
 
         # Calculate dissolved amounts of each inorganic nutrient
         dissolved_nutrient_pools = self.calculate_dissolved_nutrient_concentrations()
@@ -380,7 +391,8 @@ class SoilModel(
                 self.microbial_groups,
                 self.enzyme_classes,
                 self.core_constants.max_depth_of_microbial_activity,
-                self.core_constants.soil_moisture_capacity,
+                self.soil_moisture_saturation,
+                self.soil_moisture_residual,
                 self.layer_structure.soil_layer_thickness[0],
             ),
         )
@@ -663,7 +675,8 @@ def construct_full_soil_model(
     functional_groups: dict[str, MicrobialGroupConstants],
     enzyme_classes: dict[str, EnzymeConstants],
     max_depth_of_microbial_activity: float,
-    soil_moisture_capacity: float,
+    soil_moisture_saturation: float,
+    soil_moisture_residual: float,
     top_soil_layer_thickness: float,
 ) -> NDArray[np.float32]:
     """Function that constructs the full soil model in a solve_ivp friendly form.
@@ -684,9 +697,11 @@ def construct_full_soil_model(
         enzyme_classes: Set of enzyme classes used by the soil model.
         max_depth_of_microbial_activity: Maximum depth of the soil profile where
             microbial activity occurs [m].
-        soil_moisture_capacity: Soil moisture capacity, i.e. the maximum
+        soil_moisture_saturation: :term:`soil moisture saturation`, i.e. the maximum
             (volumetric) moisture the soil can hold [unitless].
-        top_soil_layer_thickness: Thickness of the topsoil layer [mm].
+        soil_moisture_residual: :term:`soil moisture residual`, i.e. the minimum
+            (volumetric) moisture the soil can hold [unitless].
+        top_soil_layer_thickness: Thickness of the topsoil layer [m].
 
     Returns:
         The rate of change for each soil pool
@@ -712,8 +727,8 @@ def construct_full_soil_model(
     return soil_pools.calculate_all_pool_updates(
         delta_pools_ordered=delta_pools_ordered,
         layer_structure=layer_structure,
-        # TODO - This needs to be reconsidered as part of the soil-abiotic links review
-        soil_moisture_capacity=soil_moisture_capacity,
+        soil_moisture_saturation=soil_moisture_saturation,
+        soil_moisture_residual=soil_moisture_residual,
         top_soil_layer_thickness=top_soil_layer_thickness,
     )
 


### PR DESCRIPTION
# Description

The effective saturation calculation has now been added as a function in hydrology tools, so that the hydrology model and the soil model use the same calculation.

The soil model now uses `soil_moisture_saturation` and `soil_moisture_saturation` from `HydroConsts` rather than `soil_moisture_capacity` from `CoreConsts` which should unblock #880

I also changed the core testing to use the litter model as a test case rather than the soil model. This has been annoying me for a while, and I reached breaking point so switching the testing to use the simpler model.

Fixes #770

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
