### PR TITLE
Silence unneeded divide by zero warnings

### DIFF
--- a/virtual_ecosystem/models/soil/uptake.py
+++ b/virtual_ecosystem/models/soil/uptake.py
@@ -275,10 +275,15 @@ def find_net_nutrient_consumptions_free_living(
         The net consumption/production of each nutrient class [kg m^-3 day^-1].
     """
 
-    # Determine how limiting carbon is (as a proportion)
-    carbon_limitation = actual_carbon_gain / (
-        max_uptake_rates.carbon * carbon_use_efficiency
-    )
+    # Determine how limiting carbon is (as a proportion). The zero carbon uptake case is
+    # handled by assuming that carbon limitation is total in this case. Divide by zero
+    # warnings are turned off because this is explicitly handled.
+    with np.errstate(divide="ignore", invalid="ignore"):
+        carbon_limitation = np.where(
+            max_uptake_rates.carbon > 0,
+            actual_carbon_gain / (max_uptake_rates.carbon * carbon_use_efficiency),
+            1,
+        )
 
     # Calculate biomass demands for nitrogen and phosphorus
     nitrogen_demand = (

--- a/virtual_ecosystem/models/soil/uptake.py
+++ b/virtual_ecosystem/models/soil/uptake.py
@@ -460,12 +460,15 @@ def find_net_nutrient_consumptions_symbiotic(
 
     # For immobilisation of nitrogen, the proportion of ammonium and nitrate taken up
     # follows the proportion of the maximum uptake rates (if either is above zero)
-    ammonium_uptake_proportion = np.where(
-        (max_uptake_rates.ammonium > 0) | (max_uptake_rates.nitrate > 0),
-        max_uptake_rates.ammonium
-        / (max_uptake_rates.ammonium + max_uptake_rates.nitrate),
-        0.0,
-    )
+    # I explicitly handle the divide by zero case here, so that error state is ignored
+    # to prevent runtime warnings related to something that I have actually handled.
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ammonium_uptake_proportion = np.where(
+            (max_uptake_rates.ammonium > 0) | (max_uptake_rates.nitrate > 0),
+            max_uptake_rates.ammonium
+            / (max_uptake_rates.ammonium + max_uptake_rates.nitrate),
+            0.0,
+        )
 
     # Whether the uptake proportion or the mineralisation proportion is relevant depends
     # whether inorganic nitrogen is being taken up or not


### PR DESCRIPTION
# Description

This PR reduces the amount of runtime warnings that get emitted by `ve_run`.

In one case, this was happening for a calculation that already handled the divide by zero case. In this case I used the `np.errstate` to silence the relevant warning.

In the other case, the divide by zero case wasn't handled so I added handling for this, and silenced the relevant warning.

Fixes #885

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
