### PR TITLE
Stop negative growth rates from resulting in negative enzyme productions

### DIFF
--- a/tests/models/soil/test_pools.py
+++ b/tests/models/soil/test_pools.py
@@ -414,15 +414,15 @@ def test_calculate_enzyme_changes(soil_pool_data, enzyme_production, enzyme_clas
             -0.00010931,
         ],
         "net_change_pom_fungi": [
-            -6.29372863e-4,
-            -2.34035315e-4,
-            -1.07468399e-4,
+            -0.000625573463,
+            -0.000124303515,
+            -0.000107468399,
             -8.01794976e-5,
         ],
         "net_change_maom_fungi": [
-            -2.11748863e-4,
-            -2.59859315e-4,
-            -4.37963990e-5,
+            -0.000207949463,
+            -0.000150127515,
+            -4.3796399e-5,
             -2.62514976e-5,
         ],
         "denaturation_maom_bacteria": [0.0008544, 0.0002808, 0.00060216, 0.00010944],
@@ -479,8 +479,8 @@ def test_calculate_enzyme_production(functional_groups, growth_rates):
     expected_production = {
         "bacteria_pom": [2.77675102e-07, 1.47377060e-6, 6.05047838e-6, 1.33284114e-7],
         "bacteria_maom": [2.77675102e-7, 1.47377060e-6, 6.05047838e-6, 1.33284114e-7],
-        "fungi_pom": [-3.69286270e-6, -9.60353150e-5, 4.75716010e-5, 2.56605024e-5],
-        "fungi_maom": [-3.69286270e-6, -9.60353150e-5, 4.75716010e-5, 2.56605024e-5],
+        "fungi_pom": [1.065373e-7, 1.3696485e-5, 4.7571601e-5, 2.56605024e-5],
+        "fungi_maom": [1.065373e-7, 1.3696485e-5, 4.7571601e-5, 2.56605024e-5],
     }
 
     actual_production = calculate_enzyme_production(

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -1241,13 +1241,19 @@ def calculate_enzyme_production(
 
     for group in microbial_groups.values():
         for substrate in group.find_enzyme_substrates():
-            if f"{group.taxonomic_group}_{substrate}" in production_rates.keys():
-                production_rates[f"{group.taxonomic_group}_{substrate}"] += (
-                    growth_rates[group.name] * group.enzyme_production[substrate]
+            enzyme_class = f"{group.taxonomic_group}_{substrate}"
+
+            # This step catches negative growth rates (which can occur for mycorrhizal
+            # fungi, but shouldn't produce a negative amount of enzyme)
+            growth = np.where(growth_rates[group.name] > 0, growth_rates[group.name], 0)
+
+            if enzyme_class in production_rates.keys():
+                production_rates[enzyme_class] += (
+                    growth * group.enzyme_production[substrate]
                 )
             else:
-                production_rates[f"{group.taxonomic_group}_{substrate}"] = (
-                    growth_rates[group.name] * group.enzyme_production[substrate]
+                production_rates[enzyme_class] = (
+                    growth * group.enzyme_production[substrate]
                 )
 
     return production_rates


### PR DESCRIPTION
# Description

This PR changes the calculation of enzyme production so that when microbial growth rates are negative (which can happen if mycorrhiza can't meet nutrient demands) the enzyme production rates don't go negative

Fixes #892

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
