### PR TITLE
880 soil moisture capacity needs to come out of core constants

### DIFF
--- a/tests/models/hydrology/test_above_ground.py
+++ b/tests/models/hydrology/test_above_ground.py
@@ -113,7 +113,7 @@ def test_calculate_soil_evaporation(dens_air, latvap):
         atmospheric_pressure=np.array([101.0, 101.0, 101.0]),
         soil_moisture=np.array([1.0, 2.0, 5.0]),
         soil_moisture_residual=0.1,
-        soil_moisture_capacity=0.9,
+        soil_moisture_saturation=0.9,
         leaf_area_index=np.array([3.0, 4.0, 5.0]),
         density_air=dens_air,
         latent_heat_vapourisation=latvap,
@@ -361,7 +361,7 @@ def test_calculate_surface_runoff():
     result = calculate_surface_runoff(
         precipitation_surface=np.array([100, 200, 300]),
         top_soil_moisture=np.array([150, 150, 150]),
-        top_soil_moisture_capacity=np.array([200, 400, 400]),
+        top_soil_moisture_saturation=np.array([200, 400, 400]),
     )
 
     np.testing.assert_allclose(result, exp_result, rtol=1e-4, atol=1e-4)

--- a/tests/models/hydrology/test_below_ground.py
+++ b/tests/models/hydrology/test_below_ground.py
@@ -3,7 +3,6 @@
 import numpy as np
 import pytest
 
-from virtual_ecosystem.core.constants import CoreConsts
 from virtual_ecosystem.models.hydrology.constants import HydroConsts
 
 
@@ -71,14 +70,14 @@ def test_update_soil_moisture():
 
     layer_thickness = np.array([[100, 100, 100], [900, 900, 900], [900, 900, 900]])
     exp_result = np.array(
-        [[20.0, 50.0, 47.0], [290.0, 450.0, 450.0], [300.0, 450.0, 450.0]]
+        [[20.0, 51.0, 47.0], [290.0, 459.0, 459.0], [300.0, 459.0, 459.0]]
     )
 
     result = update_soil_moisture(
         soil_moisture=np.array([[30, 60, 50], [300, 600, 500], [300, 600, 500]]),
         vertical_flow=np.array([[10, 2, 3], [10, 2, 3], [15, 25, 35]]),
         transpiration=np.array([10, 2, 3]),
-        soil_moisture_capacity=CoreConsts.soil_moisture_capacity * layer_thickness,
+        soil_moisture_saturation=HydroConsts.soil_moisture_saturation * layer_thickness,
         soil_moisture_residual=HydroConsts.soil_moisture_residual * layer_thickness,
     )
 

--- a/tests/models/hydrology/test_hydrology_model.py
+++ b/tests/models/hydrology/test_hydrology_model.py
@@ -115,24 +115,22 @@ def test_hydrology_model_initialization(
 
 
 @pytest.mark.parametrize(
-    "cfg_string,sm_capacity,raises,expected_log_entries",
+    "cfg_string,sm_saturation,raises,expected_log_entries",
     [
         pytest.param(
             "[core]\n"
             "[hydrology]\ninitial_soil_moisture = 0.5\n"
-            "initial_groundwater_saturation = 0.9\n",
-            0.9,
+            "initial_groundwater_saturation = 0.51\n",
+            0.51,
             does_not_raise(),
-            tuple(
-                [
-                    (INFO, "Initialised hydrology.HydroConsts from config"),
-                    (
-                        INFO,
-                        "Information required to initialise the hydrology model "
-                        "successfully extracted.",
-                    ),
-                    *MODEL_VAR_CHECK_LOG,
-                ]
+            (
+                (INFO, "Initialised hydrology.HydroConsts from config"),
+                (
+                    INFO,
+                    "Information required to initialise the hydrology model "
+                    "successfully extracted.",
+                ),
+                *MODEL_VAR_CHECK_LOG,
             ),
             id="default_config",
         ),
@@ -140,19 +138,17 @@ def test_hydrology_model_initialization(
             "[core]\n"
             "[hydrology]\ninitial_soil_moisture = 0.5\n"
             "initial_groundwater_saturation = 0.9\n"
-            "[core.constants.CoreConsts]\nsoil_moisture_capacity = 0.7\n",
+            "[hydrology.constants.HydroConsts]\nsoil_moisture_saturation = 0.7\n",
             0.7,
             does_not_raise(),
-            tuple(
-                [
-                    (INFO, "Initialised hydrology.HydroConsts from config"),
-                    (
-                        INFO,
-                        "Information required to initialise the hydrology model "
-                        "successfully extracted.",
-                    ),
-                    *MODEL_VAR_CHECK_LOG,
-                ]
+            (
+                (INFO, "Initialised hydrology.HydroConsts from config"),
+                (
+                    INFO,
+                    "Information required to initialise the hydrology model "
+                    "successfully extracted.",
+                ),
+                *MODEL_VAR_CHECK_LOG,
             ),
             id="modified_config_correct",
         ),
@@ -176,7 +172,7 @@ def test_generate_hydrology_model(
     caplog,
     dummy_climate_data,
     cfg_string,
-    sm_capacity,
+    sm_saturation,
     raises,
     expected_log_entries,
 ):
@@ -187,14 +183,10 @@ def test_generate_hydrology_model(
     from virtual_ecosystem.models.hydrology.constants import HydroConsts
     from virtual_ecosystem.models.hydrology.hydrology_model import HydrologyModel
 
-    # Build the config object and core components
     config = Config(cfg_strings=cfg_string)
     core_components = CoreComponents(config)
     caplog.clear()
 
-    # Check whether model is initialised (or not) as expected
-    # We patch the _setup step as it is tested separately
-    expected_const = HydroConsts()
     with (
         patch_run_update(HydrologyModel),
         patch_bypass_setup(HydrologyModel) as mock_bypass_setup,
@@ -209,15 +201,24 @@ def test_generate_hydrology_model(
                     core_components=core_components,
                     config=config,
                 )
-                mock_setup.assert_called_once_with(
-                    initial_soil_moisture=config["hydrology"]["initial_soil_moisture"],
-                    initial_groundwater_saturation=config["hydrology"][
-                        "initial_groundwater_saturation"
-                    ],
-                    model_constants=expected_const,
+                mock_setup.assert_called_once()
+
+                # Check arguments passed to _setup
+                called_args, called_kwargs = mock_setup.call_args
+                assert (
+                    called_kwargs["initial_soil_moisture"]
+                    == config["hydrology"]["initial_soil_moisture"]
+                )
+                assert (
+                    called_kwargs["initial_groundwater_saturation"]
+                    == config["hydrology"]["initial_groundwater_saturation"]
                 )
 
-    # Final check that expected logging entries are produced
+                model_constants = called_kwargs["model_constants"]
+                assert isinstance(model_constants, HydroConsts)
+                if sm_saturation is not None:
+                    assert model_constants.soil_moisture_saturation == sm_saturation
+
     log_check(caplog, expected_log_entries)
 
 
@@ -303,12 +304,12 @@ def test_setup(
             # Test 2d variables
             expected_2d = {
                 "soil_moisture": [
-                    [247.25352, 247.25352, 247.25352, 247.25352],
-                    [218.999041, 218.999041, 218.999041, 218.999041],
+                    [248.938056, 248.937037, 248.935933, 248.936385],
+                    [218.994795, 218.994795, 218.994795, 218.994795],
                 ],
                 "matric_potential": [
-                    [-66.550207, -66.550207, -66.550207, -66.550207],
-                    [-217.596714, -217.596714, -217.596714, -217.596714],
+                    [-56.432398, -56.438614, -56.44538, -56.442609],
+                    [-217.596626, -217.596626, -217.596626, -217.596626],
                 ],
             }
 
@@ -326,9 +327,9 @@ def test_setup(
             # Test one dimensional variables
             expected_1d = {
                 "vertical_flow": [6.916e-05, 6.916e-05, 6.916e-05, 6.916e-05],
-                "total_river_discharge": [0, 0, 69035, 22660],
-                "surface_runoff": [122.432417, 122.432417, 122.432417, 122.432417],
-                "surface_runoff_accumulated": [0, 0, 10530, 3300],
+                "total_river_discharge": [0, 0, 67002, 22095],
+                "surface_runoff": [20.343781, 20.66599, 20.896484, 20.443394],
+                "surface_runoff_accumulated": [0, 0, 1470, 330],
                 "soil_evaporation": [5.870856, 5.870856, 5.870856, 5.870856],
             }
 

--- a/tests/models/hydrology/test_hydrology_tools.py
+++ b/tests/models/hydrology/test_hydrology_tools.py
@@ -58,7 +58,7 @@ def test_setup_hydrology_input_current_timestep(
         seed=42,
         layer_structure=lyr_strct,
         soil_layer_thickness_mm=lyr_strct.soil_layer_thickness * 1000,
-        soil_moisture_capacity=0.9,
+        soil_moisture_saturation=0.9,
         soil_moisture_residual=0.1,
     )
 
@@ -71,7 +71,7 @@ def test_setup_hydrology_input_current_timestep(
         "surface_wind_speed",
         "leaf_area_index_sum",
         "current_transpiration",
-        "top_soil_moisture_capacity",
+        "top_soil_moisture_saturation",
         "top_soil_moisture_residual",
         "previous_accumulated_runoff",
         "previous_subsurface_flow_accumulated",

--- a/tests/models/soil/test_env_factors.py
+++ b/tests/models/soil/test_env_factors.py
@@ -232,7 +232,7 @@ def test_calculate_nitrification_moisture_factor(
     dummy_carbon_data, fixture_core_components
 ):
     """Test calculation of nitrification moisture factor."""
-    from virtual_ecosystem.core.constants import CoreConsts
+    from virtual_ecosystem.models.hydrology.constants import HydroConsts
     from virtual_ecosystem.models.soil.env_factors import (
         calculate_nitrification_moisture_factor,
     )
@@ -242,10 +242,10 @@ def test_calculate_nitrification_moisture_factor(
     ] / (
         fixture_core_components.layer_structure.soil_layer_thickness[0]
         * 1e3
-        * CoreConsts.soil_moisture_capacity
+        * HydroConsts.soil_moisture_saturation
     )
 
-    expected_factor = [0.25880985, 0.66926154, 0.9999273, 0.84401893]
+    expected_factor = [0.32030643, 0.70383072, 0.99987347, 0.83450707]
 
     actual_factor = calculate_nitrification_moisture_factor(
         effective_saturation=effective_saturation

--- a/tests/models/soil/test_pools.py
+++ b/tests/models/soil/test_pools.py
@@ -782,7 +782,7 @@ def test_calculate_net_nutrient_transfers_from_maom_to_lmwc(
 
 def test_calculate_rate_of_nitrification(dummy_carbon_data, fixture_core_components):
     """Test that calculation of the rate of nitrification is correct."""
-    from virtual_ecosystem.core.constants import CoreConsts
+    from virtual_ecosystem.models.hydrology.constants import HydroConsts
     from virtual_ecosystem.models.soil.constants import SoilConsts
     from virtual_ecosystem.models.soil.pools import calculate_rate_of_nitrification
 
@@ -791,10 +791,10 @@ def test_calculate_rate_of_nitrification(dummy_carbon_data, fixture_core_compone
     ] / (
         fixture_core_components.layer_structure.soil_layer_thickness[0]
         * 1e3
-        * CoreConsts.soil_moisture_capacity
+        * HydroConsts.soil_moisture_saturation
     )
 
-    expected_rate = [1.48136406e-06, 2.88209167e-04, 1.93117164e-05, 1.73005910e-04]
+    expected_rate = [1.83335539e-06, 3.03095957e-04, 1.93106767e-05, 1.71056181e-04]
 
     actual_rate = calculate_rate_of_nitrification(
         soil_temp=dummy_carbon_data["soil_temperature"][
@@ -812,7 +812,7 @@ def test_negative_nitrification_rate_impossible(
     dummy_carbon_data, fixture_core_components
 ):
     """Test that negative nitrification rates can't occur."""
-    from virtual_ecosystem.core.constants import CoreConsts
+    from virtual_ecosystem.models.hydrology.constants import HydroConsts
     from virtual_ecosystem.models.soil.constants import SoilConsts
     from virtual_ecosystem.models.soil.pools import calculate_rate_of_nitrification
 
@@ -821,13 +821,13 @@ def test_negative_nitrification_rate_impossible(
     ] / (
         fixture_core_components.layer_structure.soil_layer_thickness[0]
         * 1e3
-        * CoreConsts.soil_moisture_capacity
+        * HydroConsts.soil_moisture_saturation
     )
     ammonium_data = dummy_carbon_data["soil_n_pool_ammonium"]
     ammonium_data[0] = -0.0001
     ammonium_data[3] = -3e-4
 
-    expected_rate = [0.0, 2.88209167e-04, 1.93117164e-05, 0.0]
+    expected_rate = [0.0, 3.03095957e-04, 1.93106767e-05, 0.0]
 
     actual_rate = calculate_rate_of_nitrification(
         soil_temp=dummy_carbon_data["soil_temperature"][
@@ -843,7 +843,7 @@ def test_negative_nitrification_rate_impossible(
 
 def test_calculate_rate_of_denitrification(dummy_carbon_data, fixture_core_components):
     """Test that calculation of the rate of denitrification is correct."""
-    from virtual_ecosystem.core.constants import CoreConsts
+    from virtual_ecosystem.models.hydrology.constants import HydroConsts
     from virtual_ecosystem.models.soil.constants import SoilConsts
     from virtual_ecosystem.models.soil.pools import calculate_rate_of_denitrification
 
@@ -852,10 +852,10 @@ def test_calculate_rate_of_denitrification(dummy_carbon_data, fixture_core_compo
     ] / (
         fixture_core_components.layer_structure.soil_layer_thickness[0]
         * 1e3
-        * CoreConsts.soil_moisture_capacity
+        * HydroConsts.soil_moisture_saturation
     )
 
-    expected_rate = [9.37815950e-04, 1.38175611e-03, 4.86522454e-05, 3.14642097e-04]
+    expected_rate = [9.01399413e-04, 1.32810083e-03, 4.67630194e-05, 3.02424161e-04]
 
     actual_rate = calculate_rate_of_denitrification(
         soil_temp=dummy_carbon_data["soil_temperature"][
@@ -873,7 +873,7 @@ def test_negative_denitrification_rate_impossible(
     dummy_carbon_data, fixture_core_components
 ):
     """Test that negative denitrification rates can't occur."""
-    from virtual_ecosystem.core.constants import CoreConsts
+    from virtual_ecosystem.models.hydrology.constants import HydroConsts
     from virtual_ecosystem.models.soil.constants import SoilConsts
     from virtual_ecosystem.models.soil.pools import calculate_rate_of_denitrification
 
@@ -882,13 +882,13 @@ def test_negative_denitrification_rate_impossible(
     ] / (
         fixture_core_components.layer_structure.soil_layer_thickness[0]
         * 1e3
-        * CoreConsts.soil_moisture_capacity
+        * HydroConsts.soil_moisture_saturation
     )
     nitrate_data = dummy_carbon_data["soil_n_pool_nitrate"]
     nitrate_data[1] = -0.0001
     nitrate_data[2] = -7e-4
 
-    expected_rate = [0.00093782, 0.0, 0.0, 0.00031464]
+    expected_rate = [0.0009014, 0.0, 0.0, 0.00030242]
 
     actual_rate = calculate_rate_of_denitrification(
         soil_temp=dummy_carbon_data["soil_temperature"][

--- a/virtual_ecosystem/core/constants.py
+++ b/virtual_ecosystem/core/constants.py
@@ -70,20 +70,6 @@ class CoreConsts(ConstantsDataclass):
     :cite:t:`fatichi_mechanistic_2019`. No empirical source is provided for this value.
     """
 
-    soil_moisture_capacity: float = 0.5
-    """Soil moisture capacity, unitless.
-
-    The soil moisture capacity, also known as field capacity or water holding capacity,
-    refers to the maximum amount of water that a soil can retain against the force of
-    gravity after it has been saturated and excess water has drained away. The value is
-    soil type specific, the format here is volumetric relative water content (unitless,
-    between 0 and 1).
-
-    TODO - This constant also exists in the hydrology model. There really should be a
-    single location for this, but I didn't want to force a refactor of the hydrology
-    code. This should be reviewed when the soil-abiotic links are reviewed.
-    """
-
     meters_to_mm: float = 1000.0
     """Factor to convert variable unit from meters to millimeters."""
 

--- a/virtual_ecosystem/models/hydrology/above_ground.py
+++ b/virtual_ecosystem/models/hydrology/above_ground.py
@@ -231,7 +231,7 @@ def calculate_soil_evaporation(
     atmospheric_pressure: NDArray[np.float32],
     soil_moisture: NDArray[np.float32],
     soil_moisture_residual: float | NDArray[np.float32],
-    soil_moisture_capacity: float | NDArray[np.float32],
+    soil_moisture_saturation: float | NDArray[np.float32],
     leaf_area_index: NDArray[np.float32],
     wind_speed_surface: NDArray[np.float32],
     density_air: float | NDArray[np.float32],
@@ -274,7 +274,7 @@ def calculate_soil_evaporation(
         atmospheric_pressure: Atmospheric pressure at reference height, [kPa]
         soil_moisture: Volumetric relative water content, [unitless]
         soil_moisture_residual: Residual soil moisture, [unitless]
-        soil_moisture_capacity: Soil moisture capacity, [unitless]
+        soil_moisture_saturation: Soil moisture saturation, [unitless]
         wind_speed_surface: Wind speed in the bottom air layer, [m s-1]
         density_air: Density if air, [kg m-3]
         latent_heat_vapourisation: Latent heat of vapourisation, [kJ kg-1]
@@ -296,7 +296,7 @@ def calculate_soil_evaporation(
     soil_moisture_free = np.clip(
         (soil_moisture - soil_moisture_residual),
         0.0,
-        (soil_moisture_capacity - soil_moisture_residual),
+        (soil_moisture_saturation - soil_moisture_residual),
     )
 
     # Estimate alpha using the Barton (1979) equation
@@ -614,30 +614,30 @@ def convert_mm_flow_to_m3_per_second(
 def calculate_surface_runoff(
     precipitation_surface: NDArray[np.float32],
     top_soil_moisture: NDArray[np.float32],
-    top_soil_moisture_capacity: NDArray[np.float32],
+    top_soil_moisture_saturation: NDArray[np.float32],
 ) -> NDArray[np.float32]:
     """Calculate surface runoff, [mm].
 
     Surface runoff is calculated with a simple bucket model based on
-    :cite:t:`davis_simple_2017`: if precipitation exceeds top soil moisture capacity
+    :cite:t:`davis_simple_2017`: if precipitation exceeds top soil moisture saturation
     , the excess water is added to runoff and top soil moisture is set to soil
-    moisture capacity value; if the top soil is not saturated, precipitation is
+    moisture saturation value; if the top soil is not saturated, precipitation is
     added to the current soil moisture level and runoff is set to zero.
 
-    TODO adjust capacity to account for new set of soil layers #535
+    TODO adjust saturation to account for new set of soil layers #535
 
     Args:
         precipitation_surface: Precipitation that reaches surface, [mm]
         top_soil_moisture: Water content of top soil layer, [mm]
-        top_soil_moisture_capacity: Soil mositure capacity of top soil layer, [mm]
+        top_soil_moisture_saturation: Soil mositure saturation of top soil layer, [mm]
     """
 
-    # Calculate how much water can be added to soil before capacity is reached, [mm]
-    free_capacity_mm = top_soil_moisture_capacity - top_soil_moisture
+    # Calculate how much water can be added to soil before saturation is reached, [mm]
+    free_saturation_mm = top_soil_moisture_saturation - top_soil_moisture
 
     # Calculate daily surface runoff of each grid cell, [mm]; replace by SPLASH
     return np.where(
-        precipitation_surface > free_capacity_mm,
-        precipitation_surface - free_capacity_mm,
+        precipitation_surface > free_saturation_mm,
+        precipitation_surface - free_saturation_mm,
         0,
     )

--- a/virtual_ecosystem/models/hydrology/below_ground.py
+++ b/virtual_ecosystem/models/hydrology/below_ground.py
@@ -155,7 +155,7 @@ def update_soil_moisture(
     soil_moisture: NDArray[np.float32],
     vertical_flow: NDArray[np.float32],
     transpiration: NDArray[np.float32],
-    soil_moisture_capacity: NDArray[np.float32],
+    soil_moisture_saturation: NDArray[np.float32],
     soil_moisture_residual: NDArray[np.float32],
 ) -> NDArray[np.float32]:
     """Update soil moisture profile.
@@ -169,7 +169,7 @@ def update_soil_moisture(
         soil_moisture: Soil moisture after infiltration and surface evaporation, [mm]
         vertical_flow: Vertical flow between all layers, [mm]
         transpiration: Canopy transpiration, [mm]
-        soil_moisture_capacity: Soil moisture capacity for each layer, [mm]
+        soil_moisture_saturation: Soil moisture saturation for each layer, [mm]
         soil_moisture_residual: Residual soil moisture for each layer, [mm]
 
     Returns:
@@ -180,7 +180,7 @@ def update_soil_moisture(
     top_soil_moisture = np.clip(
         soil_moisture[0] - vertical_flow[0],
         soil_moisture_residual[0],
-        soil_moisture_capacity[0],
+        soil_moisture_saturation[0],
     )
 
     # Add topsoil vertical flow to layer below and remove that layers flow as well as
@@ -188,7 +188,7 @@ def update_soil_moisture(
     root_soil_moisture = np.clip(
         soil_moisture[1] + vertical_flow[0] - vertical_flow[1] - transpiration,
         soil_moisture_residual[1],
-        soil_moisture_capacity[1],
+        soil_moisture_saturation[1],
     )
 
     # For all further soil layers, add the vertical flow from the layer above, remove
@@ -201,7 +201,7 @@ def update_soil_moisture(
             np.clip(
                 (soil_moisture[i + 1] + vertical_flow[i] - vertical_flow[i + 1]),
                 soil_moisture_residual[i + 1],
-                soil_moisture_capacity[i + 1],
+                soil_moisture_saturation[i + 1],
             )
             for sm, vf in zip(
                 soil_moisture[2:],

--- a/virtual_ecosystem/models/hydrology/hydrology_model.py
+++ b/virtual_ecosystem/models/hydrology/hydrology_model.py
@@ -438,7 +438,7 @@ class HydrologyModel(
             seed=seed,
             layer_structure=self.layer_structure,
             soil_layer_thickness_mm=self.soil_layer_thickness_mm,
-            soil_moisture_capacity=self.core_constants.soil_moisture_capacity,
+            soil_moisture_saturation=self.model_constants.soil_moisture_saturation,
             soil_moisture_residual=self.model_constants.soil_moisture_residual,
         )
 
@@ -513,14 +513,16 @@ class HydrologyModel(
             surface_runoff = above_ground.calculate_surface_runoff(
                 precipitation_surface=precipitation_surface,
                 top_soil_moisture=hydro_input["current_soil_moisture"][0],
-                top_soil_moisture_capacity=hydro_input["top_soil_moisture_capacity"],
+                top_soil_moisture_saturation=hydro_input[
+                    "top_soil_moisture_saturation"
+                ],
             )
             daily_lists["surface_runoff"].append(surface_runoff)
 
             # Calculate preferential bypass flow, [mm]
             bypass_flow = above_ground.calculate_bypass_flow(
                 top_soil_moisture=hydro_input["current_soil_moisture"][0],
-                sat_top_soil_moisture=hydro_input["top_soil_moisture_capacity"],
+                sat_top_soil_moisture=hydro_input["top_soil_moisture_saturation"],
                 available_water=precipitation_surface - surface_runoff,
                 bypass_flow_coefficient=(self.model_constants.bypass_flow_coefficient),
             )
@@ -535,7 +537,7 @@ class HydrologyModel(
                     - bypass_flow,
                 ),
                 0,
-                hydro_input["top_soil_moisture_capacity"],
+                hydro_input["top_soil_moisture_saturation"],
             ).squeeze()
 
             # Prepare inputs for soil evaporation function
@@ -550,7 +552,7 @@ class HydrologyModel(
                 atmospheric_pressure=hydro_input["surface_pressure"],
                 soil_moisture=top_soil_moisture_vol,
                 soil_moisture_residual=self.model_constants.soil_moisture_residual,
-                soil_moisture_capacity=self.core_constants.soil_moisture_capacity,
+                soil_moisture_saturation=self.model_constants.soil_moisture_saturation,
                 leaf_area_index=hydro_input["leaf_area_index_sum"],
                 wind_speed_surface=hydro_input["surface_wind_speed"],
                 density_air=self.data["density_air"][
@@ -585,7 +587,7 @@ class HydrologyModel(
                                 - soil_evaporation["soil_evaporation"]
                             ),
                             hydro_input["top_soil_moisture_residual"],
-                            hydro_input["top_soil_moisture_capacity"],
+                            hydro_input["top_soil_moisture_saturation"],
                         ),
                         axis=0,
                     ),
@@ -635,8 +637,8 @@ class HydrologyModel(
                 soil_moisture=soil_moisture_evap_mm,  # mm
                 vertical_flow=vertical_flow["vertical_flow"],  # mm day-1
                 transpiration=hydro_input["current_transpiration"],  # mm
-                soil_moisture_capacity=(  # mm
-                    self.core_constants.soil_moisture_capacity
+                soil_moisture_saturation=(  # mm
+                    self.model_constants.soil_moisture_saturation
                     * self.soil_layer_thickness_mm
                 ),
                 soil_moisture_residual=(  # mm

--- a/virtual_ecosystem/models/hydrology/hydrology_tools.py
+++ b/virtual_ecosystem/models/hydrology/hydrology_tools.py
@@ -106,7 +106,7 @@ def setup_hydrology_input_current_timestep(
     seed: None | int,
     layer_structure: LayerStructure,
     soil_layer_thickness_mm: NDArray[np.float32],
-    soil_moisture_capacity: float | NDArray[np.float32],
+    soil_moisture_saturation: float | NDArray[np.float32],
     soil_moisture_residual: float | NDArray[np.float32],
 ) -> dict[str, NDArray[np.float32]]:
     """Select and pre-process inputs for hydrology.update() for current time step.
@@ -133,7 +133,7 @@ def setup_hydrology_input_current_timestep(
     * current_precipitation
     * current_transpiration
     * current_soil_moisture
-    * top_soil_moisture_capacity
+    * top_soil_moisture_saturation
     * top_soil_moisture_residual
     * previous_accumulated_runoff
     * previous_subsurface_flow_accumulated
@@ -147,7 +147,7 @@ def setup_hydrology_input_current_timestep(
         seed: Seed for random rainfall generator
         layer_structure: The LayerStructure instance for a simulation.
         soil_layer_thickness_mm: The thickness of the soil layer, [mm]
-        soil_moisture_capacity: Soil moisture capacity, unitless
+        soil_moisture_saturation: Soil moisture saturation, unitless
         soil_moisture_residual: Soil moisture residual, unitless
 
     Returns:
@@ -183,8 +183,8 @@ def setup_hydrology_input_current_timestep(
     )
 
     # Select soil variables
-    output["top_soil_moisture_capacity"] = (
-        soil_moisture_capacity * soil_layer_thickness_mm[0]
+    output["top_soil_moisture_saturation"] = (
+        soil_moisture_saturation * soil_layer_thickness_mm[0]
     )
     output["top_soil_moisture_residual"] = (
         soil_moisture_residual * soil_layer_thickness_mm[0]


### PR DESCRIPTION
This PR removes `CoreConsts.soil_moisture_capacity` and uses `HydroConsts.soil_moisture_saturation` instead.

Fixes #880 