### PR TITLE
Changed calculation of removal rate of nutrients due to water

### DIFF
--- a/tests/models/soil/conftest.py
+++ b/tests/models/soil/conftest.py
@@ -96,7 +96,7 @@ def dummy_carbon_data(fixture_core_components):
 
     data["vertical_flow"] = lyr_str.from_template()
     data["vertical_flow"][lyr_str.index_all_soil] = np.array(
-        [[0.1, 0.5, 2.5, 1.59], [0.1, 0.5, 2.5, 1.59]]
+        [[0.1, 0.5, 2.5, 1.59], [0.15, 0.75, 2.75, 1.33]]
     )
 
     data["air_temperature"] = lyr_str.from_template()

--- a/tests/models/soil/test_env_factors.py
+++ b/tests/models/soil/test_env_factors.py
@@ -393,17 +393,21 @@ def test_calculate_carbon_use_efficiency(averaged_soil_temp):
     assert np.allclose(actual_cues, expected_cues)
 
 
-def test_calculate_leaching_rate(dummy_carbon_data, fixture_core_components):
-    """Test calculation of solute leaching rates."""
+def test_calculate_solute_removal_by_soil_water(
+    dummy_carbon_data, fixture_core_components
+):
+    """Test calculation of solute removal rates."""
     from virtual_ecosystem.models.soil.constants import SoilConsts
-    from virtual_ecosystem.models.soil.env_factors import calculate_leaching_rate
+    from virtual_ecosystem.models.soil.env_factors import (
+        calculate_solute_removal_by_soil_water,
+    )
 
     expected_rate = [1.07473723e-6, 2.53952130e-6, 9.91551977e-5, 5.25567712e-5]
-    vertical_flow_per_day = np.array([0.1, 0.5, 2.5, 15.9])
+    exit_flow_per_day = np.array([0.1, 0.5, 2.5, 15.9])
 
-    actual_rate = calculate_leaching_rate(
+    actual_rate = calculate_solute_removal_by_soil_water(
         solute_density=dummy_carbon_data["soil_c_pool_lmwc"],
-        vertical_flow_rate=vertical_flow_per_day,
+        exit_rate=exit_flow_per_day,
         soil_moisture=dummy_carbon_data["soil_moisture"][
             fixture_core_components.layer_structure.index_topsoil_scalar
         ],

--- a/tests/models/soil/test_env_factors.py
+++ b/tests/models/soil/test_env_factors.py
@@ -452,3 +452,38 @@ def test_find_total_soil_moisture_for_microbially_active_depth(
     )
 
     assert np.allclose(actual_soil_moisture, expected_soil_moisture)
+
+
+@pytest.mark.parametrize(
+    "increased_depth,expected_vertical_flow",
+    [
+        pytest.param(
+            True,
+            [0.12, 0.6, 2.6, 1.486],
+            id="increased depth",
+        ),
+        pytest.param(
+            False,
+            [0.1, 0.5, 2.5, 1.59],
+            id="normal depth",
+        ),
+    ],
+)
+def test_find_water_outflow_rates(
+    dummy_carbon_data, fixture_core_components, increased_depth, expected_vertical_flow
+):
+    """Test function that finds the rates of water flow out of the soil column."""
+    from virtual_ecosystem.models.soil.env_factors import find_water_outflow_rates
+
+    if increased_depth:
+        fixture_core_components.layer_structure.soil_layer_active_thickness = np.array(
+            [0.5, 0.20]
+        )
+        fixture_core_components.layer_structure.max_depth_of_microbial_activity = 0.70
+
+    actual_vertical_flow = find_water_outflow_rates(
+        vertical_flow=dummy_carbon_data["vertical_flow"].to_numpy(),
+        layer_structure=fixture_core_components.layer_structure,
+    )
+
+    assert np.allclose(expected_vertical_flow, actual_vertical_flow)

--- a/tests/models/soil/test_pools.py
+++ b/tests/models/soil/test_pools.py
@@ -327,11 +327,13 @@ def test_calculate_enzyme_mediated_rates(
             assert np.allclose(getattr(actual_rates, attr), expected_rates[attr])
 
 
-def test_calculate_nutrient_leaching(dummy_carbon_data, fixture_core_components):
-    """Check that the calculation of dissolved nutrient leaching rates is correct."""
-    from virtual_ecosystem.models.soil.pools import calculate_nutrient_leaching
+def test_ccalculate_nutrient_removal_by_water(
+    dummy_carbon_data, fixture_core_components
+):
+    """Check that the calculation of dissolved nutrient removal rates is correct."""
+    from virtual_ecosystem.models.soil.pools import calculate_nutrient_removal_by_water
 
-    expected_leaching = {
+    expected_removal = {
         "lmwc": [1.0747349e-6, 2.5395235e-6, 9.9154571e-5, 5.2557152e-6],
         "don": [1.22826724e-8, 1.81394352e-7, 1.41642304e-7, 3.00326494e-6],
         "dop": [1.2282071e-10, 2.90230964e-9, 5.66596981e-8, 1.20130598e-7],
@@ -340,7 +342,7 @@ def test_calculate_nutrient_leaching(dummy_carbon_data, fixture_core_components)
         "labile_P": [2.274653e-11, 4.130485e-10, 6.749199e-9, 2.045141e-8],
     }
 
-    actual_leaching = calculate_nutrient_leaching(
+    actual_removal = calculate_nutrient_removal_by_water(
         soil_c_pool_lmwc=dummy_carbon_data["soil_c_pool_lmwc"],
         soil_n_pool_don=dummy_carbon_data["soil_n_pool_don"],
         soil_p_pool_dop=dummy_carbon_data["soil_p_pool_dop"],
@@ -356,15 +358,15 @@ def test_calculate_nutrient_leaching(dummy_carbon_data, fixture_core_components)
         constants=SoilConsts,
     )
 
-    for attr in dir(actual_leaching):
+    for attr in dir(actual_removal):
         if not attr.startswith("_"):
-            assert attr in expected_leaching.keys(), f"Attribute {attr} not tested"
-            assert np.allclose(getattr(actual_leaching, attr), expected_leaching[attr])
+            assert attr in expected_removal.keys(), f"Attribute {attr} not tested"
+            assert np.allclose(getattr(actual_removal, attr), expected_removal[attr])
 
 
-def test_negative_nutrient_leaching(dummy_carbon_data, fixture_core_components):
-    """Test that negative leaching rates cannot occur."""
-    from virtual_ecosystem.models.soil.pools import calculate_nutrient_leaching
+def test_negative_nutrient_removal_by_water(dummy_carbon_data, fixture_core_components):
+    """Test that negative rates of nutrient removal by water cannot occur."""
+    from virtual_ecosystem.models.soil.pools import calculate_nutrient_removal_by_water
 
     # Add negative values to the inorganic nutrient pools
     ammonium_data = dummy_carbon_data["soil_n_pool_ammonium"]
@@ -378,7 +380,7 @@ def test_negative_nutrient_leaching(dummy_carbon_data, fixture_core_components):
     expected_nitrate = [0.0, 1.128640314e-5, 6.798727493e-6, 0.00027625126]
     expected_labile_P = [2.274653e-11, 4.130485e-10, 6.749199e-9, 0.0]
 
-    actual_leaching = calculate_nutrient_leaching(
+    actual_removal = calculate_nutrient_removal_by_water(
         soil_c_pool_lmwc=dummy_carbon_data["soil_c_pool_lmwc"],
         soil_n_pool_don=dummy_carbon_data["soil_n_pool_don"],
         soil_p_pool_dop=dummy_carbon_data["soil_p_pool_dop"],
@@ -394,9 +396,9 @@ def test_negative_nutrient_leaching(dummy_carbon_data, fixture_core_components):
         constants=SoilConsts,
     )
 
-    assert np.allclose(actual_leaching.ammonium, expected_ammonium)
-    assert np.allclose(actual_leaching.nitrate, expected_nitrate)
-    assert np.allclose(actual_leaching.labile_P, expected_labile_P)
+    assert np.allclose(actual_removal.ammonium, expected_ammonium)
+    assert np.allclose(actual_removal.nitrate, expected_nitrate)
+    assert np.allclose(actual_removal.labile_P, expected_labile_P)
 
 
 def test_calculate_enzyme_changes(soil_pool_data, enzyme_production, enzyme_classes):

--- a/tests/models/soil/test_pools.py
+++ b/tests/models/soil/test_pools.py
@@ -327,7 +327,7 @@ def test_calculate_enzyme_mediated_rates(
             assert np.allclose(getattr(actual_rates, attr), expected_rates[attr])
 
 
-def test_ccalculate_nutrient_removal_by_water(
+def test_calculate_nutrient_removal_by_water(
     dummy_carbon_data, fixture_core_components
 ):
     """Check that the calculation of dissolved nutrient removal rates is correct."""
@@ -349,12 +349,11 @@ def test_ccalculate_nutrient_removal_by_water(
         soil_n_pool_ammonium=dummy_carbon_data["soil_n_pool_ammonium"],
         soil_n_pool_nitrate=dummy_carbon_data["soil_n_pool_nitrate"],
         soil_p_pool_labile=dummy_carbon_data["soil_p_pool_labile"],
-        vertical_flow_rate=dummy_carbon_data["vertical_flow"][
-            fixture_core_components.layer_structure.index_topsoil_scalar
-        ].to_numpy(),
+        vertical_flow_rates=dummy_carbon_data["vertical_flow"].to_numpy(),
         soil_moisture=dummy_carbon_data["soil_moisture"][
             fixture_core_components.layer_structure.index_topsoil_scalar
         ].to_numpy(),
+        layer_structure=fixture_core_components.layer_structure,
         constants=SoilConsts,
     )
 
@@ -387,12 +386,11 @@ def test_negative_nutrient_removal_by_water(dummy_carbon_data, fixture_core_comp
         soil_n_pool_ammonium=ammonium_data,
         soil_n_pool_nitrate=nitrate_data,
         soil_p_pool_labile=labile_p_data,
-        vertical_flow_rate=dummy_carbon_data["vertical_flow"][
-            fixture_core_components.layer_structure.index_topsoil_scalar
-        ].to_numpy(),
+        vertical_flow_rates=dummy_carbon_data["vertical_flow"],
         soil_moisture=dummy_carbon_data["soil_moisture"][
             fixture_core_components.layer_structure.index_topsoil_scalar
         ].to_numpy(),
+        layer_structure=fixture_core_components.layer_structure,
         constants=SoilConsts,
     )
 

--- a/virtual_ecosystem/models/soil/env_factors.py
+++ b/virtual_ecosystem/models/soil/env_factors.py
@@ -496,7 +496,7 @@ def find_water_outflow_rates(
     For the vertical movement, water only leaves this region if it passes into a soil
     layer that is either only partially microbially active or completely inactive.
     Therefore, we only need to consider the bottom two microbially active layers as
-    these are the layers only which can have flows into partially active or inactive
+    these are the only layers which can have flows into partially active or inactive
     layers. How much of a given flow is considered to have exited the microbially active
     region depends on how much of each layer is assumed to be microbially active. If
     water is flowing from a layer that is only partially active, the exit rate will be

--- a/virtual_ecosystem/models/soil/env_factors.py
+++ b/virtual_ecosystem/models/soil/env_factors.py
@@ -493,17 +493,19 @@ def find_water_outflow_rates(
     that the upper layers also have horizontal water movements this function will need
     to change to ensure that nutrient flows properly track the water flows.
 
-    For the vertical movement, water only leaves this region if it passes into a soil
-    layer that is either only partially microbially active or completely inactive.
-    Therefore, we only need to consider the bottom two microbially active layers as
-    these are the only layers which can have flows into partially active or inactive
-    layers. How much of a given flow is considered to have exited the microbially active
-    region depends on how much of each layer is assumed to be microbially active. If
-    water is flowing from a layer that is only partially active, the exit rate will be
-    proportional to the fraction of this layer that is considered to be microbially
-    active. Conversely, if water is flowing to a layer that is partially microbially
-    active the exit rate will be proportional to the inverse of the fraction of the
-    layer that is considered to be microbially active.
+    The water column that the soil model is interested in (i.e. the amount of water down
+    to the maximum depth of microbial activity) generally spans a fractional number of
+    soil hydrology layers, meaning that water exits the microbially active region within
+    a specific soil hydrology layer rather than at the boundary of two layers. This
+    complicates things as the vertical flow rates are defined for passing between
+    hydrology layers. We therefore calculate two separate exit rates which we then sum
+    to find the combined rate. Firstly, we calculate the rate at which water flows into
+    the microbially inactive portion of the partially microbially active layer. This is
+    found by multiplying the vertical flow into the layer by the fraction of the layer
+    that is microbially inactive. Secondly, we calculate the rate at which water flows
+    from the microbially active portion of this layer to the microbially inactive layer
+    below. This flow is found by multiplying the vertical flow to the lower layer by the
+    fraction of the upper layer that is microbially active.
 
     Args:
         vertical_flow: The flow rate between each soil layer [mm day^-1]

--- a/virtual_ecosystem/models/soil/env_factors.py
+++ b/virtual_ecosystem/models/soil/env_factors.py
@@ -472,3 +472,73 @@ def find_total_soil_moisture_for_microbially_active_depth(
     )
 
     return np.dot(layer_weights, soil_moistures[layer_structure.index_all_soil])
+
+
+def find_water_outflow_rates(
+    vertical_flow: NDArray[np.floating], layer_structure: LayerStructure
+) -> NDArray[np.floating]:
+    """Find the rate at which water leaves the microbially active soil region.
+
+    This functions calculates the rate at which soil water in the microbially active
+    region is refreshed with "new" water from rainfall. The reason to specifically care
+    about "new" water is that it does not carry any significant amount of nutrients with
+    it (in contrast to water moving from a different part of the soil), meaning that the
+    soil nutrients will dissolve from the soil without impediment (which is the
+    assumption underlying the
+    :func:`~virtual_ecosystem.models.soil.env_factors.calculate_solute_removal_by_soil_water`
+    function). The rate of "new" water refreshing the microbially active column will be
+    equivalent to the rate at which water escapes from this region. For the upper soil
+    layers, all water flows are vertical rather than horizontal, so this function only
+    considers vertical flows. If the implementation of the hydrology model changes so
+    that the upper layers also have horizontal water movements this function will need
+    to change to ensure that nutrient flows properly track the water flows.
+
+    For the vertical movement, water only leaves this region if it passes into a soil
+    layer that is either only partially microbially active or completely inactive.
+    Therefore, we only need to consider the bottom two microbially active layers as
+    these are the layers only which can have flows into partially active or inactive
+    layers. How much of a given flow is considered to have exited the microbially active
+    region depends on how much of each layer is assumed to be microbially active. If
+    water is flowing from a layer that is only partially active, the exit rate will be
+    proportional to the fraction of this layer that is considered to be microbially
+    active. Conversely, if water is flowing to a layer that is partially microbially
+    active the exit rate will be proportional to the inverse of the fraction of the
+    layer that is considered to be microbially active.
+
+    Args:
+        vertical_flow: The flow rate between each soil layer [mm day^-1]
+        layer_structure: The LayerStructure instance for the simulation. From this we
+           use the thickness of each layer, as well as `soil_layer_active_thickness`
+           which is how much of each layer lies within the microbially active zone
+
+    Returns:
+        The rate at which water leaves the microbially active region of the soil [mm
+        day^-1]
+    """
+
+    # Find the fraction of each layer that lies within the microbially active zone
+    layer_weights = (
+        layer_structure.soil_layer_active_thickness
+        / layer_structure.soil_layer_thickness
+    )
+
+    # Water only leaves the microbial zone from the bottom two microbially active
+    # layers. (If only the top layer is active use it and the layer beneath)
+    non_zero_indices = np.flatnonzero(layer_weights)
+    if len(non_zero_indices) == 1:
+        lowest_active_layers = np.array([non_zero_indices[0], non_zero_indices[0] + 1])
+    else:
+        lowest_active_layers = np.array([non_zero_indices[-2], non_zero_indices[-1]])
+
+    lowest_layer_weight = layer_weights[lowest_active_layers[1]]
+
+    # Need to switch from soil layers (which the weights are counted in) to the total
+    # layers in the layer structure (which vertical flow is measured in)
+    lowest_active_layers += layer_structure.index_topsoil_scalar
+
+    vertical_exit_flow = (
+        lowest_layer_weight * vertical_flow[lowest_active_layers[1]]
+        + (1 - lowest_layer_weight) * vertical_flow[lowest_active_layers[0]]
+    )
+
+    return vertical_exit_flow

--- a/virtual_ecosystem/models/soil/env_factors.py
+++ b/virtual_ecosystem/models/soil/env_factors.py
@@ -382,32 +382,37 @@ def calculate_symbiotic_nitrogen_fixation_carbon_cost(
     )
 
 
-def calculate_leaching_rate(
+def calculate_solute_removal_by_soil_water(
     solute_density: NDArray[np.floating],
-    vertical_flow_rate: NDArray[np.floating],
+    exit_rate: NDArray[np.floating],
     soil_moisture: NDArray[np.floating],
     solubility_coefficient: float,
 ) -> NDArray[np.floating]:
-    """Calculate leaching rate for a given solute based on flow rate.
+    """Calculate rate at which water removes a given solute based on flow rate.
 
     This functional form is adapted from :cite:t:`porporato_hydrologic_2003`. The amount
     of solute that is expected to be found in dissolved form is calculated by
     multiplying the solute density by its solubility coefficient. This is then
-    multiplied by the frequency with which the water column is completely replaced, i.e.
-    the ratio of vertical flow rate to soil moisture in mm.
+    multiplied by the frequency with which the water column in the microbially active
+    depth is completely replaced. This replacement can happen through downwards flow
+    (leaching) or through horizontal flow. The replacement frequency can be found as the
+    ratio the total rate at which water exits the microbially active portion of the soil
+    to soil moisture in mm.
 
     Args:
         solute_density: The density of the solute in the soil [kg solute m^-3]
-        vertical_flow_rate: Rate of flow downwards through the soil [mm day^-1]
+        exit_rate: Rate at which water exits the microbially active portion of the soil
+            [mm day^-1]
         soil_moisture: Volume of water contained in topsoil layer [mm]
         solubility_coefficient: The solubility coefficient of the solute in question
             [unitless]
 
     Returns:
-        The rate at which the solute in question is leached [kg solute m^-3 day^-1]
+        The rate at which the solute in question is removed from the soil by the flow of
+        water [kg solute m^-3 day^-1]
     """
 
-    return solubility_coefficient * solute_density * vertical_flow_rate / soil_moisture
+    return solubility_coefficient * solute_density * exit_rate / soil_moisture
 
 
 def calculate_carbon_use_efficiency(

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -26,9 +26,9 @@ from virtual_ecosystem.models.soil.env_factors import (
     EnvironmentalEffectFactors,
     calculate_denitrification_temperature_factor,
     calculate_environmental_effect_factors,
-    calculate_leaching_rate,
     calculate_nitrification_moisture_factor,
     calculate_nitrification_temperature_factor,
+    calculate_solute_removal_by_soil_water,
     calculate_symbiotic_nitrogen_fixation_carbon_cost,
     calculate_temperature_effect_on_microbes,
     find_total_soil_moisture_for_microbially_active_depth,
@@ -215,26 +215,26 @@ class BiomassLosses:
 
 
 @dataclass
-class LeachingRates:
-    """Leaching rate for each soluble nutrient pool."""
+class WaterRemovalRates:
+    """Rate at which each soluble nutrient pool is removed due to soil water flows."""
 
     lmwc: NDArray[np.floating]
-    """Leaching rate for the low molecular weight carbon pool [kg C m^-3 day^-1]."""
+    """Removal rate for the low molecular weight carbon pool [kg C m^-3 day^-1]."""
 
     don: NDArray[np.floating]
-    """Loss of dissolved organic nitrogen due to LMWC leaching [kg N m^-3 day^-1]."""
+    """Loss of dissolved organic nitrogen due to LMWC removal [kg N m^-3 day^-1]."""
 
     dop: NDArray[np.floating]
-    """Loss of dissolved organic phosphorus due to LMWC leaching [kg P m^-3 day^-1]."""
+    """Loss of dissolved organic phosphorus due to LMWC removal [kg P m^-3 day^-1]."""
 
     ammonium: NDArray[np.floating]
-    """Leaching rate for the soil ammonium pool [kg N m^-3 day^-1]."""
+    """Removal rate for the soil ammonium pool [kg N m^-3 day^-1]."""
 
     nitrate: NDArray[np.floating]
-    """Leaching rate for the soil nitrate pool [kg N m^-3 day^-1]."""
+    """Removal rate for the soil nitrate pool [kg N m^-3 day^-1]."""
 
     labile_P: NDArray[np.floating]
-    """Leaching rate for the labile inorganic phosphorus pool [kg P m^-3 day^-1]."""
+    """Removal rate for the labile inorganic phosphorus pool [kg P m^-3 day^-1]."""
 
 
 @dataclass
@@ -500,8 +500,8 @@ class SoilPools:
             enzyme_classes=self.enzyme_classes,
         )
 
-        # Calculate leaching rates
-        nutrient_leaching = calculate_nutrient_leaching(
+        # Calculate nutrient removal due to water flows
+        nutrient_removal_by_water = calculate_nutrient_removal_by_water(
             soil_c_pool_lmwc=self.pools.soil_c_pool_lmwc,
             soil_n_pool_don=self.pools.soil_n_pool_don,
             soil_p_pool_dop=self.pools.soil_p_pool_dop,
@@ -645,7 +645,7 @@ class SoilPools:
             + necromass_decay_to_lmwc
             - microbial_changes.lmwc_uptake
             - lmwc_sorption_to_maom
-            - nutrient_leaching.lmwc
+            - nutrient_removal_by_water.lmwc
         )
 
         delta_pools_ordered["soil_c_pool_maom"] = (
@@ -698,7 +698,7 @@ class SoilPools:
             + necromass_outflows["decay_nitrogen"]
             + nutrient_transfers_maom_to_lmwc["nitrogen"]
             - microbial_changes.don_uptake
-            - nutrient_leaching.don
+            - nutrient_removal_by_water.don
         )
         delta_pools_ordered["soil_n_pool_particulate"] = (
             litter_mineralisation_flux.particulate_n
@@ -721,7 +721,7 @@ class SoilPools:
             + free_living_nitrogen_fixation
             - microbial_changes.ammonium_change
             - self.to_per_volume(self.data["plant_ammonium_uptake"].to_numpy())
-            - nutrient_leaching.ammonium
+            - nutrient_removal_by_water.ammonium
             - ammonia_volatilisation_rate
             - nitrification_rate
         )
@@ -730,7 +730,7 @@ class SoilPools:
             - denitrification_rate
             - microbial_changes.nitrate_change
             - self.to_per_volume(self.data["plant_nitrate_uptake"].to_numpy())
-            - nutrient_leaching.nitrate
+            - nutrient_removal_by_water.nitrate
         )
         delta_pools_ordered["soil_p_pool_dop"] = (
             litter_mineralisation_flux.dop
@@ -738,7 +738,7 @@ class SoilPools:
             + necromass_outflows["decay_phosphorus"]
             + nutrient_transfers_maom_to_lmwc["phosphorus"]
             - microbial_changes.dop_uptake
-            - nutrient_leaching.dop
+            - nutrient_removal_by_water.dop
         )
         delta_pools_ordered["soil_p_pool_particulate"] = (
             litter_mineralisation_flux.particulate_p
@@ -766,7 +766,7 @@ class SoilPools:
             - microbial_changes.labile_p_change
             - self.to_per_volume(self.data["plant_phosphorus_uptake"].to_numpy())
             - net_formation_secondary_P
-            - nutrient_leaching.labile_P
+            - nutrient_removal_by_water.labile_P
         )
 
         # Create output array of pools in desired order
@@ -1068,7 +1068,7 @@ def calculate_enzyme_mediated_rates(
     return EnzymeMediatedRates(**decomposition_rates)
 
 
-def calculate_nutrient_leaching(
+def calculate_nutrient_removal_by_water(
     soil_c_pool_lmwc: NDArray[np.floating],
     soil_n_pool_don: NDArray[np.floating],
     soil_p_pool_dop: NDArray[np.floating],
@@ -1078,14 +1078,14 @@ def calculate_nutrient_leaching(
     vertical_flow_rate: NDArray[np.floating],
     soil_moisture: NDArray[np.floating],
     constants: SoilConsts,
-) -> LeachingRates:
-    """Calculate the rate a which each soluble nutrient pool is leached.
+) -> WaterRemovalRates:
+    """Calculate the rate a which each soluble nutrient pool is removed by water.
 
-    Leaching rates are calculated for the low molecular weight carbon pool and the
+    Removal rates are calculated for the low molecular weight carbon pool and the
     inorganic nitrogen and phosphorus pools based on their solubility and the rate at
-    which water flows through the soil. The loss of organic nitrogen and phosphorus due
-    to leaching is then calculated based on the stoichiometry and leaching rate of the
-    LMWC pool.
+    which water exits the microbially active part of the soil. The removal rates for
+    organic nitrogen and phosphorus are then calculated based on the stoichiometry and
+    removal rate of the LMWC pool.
 
     Args:
         soil_c_pool_lmwc: Low molecular weight carbon pool [kg C m^-3]
@@ -1099,49 +1099,52 @@ def calculate_nutrient_leaching(
         constants: Set of constants for the soil model.
 
     Returns:
-        A dataclass containing the rate a which each soluble nutrient pool leaches.
+        A dataclass containing the rate a which each soluble nutrient pool is removed by
+        flows of water through the soil.
     """
 
-    # Find leaching rates
-    labile_carbon_leaching = calculate_leaching_rate(
+    # TODO - THE CALCULATION OF TOTAL WATER LOSS SHOULD (PROBABLY) HAPPEN HERE
+
+    # Find rates at which water removes soluble nutrients
+    labile_carbon_removal = calculate_solute_removal_by_soil_water(
         solute_density=soil_c_pool_lmwc,
-        vertical_flow_rate=vertical_flow_rate,
+        exit_rate=vertical_flow_rate,
         soil_moisture=soil_moisture,
         solubility_coefficient=constants.solubility_coefficient_lmwc,
     )
-    ammonium_leaching = calculate_leaching_rate(
+    ammonium_removal = calculate_solute_removal_by_soil_water(
         solute_density=soil_n_pool_ammonium,
-        vertical_flow_rate=vertical_flow_rate,
+        exit_rate=vertical_flow_rate,
         soil_moisture=soil_moisture,
         solubility_coefficient=constants.solubility_coefficient_ammonium,
     )
-    nitrate_leaching = calculate_leaching_rate(
+    nitrate_removal = calculate_solute_removal_by_soil_water(
         solute_density=soil_n_pool_nitrate,
-        vertical_flow_rate=vertical_flow_rate,
+        exit_rate=vertical_flow_rate,
         soil_moisture=soil_moisture,
         solubility_coefficient=constants.solubility_coefficient_nitrate,
     )
-    labile_phosphorus_leaching = calculate_leaching_rate(
+    labile_phosphorus_removal = calculate_solute_removal_by_soil_water(
         solute_density=soil_p_pool_labile,
-        vertical_flow_rate=vertical_flow_rate,
+        exit_rate=vertical_flow_rate,
         soil_moisture=soil_moisture,
         solubility_coefficient=constants.solubility_coefficient_labile_p,
     )
 
-    # Find rate at which don and dop are lost due to lmwc leaching
+    # Find rate at which don and dop are lost due to lmwc removal
     c_n_ratio_lmwc = soil_c_pool_lmwc / soil_n_pool_don
     c_p_ratio_lmwc = soil_c_pool_lmwc / soil_p_pool_dop
-    don_leaching = labile_carbon_leaching / c_n_ratio_lmwc
-    dop_leaching = labile_carbon_leaching / c_p_ratio_lmwc
+    don_removal = labile_carbon_removal / c_n_ratio_lmwc
+    dop_removal = labile_carbon_removal / c_p_ratio_lmwc
 
-    return LeachingRates(
-        lmwc=labile_carbon_leaching,
-        don=don_leaching,
-        dop=dop_leaching,
-        ammonium=np.where(ammonium_leaching >= 0.0, ammonium_leaching, 0.0),
-        nitrate=np.where(nitrate_leaching >= 0.0, nitrate_leaching, 0.0),
+    return WaterRemovalRates(
+        lmwc=labile_carbon_removal,
+        don=don_removal,
+        dop=dop_removal,
+        ammonium=np.where(ammonium_removal >= 0.0, ammonium_removal, 0.0),
+        nitrate=np.where(nitrate_removal >= 0.0, nitrate_removal, 0.0),
         labile_P=np.where(
-            labile_phosphorus_leaching >= 0.0, labile_phosphorus_leaching, 0.0
+            labile_phosphorus_removal >= 0.0, labile_phosphorus_removal, 0.0
         ),
     )
 

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -32,6 +32,7 @@ from virtual_ecosystem.models.soil.env_factors import (
     calculate_symbiotic_nitrogen_fixation_carbon_cost,
     calculate_temperature_effect_on_microbes,
     find_total_soil_moisture_for_microbially_active_depth,
+    find_water_outflow_rates,
 )
 from virtual_ecosystem.models.soil.microbial_groups import (
     CarbonSupply,
@@ -508,10 +509,9 @@ class SoilPools:
             soil_n_pool_ammonium=self.pools.soil_n_pool_ammonium,
             soil_n_pool_nitrate=self.pools.soil_n_pool_nitrate,
             soil_p_pool_labile=self.pools.soil_p_pool_labile,
-            vertical_flow_rate=self.data["vertical_flow"][
-                layer_structure.index_topsoil_scalar
-            ].to_numpy(),
+            vertical_flow_rates=self.data["vertical_flow"].to_numpy(),
             soil_moisture=soil_moisture,
+            layer_structure=layer_structure,
             constants=self.constants,
         )
 
@@ -1075,8 +1075,9 @@ def calculate_nutrient_removal_by_water(
     soil_n_pool_ammonium: NDArray[np.floating],
     soil_n_pool_nitrate: NDArray[np.floating],
     soil_p_pool_labile: NDArray[np.floating],
-    vertical_flow_rate: NDArray[np.floating],
+    vertical_flow_rates: NDArray[np.floating],
     soil_moisture: NDArray[np.floating],
+    layer_structure: LayerStructure,
     constants: SoilConsts,
 ) -> WaterRemovalRates:
     """Calculate the rate a which each soluble nutrient pool is removed by water.
@@ -1094,8 +1095,11 @@ def calculate_nutrient_removal_by_water(
         soil_n_pool_ammonium: Soil ammonium pool [kg N m^-3]
         soil_n_pool_nitrate: Soil nitrate pool [kg N m^-3]
         soil_p_pool_labile: Labile inorganic phosphorus pool [kg P m^-3]
-        vertical_flow_rate: Rate of flow downwards through the soil [mm day^-1]
+        vertical_flow_rates: Rates of flow downwards between the different soil layers
+            [mm day^-1]
         soil_moisture: Volume of water contained in topsoil layer [mm]
+        layer_structure: The details of the layer structure used across the Virtual
+                Ecosystem.
         constants: Set of constants for the soil model.
 
     Returns:
@@ -1103,30 +1107,32 @@ def calculate_nutrient_removal_by_water(
         flows of water through the soil.
     """
 
-    # TODO - THE CALCULATION OF TOTAL WATER LOSS SHOULD (PROBABLY) HAPPEN HERE
+    total_exit_rate = find_water_outflow_rates(
+        vertical_flow=vertical_flow_rates, layer_structure=layer_structure
+    )
 
     # Find rates at which water removes soluble nutrients
     labile_carbon_removal = calculate_solute_removal_by_soil_water(
         solute_density=soil_c_pool_lmwc,
-        exit_rate=vertical_flow_rate,
+        exit_rate=total_exit_rate,
         soil_moisture=soil_moisture,
         solubility_coefficient=constants.solubility_coefficient_lmwc,
     )
     ammonium_removal = calculate_solute_removal_by_soil_water(
         solute_density=soil_n_pool_ammonium,
-        exit_rate=vertical_flow_rate,
+        exit_rate=total_exit_rate,
         soil_moisture=soil_moisture,
         solubility_coefficient=constants.solubility_coefficient_ammonium,
     )
     nitrate_removal = calculate_solute_removal_by_soil_water(
         solute_density=soil_n_pool_nitrate,
-        exit_rate=vertical_flow_rate,
+        exit_rate=total_exit_rate,
         soil_moisture=soil_moisture,
         solubility_coefficient=constants.solubility_coefficient_nitrate,
     )
     labile_phosphorus_removal = calculate_solute_removal_by_soil_water(
         solute_density=soil_p_pool_labile,
-        exit_rate=vertical_flow_rate,
+        exit_rate=total_exit_rate,
         soil_moisture=soil_moisture,
         solubility_coefficient=constants.solubility_coefficient_labile_p,
     )


### PR DESCRIPTION
# Description

This PR changes the calculation of removal of nutrient due to water so that it averages over all flows of water out of the microbial active soil region. This actually turns out to be just vertical flows, but this isn't an issue as what we want is for the soil nutrient flows to track the hydrology flows.

I've tried to future proof a bit against possible future changes to the hydrology model by referring to "soil nutrient" removal rather than "leaching" (which is vertical flow specific, I think). 

Fixes #804

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
