### PR TITLE
973 test abiotic model with different number of canopy layers

### DIFF
--- a/tests/models/abiotic/test_abiotic_model.py
+++ b/tests/models/abiotic/test_abiotic_model.py
@@ -45,7 +45,7 @@ SETUP_MANIPULATIONS = (
 
 
 def test_abiotic_model_initialization(
-    caplog, dummy_climate_data, fixture_core_components
+    caplog, dummy_climate_data_varying_canopy, fixture_core_components
 ):
     """Test `AbioticModel` initialization."""
     from virtual_ecosystem.core.base_model import BaseModel
@@ -59,7 +59,7 @@ def test_abiotic_model_initialization(
     ):
         mock_bypass_setup.return_value = False
         model = AbioticModel(
-            dummy_climate_data,
+            dummy_climate_data_varying_canopy,
             core_components=fixture_core_components,
             model_constants=AbioticConsts(),
         )
@@ -178,7 +178,7 @@ def test_abiotic_model_initialization_no_data(caplog, fixture_core_components):
 )
 def test_generate_abiotic_model(
     caplog,
-    dummy_climate_data,
+    dummy_climate_data_varying_canopy,
     cfg_string,
     drag_coeff,
     raises,
@@ -208,7 +208,7 @@ def test_generate_abiotic_model(
         # Check whether model is initialised (or not) as expected
         with raises:
             AbioticModel.from_config(
-                data=dummy_climate_data,
+                data=dummy_climate_data_varying_canopy,
                 core_components=core_components,
                 config=config,
             )
@@ -246,7 +246,7 @@ def test_generate_abiotic_model(
 )
 def test_generate_abiotic_model_bounds_error(
     caplog,
-    dummy_climate_data,
+    dummy_climate_data_varying_canopy,
     cfg_string,
     raises,
     expected_log_entries,
@@ -270,7 +270,7 @@ def test_generate_abiotic_model_bounds_error(
         mock_bypass_setup.return_value = False
         with raises:
             _ = AbioticModel.from_config(
-                data=dummy_climate_data,
+                data=dummy_climate_data_varying_canopy,
                 core_components=core_components,
                 config=config,
             )
@@ -279,7 +279,9 @@ def test_generate_abiotic_model_bounds_error(
     log_check(caplog, expected_log_entries)
 
 
-def test_setup_abiotic_model(dummy_climate_data, fixture_core_components):
+def test_setup_abiotic_model(
+    dummy_climate_data_varying_canopy, fixture_core_components
+):
     """Test that setup() returns expected output in data object."""
 
     from virtual_ecosystem.models.abiotic.abiotic_model import AbioticModel
@@ -293,7 +295,7 @@ def test_setup_abiotic_model(dummy_climate_data, fixture_core_components):
     ):
         mock_bypass_setup.return_value = False
         model = AbioticModel(
-            data=dummy_climate_data,
+            data=dummy_climate_data_varying_canopy,
             core_components=fixture_core_components,
         )
 
@@ -324,18 +326,23 @@ def test_setup_abiotic_model(dummy_climate_data, fixture_core_components):
 
     # Test that soil temperature was created correctly
     expected_soil_temp = lyr_strct.from_template()
-    expected_soil_temp[lyr_strct.index_all_soil] = np.array([20.712458, 20.0])[:, None]
+    expected_soil_temp[lyr_strct.index_all_soil] = np.array(
+        [[20.712458, 21.317566, 21.922674, 21.922674], [20.0, 20.0, 20.0, 20.0]]
+    )
     xr.testing.assert_allclose(model.data["soil_temperature"], expected_soil_temp)
 
     # Test that air temperature was interpolated correctly
     exp_air_temp = lyr_strct.from_template()
-    exp_air_temp[0] = 30.0
-    exp_air_temp[lyr_strct.index_filled_canopy] = np.array(
-        [29.91965, 29.414851, 28.551891]
-    )[:, None]
-    exp_air_temp[lyr_strct.index_surface_scalar] = np.array(
-        [22.81851, 22.81851, 22.81851, 22.81851]
+    exp_air_temp[lyr_strct.index_filled_atmosphere] = np.array(
+        [
+            [30, 30, 30, 30],
+            [29.91965, 29.946434, 29.973217, 29.973217],
+            [29.414851, 29.609901, np.nan, np.nan],
+            [28.551891, np.nan, np.nan, np.nan],
+            [22.81851, 25.21234, 27.60617, 27.60617],
+        ]
     )
+
     xr.testing.assert_allclose(model.data["air_temperature"], exp_air_temp)
 
     # Test other variables have been inserted and some check values
@@ -356,7 +363,7 @@ def test_setup_abiotic_model(dummy_climate_data, fixture_core_components):
     with patch_static_config(AbioticModel) as mock_static_config:
         mock_static_config.return_value = False, False
         model = AbioticModel(
-            data=dummy_climate_data,
+            data=dummy_climate_data_varying_canopy,
             core_components=fixture_core_components,
         )
 
@@ -365,8 +372,8 @@ def test_setup_abiotic_model(dummy_climate_data, fixture_core_components):
     expected_soil_temp1 = lyr_strct.from_template()
     expected_soil_temp1[lyr_strct.index_all_soil] = np.array(
         [
-            [22.3935, 22.35095, 21.925444, 21.925444],
-            [20.040154, 20.03944, 20.032302, 20.032302],
+            [22.3935, 24.064858, 25.343753, 25.343753],
+            [20.040154, 20.068193, 20.089648, 20.089648],
         ],
     )
     expected_soil_moist = lyr_strct.from_template()
@@ -377,18 +384,25 @@ def test_setup_abiotic_model(dummy_climate_data, fixture_core_components):
     xr.testing.assert_allclose(model.data["soil_moisture"], expected_soil_moist)
 
     exp_air_temp = lyr_strct.from_template()
-    exp_air_temp[0] = 30.000122
-    exp_air_temp[lyr_strct.index_filled_canopy] = np.array(
-        [29.913604, 29.408153, 28.545607]
-    )[:, None]
-    exp_air_temp[lyr_strct.index_surface_scalar] = np.array(
-        [22.478502, 22.444462, 22.104057, 22.104057]
+
+    exp_air_temp[lyr_strct.index_filled_atmosphere] = np.array(
+        [
+            [30.000122, 30.000067, np.nan, np.nan],
+            [29.913604, 29.954362, np.nan, np.nan],
+            [29.408153, np.nan, np.nan, np.nan],
+            [28.545607, np.nan, np.nan, np.nan],
+            [22.478502, 24.294355, 25.796236, 25.796236],
+        ]
     )
     xr.testing.assert_allclose(model.data["air_temperature"], exp_air_temp)
 
     exp_canopytemp = lyr_strct.from_template()
     exp_canopytemp[lyr_strct.index_filled_canopy] = np.array(
-        [28.489317, 29.414784, 28.551829]
-    )[:, None]
+        [
+            [28.489317, 31.736854, 31.631768, 31.631768],
+            [29.414784, 29.609833, np.nan, np.nan],
+            [28.551829, np.nan, np.nan, np.nan],
+        ]
+    )
 
     xr.testing.assert_allclose(model.data["canopy_temperature"], exp_canopytemp)

--- a/tests/models/abiotic/test_abiotic_model.py
+++ b/tests/models/abiotic/test_abiotic_model.py
@@ -387,11 +387,11 @@ def test_setup_abiotic_model(
 
     exp_air_temp[lyr_strct.index_filled_atmosphere] = np.array(
         [
-            [30.000122, 30.000067, np.nan, np.nan],
-            [29.913604, 29.954362, np.nan, np.nan],
-            [29.408153, np.nan, np.nan, np.nan],
-            [28.545607, np.nan, np.nan, np.nan],
-            [22.478502, 24.294355, 25.796236, 25.796236],
+            [30.000105, 30.000091, 30.000047, 30.000047],
+            [29.925696, 29.938505, 29.970583, 29.970583],
+            [29.42155, 29.613321, np.nan, np.nan],
+            [28.558176, np.nan, np.nan, np.nan],
+            [23.158518, 26.130326, 29.416104, 29.416104],
         ]
     )
     xr.testing.assert_allclose(model.data["air_temperature"], exp_air_temp)

--- a/tests/models/abiotic/test_abiotic_tools.py
+++ b/tests/models/abiotic/test_abiotic_tools.py
@@ -8,66 +8,95 @@ from virtual_ecosystem.core.constants import CoreConsts
 from virtual_ecosystem.models.abiotic.constants import AbioticConsts
 
 
-def test_calculate_molar_density_air():
+def test_calculate_molar_density_air(
+    dummy_climate_data_varying_canopy, fixture_core_components
+):
     """Test calculate temperature-dependent molar desity of air."""
 
     from virtual_ecosystem.models.abiotic.abiotic_tools import (
         calculate_molar_density_air,
     )
 
+    data = dummy_climate_data_varying_canopy
+    atm_index = fixture_core_components.layer_structure.index_filled_atmosphere
+
     result = calculate_molar_density_air(
-        temperature=np.array([[25.0] * 3, [20.0] * 3, [18.0] * 3]),
-        atmospheric_pressure=np.full((3, 3), 96.0),
+        temperature=data["air_temperature"][atm_index].to_numpy(),
+        atmospheric_pressure=data["atmospheric_pressure"][atm_index].to_numpy(),
         standard_mole=CoreConsts.standard_mole,
         standard_pressure=CoreConsts.standard_pressure,
         celsius_to_kelvin=CoreConsts.zero_Celsius,
     )
-    np.testing.assert_allclose(
-        result,
-        np.array([[38.749371] * 3, [39.410285] * 3, [39.681006] * 3]),
-        rtol=1e-5,
-        atol=1e-5,
+
+    exp_result = np.array(
+        [
+            [38.110259, 38.110259, 38.110259, 38.110259],
+            [38.129755, 38.129755, 38.129755, 38.129755],
+            [38.252699, 38.252699, np.nan, np.nan],
+            [38.46472, np.nan, np.nan, np.nan],
+            [39.256827, 39.256827, 39.256827, 39.256827],
+        ]
     )
+    np.testing.assert_allclose(result, exp_result, rtol=1e-5, atol=1e-5)
 
 
-def test_calculate_air_density(dummy_climate_data):
+def test_calculate_air_density(
+    dummy_climate_data_varying_canopy, fixture_core_components
+):
     """Test calculate the density of air."""
 
     from virtual_ecosystem.models.abiotic.abiotic_tools import calculate_air_density
 
     consts = CoreConsts()
+    data = dummy_climate_data_varying_canopy
+    atm_index = fixture_core_components.layer_structure.index_filled_atmosphere
+
     result = calculate_air_density(
-        air_temperature=dummy_climate_data["air_temperature_ref"]
-        .isel(time_index=0)
-        .to_numpy(),
-        atmospheric_pressure=dummy_climate_data["atmospheric_pressure_ref"]
-        .isel(time_index=0)
-        .to_numpy(),
+        air_temperature=data["air_temperature"][atm_index].to_numpy(),
+        atmospheric_pressure=data["atmospheric_pressure"][atm_index].to_numpy(),
         specific_gas_constant_dry_air=consts.specific_gas_constant_dry_air,
         celsius_to_kelvin=consts.zero_Celsius,
     )
-    np.testing.assert_allclose(
-        result,
-        np.repeat(1.103205, 4),
-        rtol=1e-5,
-        atol=1e-5,
+
+    exp_result = np.array(
+        [
+            [1.103205, 1.103205, 1.103205, 1.103205],
+            [1.103769, 1.103769, 1.103769, 1.103769],
+            [1.107328, 1.107328, np.nan, np.nan],
+            [1.113466, np.nan, np.nan, np.nan],
+            [1.136395, 1.136395, 1.136395, 1.136395],
+        ]
     )
+    np.testing.assert_allclose(result, exp_result, rtol=1e-5, atol=1e-5)
 
 
-def test_calculate_latent_heat_vapourisation():
+def test_calculate_latent_heat_vapourisation(
+    dummy_climate_data_varying_canopy, fixture_core_components
+):
     """Test calculation of latent heat of vapourization."""
 
     from virtual_ecosystem.models.abiotic.abiotic_tools import (
         calculate_latent_heat_vapourisation,
     )
 
+    data = dummy_climate_data_varying_canopy
+    atm_index = fixture_core_components.layer_structure.index_filled_atmosphere
     constants = AbioticConsts()
+
     result = calculate_latent_heat_vapourisation(
-        temperature=np.array([[25.0] * 3, [20.0] * 3, [18.0] * 3]),
+        temperature=data["air_temperature"][atm_index].to_numpy(),
         celsius_to_kelvin=CoreConsts.zero_Celsius,
         latent_heat_vap_equ_factors=constants.latent_heat_vap_equ_factors,
     )
-    exp_result = np.array([[2442.447596] * 3, [2453.174942] * 3, [2457.589459] * 3])
+    exp_result = np.array(
+        [
+            [2432.140894, 2432.140894, 2432.140894, 2432.140894],
+            [2432.454337, 2432.454337, 2432.454337, 2432.454337],
+            [2434.432314, 2434.432314, np.nan, np.nan],
+            [2437.849066, np.nan, np.nan, np.nan],
+            [2450.677865, 2450.677865, 2450.677865, 2450.677865],
+        ]
+    )
 
     np.testing.assert_allclose(result, exp_result, rtol=1e-5, atol=1e-5)
 
@@ -100,24 +129,38 @@ def test_find_last_valid_row(input_array, expected):
     np.testing.assert_allclose(result, expected)
 
 
-def test_calculate_slope_of_saturated_pressure_curve():
+def test_calculate_slope_of_saturated_pressure_curve(
+    dummy_climate_data_varying_canopy, fixture_core_components
+):
     """Test calculation of slope of saturated pressure curve."""
 
     from virtual_ecosystem.models.abiotic.abiotic_tools import (
         calculate_slope_of_saturated_pressure_curve,
     )
 
+    data = dummy_climate_data_varying_canopy
+    atm_index = fixture_core_components.layer_structure.index_filled_atmosphere
     const = AbioticConsts()
+
     result = calculate_slope_of_saturated_pressure_curve(
-        temperature=np.full((4, 3), 20.0),
+        temperature=data["air_temperature"][atm_index].to_numpy(),
         saturated_pressure_slope_parameters=const.saturated_pressure_slope_parameters,
     )
-    exp_result = np.full((4, 3), 0.14474)
+
+    exp_result = np.array(
+        [
+            [0.243363, 0.243363, 0.243363, 0.243363],
+            [0.241487, 0.241487, 0.241487, 0.241487],
+            [0.229981, 0.229981, np.nan, np.nan],
+            [0.211376, np.nan, np.nan, np.nan],
+            [0.153957, 0.153957, 0.153957, 0.153957],
+        ]
+    )
     np.testing.assert_allclose(result, exp_result, rtol=1e-04, atol=1e-04)
 
 
 def test_calculate_actual_vapour_pressure(dummy_climate_data, fixture_core_components):
-    """Calculate effective vapour pressure, [kPa]."""
+    """Test calculate effective vapour pressure."""
 
     from virtual_ecosystem.models.abiotic.abiotic_tools import (
         calculate_actual_vapour_pressure,

--- a/tests/models/abiotic/test_abiotic_tools.py
+++ b/tests/models/abiotic/test_abiotic_tools.py
@@ -179,3 +179,43 @@ def test_calculate_actual_vapour_pressure(dummy_climate_data, fixture_core_compo
         [3.810352, 3.790901, 3.668916, 3.461875, 2.503226]
     )[:, None]
     np.testing.assert_allclose(result, exp_result, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize(
+    "input_array, input_nan_mask, expected",
+    [
+        # Test case 1: Some NaNs, one intended
+        (
+            np.array([[1.0, np.nan], [3.0, np.nan]]),
+            np.array([[False, True], [False, False]]),
+            np.array([[1.0, np.nan], [3.0, 0.0]]),
+        ),
+        # Test case 2: All valid
+        (
+            np.array([[1.0, 2.0], [3.0, 4.0]]),
+            np.array([[False, False], [False, False]]),
+            np.array([[1.0, 2.0], [3.0, 4.0]]),
+        ),
+        # Test case 3: All intended NaNs
+        (
+            np.array([[np.nan, np.nan], [np.nan, np.nan]]),
+            np.array([[True, True], [True, True]]),
+            np.array([[np.nan, np.nan], [np.nan, np.nan]]),
+        ),
+        # Test case 4: One unintended NaN
+        (
+            np.array([[np.nan, 5.0], [6.0, 7.0]]),
+            np.array([[False, False], [False, False]]),
+            np.array([[0.0, 5.0], [6.0, 7.0]]),
+        ),
+    ],
+)
+def test_set_unintended_nan_to_zero(input_array, input_nan_mask, expected):
+    """Test 2D arrays: unintended NaNs are zeroed, intended preserved."""
+
+    from virtual_ecosystem.models.abiotic.abiotic_tools import (
+        set_unintended_nan_to_zero,
+    )
+
+    result = set_unintended_nan_to_zero(input_array, input_nan_mask)
+    np.testing.assert_allclose(result, expected, equal_nan=True)

--- a/tests/models/abiotic/test_abiotic_tools.py
+++ b/tests/models/abiotic/test_abiotic_tools.py
@@ -227,3 +227,31 @@ def test_set_unintended_nan_to_zero(input_array, input_nan_mask, expected):
 
     result = set_unintended_nan_to_zero(input_array, input_nan_mask)
     np.testing.assert_allclose(result, expected, equal_nan=True)
+
+
+def test_compute_layer_thickness_for_varying_canopy(
+    dummy_climate_data_varying_canopy, fixture_core_components
+):
+    """Test layer thickness for varying canopy."""
+    from virtual_ecosystem.models.abiotic.abiotic_tools import (
+        compute_layer_thickness_for_varying_canopy,
+    )
+
+    data = dummy_climate_data_varying_canopy
+    atm_index = fixture_core_components.layer_structure.index_filled_atmosphere
+
+    exp_result = np.array(
+        [
+            [2.0, 2.0, 2.0, 2.0],
+            [10.0, 10.0, 29.9, 29.9],
+            [10.0, 19.9, np.nan, np.nan],
+            [9.9, np.nan, np.nan, np.nan],
+            [0.1, 0.1, 0.1, 0.1],
+        ]
+    )
+
+    result = compute_layer_thickness_for_varying_canopy(
+        heights=data["layer_heights"][atm_index].to_numpy()
+    )
+
+    np.testing.assert_allclose(result, exp_result)

--- a/tests/models/abiotic/test_abiotic_tools.py
+++ b/tests/models/abiotic/test_abiotic_tools.py
@@ -159,25 +159,33 @@ def test_calculate_slope_of_saturated_pressure_curve(
     np.testing.assert_allclose(result, exp_result, rtol=1e-04, atol=1e-04)
 
 
-def test_calculate_actual_vapour_pressure(dummy_climate_data, fixture_core_components):
+def test_calculate_actual_vapour_pressure(
+    dummy_climate_data_varying_canopy, fixture_core_components
+):
     """Test calculate effective vapour pressure."""
 
     from virtual_ecosystem.models.abiotic.abiotic_tools import (
         calculate_actual_vapour_pressure,
     )
 
-    lyr_str = fixture_core_components.layer_structure
+    data = dummy_climate_data_varying_canopy
+    atm_index = fixture_core_components.layer_structure.index_filled_atmosphere
 
     result = calculate_actual_vapour_pressure(
-        air_temperature=dummy_climate_data["air_temperature"],
-        relative_humidity=dummy_climate_data["relative_humidity"],
+        air_temperature=data["air_temperature"][atm_index],
+        relative_humidity=data["relative_humidity"][atm_index],
         pyrealm_const=PyrealmConst,
     )
 
-    exp_result = lyr_str.from_template()
-    exp_result[lyr_str.index_filled_atmosphere] = np.array(
-        [3.810352, 3.790901, 3.668916, 3.461875, 2.503226]
-    )[:, None]
+    exp_result = np.array(
+        [
+            [3.810352, 3.810352, 3.810352, 3.810352],
+            [3.790901, 3.790901, 3.790901, 3.790901],
+            [3.668916, 3.668916, np.nan, np.nan],
+            [3.461875, np.nan, np.nan, np.nan],
+            [2.503226, 2.503226, 2.503226, 2.503226],
+        ]
+    )
     np.testing.assert_allclose(result, exp_result, rtol=1e-3, atol=1e-3)
 
 

--- a/tests/models/abiotic/test_energy_balance.py
+++ b/tests/models/abiotic/test_energy_balance.py
@@ -4,6 +4,9 @@ import numpy as np
 import pytest
 
 from virtual_ecosystem.core.constants import CoreConsts
+from virtual_ecosystem.models.abiotic.abiotic_tools import (
+    compute_layer_thickness_for_varying_canopy,
+)
 from virtual_ecosystem.models.abiotic.constants import AbioticConsts
 
 
@@ -316,7 +319,7 @@ def test_solve_canopy_temperature(
 def test_update_air_temperature(
     dummy_climate_data_varying_canopy, fixture_core_components
 ):
-    """Test update air and canopy temperatures."""
+    """Test update air temperature in canopy."""
     from virtual_ecosystem.models.abiotic.energy_balance import (
         update_air_temperature,
     )
@@ -325,9 +328,9 @@ def test_update_air_temperature(
     lystr = fixture_core_components.layer_structure
     canopy_index = lystr.index_filled_canopy
 
-    heights = data["layer_heights"][lystr.index_filled_atmosphere].to_numpy()
-    heights_with_base = np.vstack([heights, np.zeros(heights.shape[1])])
-    above_ground_layer_thickness = -np.diff(heights_with_base, axis=0)
+    above_ground_layer_thickness = compute_layer_thickness_for_varying_canopy(
+        heights=data["layer_heights"][lystr.index_filled_atmosphere].to_numpy()
+    )
 
     updated_air_temperature = update_air_temperature(
         air_temperature=data["air_temperature"][canopy_index].to_numpy(),
@@ -342,9 +345,9 @@ def test_update_air_temperature(
 
     exp_result = np.array(
         [
-            [29.806235, 29.806235, np.nan, np.nan],
-            [28.840201, np.nan, np.nan, np.nan],
-            [27.188754, np.nan, np.nan, np.nan],
+            [29.883755, 29.883755, 29.857958, 29.857958],
+            [28.902139, 28.886732, np.nan, np.nan],
+            [27.224235, np.nan, np.nan, np.nan],
         ]
     )
     np.testing.assert_allclose(updated_air_temperature, exp_result, rtol=1e-4)
@@ -361,12 +364,12 @@ def test_update_humidity_vpd(
 
     data = dummy_climate_data_varying_canopy
     lystr = fixture_core_components.layer_structure
-    atm_index = lystr.index_filled_atmosphere
     canopy_index = lystr.index_filled_canopy
+    atm_index = lystr.index_filled_atmosphere
 
-    heights = data["layer_heights"][atm_index].to_numpy()
-    heights_with_base = np.vstack([heights, np.zeros(heights.shape[1])])
-    above_ground_layer_thickness = -np.diff(heights_with_base, axis=0)
+    above_ground_layer_thickness = compute_layer_thickness_for_varying_canopy(
+        heights=data["layer_heights"][atm_index].to_numpy()
+    )
 
     evapotranspiration = data["transpiration"] + data["canopy_evaporation"]
     saturated_vapour_pressure = np.array(

--- a/tests/models/abiotic/test_energy_balance.py
+++ b/tests/models/abiotic/test_energy_balance.py
@@ -7,16 +7,23 @@ from virtual_ecosystem.core.constants import CoreConsts
 from virtual_ecosystem.models.abiotic.constants import AbioticConsts
 
 
-def test_initialise_canopy_and_soil_fluxes(dummy_climate_data, fixture_core_components):
+def test_initialise_canopy_and_soil_fluxes(
+    dummy_climate_data_varying_canopy, fixture_core_components
+):
     """Test that canopy and soil fluxes initialised correctly."""
 
     from virtual_ecosystem.models.abiotic.energy_balance import (
         initialise_canopy_and_soil_fluxes,
     )
 
+    data = dummy_climate_data_varying_canopy
+    lyr_str = fixture_core_components.layer_structure
+    canopy_index = lyr_str.index_filled_canopy
+    topsoil_index = lyr_str.index_topsoil_scalar
+
     result = initialise_canopy_and_soil_fluxes(
-        air_temperature=dummy_climate_data["air_temperature"],
-        layer_structure=fixture_core_components.layer_structure,
+        air_temperature=data["air_temperature"],
+        layer_structure=lyr_str,
         initial_flux_value=0.001,
     )
 
@@ -29,27 +36,47 @@ def test_initialise_canopy_and_soil_fluxes(dummy_climate_data, fixture_core_comp
         assert var in result
 
     for var in ["sensible_heat_flux", "latent_heat_flux"]:
-        np.testing.assert_allclose(result[var][1:4].to_numpy(), np.full((3, 4), 0.001))
-        np.testing.assert_allclose(result[var][12].to_numpy(), np.repeat(0.001, 4))
+        np.testing.assert_allclose(
+            result[var][canopy_index].to_numpy(), np.full((3, 4), 0.001)
+        )
+        np.testing.assert_allclose(
+            result[var][topsoil_index].to_numpy(), np.repeat(0.001, 4)
+        )
 
     np.testing.assert_allclose(
-        result["canopy_temperature"][1:4], dummy_climate_data["air_temperature"][1:4]
+        result["canopy_temperature"][canopy_index],
+        data["air_temperature"][canopy_index],
     )
 
 
-def test_calculate_longwave_emission():
+def test_calculate_longwave_emission(
+    dummy_climate_data_varying_canopy, fixture_core_components
+):
     """Test that longwave radiation is calculated correctly."""
 
     from virtual_ecosystem.models.abiotic.energy_balance import (
         calculate_longwave_emission,
     )
 
+    data = dummy_climate_data_varying_canopy
+    lyr_str = fixture_core_components.layer_structure
+    canopy_index = lyr_str.index_filled_canopy
+
     result = calculate_longwave_emission(
-        temperature=np.repeat(290.0, 3),
+        temperature=data["air_temperature"][canopy_index].to_numpy()
+        + CoreConsts.zero_Celsius,
         emissivity=AbioticConsts.soil_emissivity,
         stefan_boltzmann=CoreConsts.stefan_boltzmann_constant,
     )
-    np.testing.assert_allclose(result, np.repeat(381.002069, 3), rtol=1e-04, atol=1e-04)
+
+    exp_result = np.array(
+        [
+            [454.022275, 454.022275, 454.022275, 454.022275],
+            [448.21345, 448.21345, np.nan, np.nan],
+            [438.412504, np.nan, np.nan, np.nan],
+        ]
+    )
+    np.testing.assert_allclose(result, exp_result, rtol=1e-04, atol=1e-04)
 
 
 def test_calculate_sensible_heat_flux(
@@ -154,13 +181,15 @@ def test_update_soil_temperature(g, soil_temp, dz, k, rho, cp, dt, exp_n, exp_te
     np.testing.assert_allclose(updated_temperature, exp_temp, rtol=1e-4, atol=1e-4)
 
 
-def test_energy_balance_residual_only(dummy_climate_data, fixture_core_components):
+def test_energy_balance_residual_only(
+    dummy_climate_data_varying_canopy, fixture_core_components
+):
     """Test energy balance residual without flux return."""
     from virtual_ecosystem.models.abiotic.energy_balance import (
         calculate_energy_balance_residual,
     )
 
-    data = dummy_climate_data
+    data = dummy_climate_data_varying_canopy
     canopy_index = fixture_core_components.layer_structure.index_filled_canopy
     evapotranspiration = data["canopy_evaporation"] + data["transpiration"]
 
@@ -190,13 +219,15 @@ def test_energy_balance_residual_only(dummy_climate_data, fixture_core_component
     assert np.isfinite(result[0, 0])
 
 
-def test_energy_balance_return_fluxes(dummy_climate_data, fixture_core_components):
+def test_energy_balance_return_fluxes(
+    dummy_climate_data_varying_canopy, fixture_core_components
+):
     """Test energy balance residual with flux return."""
     from virtual_ecosystem.models.abiotic.energy_balance import (
         calculate_energy_balance_residual,
     )
 
-    data = dummy_climate_data
+    data = dummy_climate_data_varying_canopy
     canopy_index = fixture_core_components.layer_structure.index_filled_canopy
     evapotranspiration = data["canopy_evaporation"] + data["transpiration"]
 
@@ -234,14 +265,16 @@ def test_energy_balance_return_fluxes(dummy_climate_data, fixture_core_component
         assert result[key].shape == (3, 4)
 
 
-def test_solve_canopy_temperature(dummy_climate_data, fixture_core_components):
+def test_solve_canopy_temperature(
+    dummy_climate_data_varying_canopy, fixture_core_components
+):
     """Test solving canopy temperature with Newton method."""
 
     from virtual_ecosystem.models.abiotic.energy_balance import (
         solve_canopy_temperature,
     )
 
-    data = dummy_climate_data
+    data = dummy_climate_data_varying_canopy
     canopy_index = fixture_core_components.layer_structure.index_filled_canopy
     evapotranspiration = data["canopy_evaporation"] + data["transpiration"]
 
@@ -269,80 +302,122 @@ def test_solve_canopy_temperature(dummy_climate_data, fixture_core_components):
 
     assert isinstance(result, np.ndarray)
     assert result.shape == data["canopy_temperature"][canopy_index].shape
-    assert np.all((result > 0) & (result < 50))  # plausible range for °C
+
+    # Mask where input is not NaN
+    mask = ~np.isnan(data["canopy_temperature"][canopy_index])
+
+    # Assert plausible range for non-NaN input
+    assert np.all((result[mask] > 0) & (result[mask] < 50))
+
+    # Assert NaNs are preserved
+    assert np.all(np.isnan(result[~mask]))
 
 
-def test_update_air_temperature():
+def test_update_air_temperature(
+    dummy_climate_data_varying_canopy, fixture_core_components
+):
     """Test update air and canopy temperatures."""
     from virtual_ecosystem.models.abiotic.energy_balance import (
         update_air_temperature,
     )
 
-    air_temperature = np.array([[30.0, 25.0], [28.0, 23.0]])
-    canopy_temperature = np.array([[31.0, 26.0], [30.0, 25.0]])
-    expected_air_temperature = np.array([[30.01, 25.01], [28.02, 23.02]])
+    data = dummy_climate_data_varying_canopy
+    lystr = fixture_core_components.layer_structure
+    canopy_index = lystr.index_filled_canopy
+
+    heights = data["layer_heights"][lystr.index_filled_atmosphere].to_numpy()
+    heights_with_base = np.vstack([heights, np.zeros(heights.shape[1])])
+    above_ground_layer_thickness = -np.diff(heights_with_base, axis=0)
 
     updated_air_temperature = update_air_temperature(
-        air_temperature=air_temperature,
-        surface_temperature=canopy_temperature,
-        specific_heat_air=np.full((2, 2), 1006),
-        density_air=np.full((2, 2), 1.293),
-        aerodynamic_resistance=np.full((2, 2), 10.0),
-        mixing_layer_thickness=np.full((2, 2), 10),
+        air_temperature=data["air_temperature"][canopy_index].to_numpy(),
+        surface_temperature=data["canopy_temperature"][canopy_index].to_numpy(),
+        specific_heat_air=data["specific_heat_air"][canopy_index].to_numpy(),
+        density_air=data["density_air"][canopy_index].to_numpy(),
+        aerodynamic_resistance=data["aerodynamic_resistance_canopy"][
+            canopy_index
+        ].to_numpy(),
+        mixing_layer_thickness=above_ground_layer_thickness[1:-1],
     )
 
-    np.testing.assert_allclose(
-        updated_air_temperature, expected_air_temperature, rtol=1e-4
+    exp_result = np.array(
+        [
+            [29.806235, 29.806235, np.nan, np.nan],
+            [28.840201, np.nan, np.nan, np.nan],
+            [27.188754, np.nan, np.nan, np.nan],
+        ]
     )
+    np.testing.assert_allclose(updated_air_temperature, exp_result, rtol=1e-4)
 
 
-def test_update_humidity_vpd():
+def test_update_humidity_vpd(
+    dummy_climate_data_varying_canopy, fixture_core_components
+):
     """Test update atmospheric humidity."""
 
     from virtual_ecosystem.models.abiotic.energy_balance import (
         update_humidity_vpd,
     )
 
-    # Define test inputs
-    evapotranspiration = np.tile([0.1, 0.2, 0.3, 0.3], (3, 1))
-    soil_evaporation = np.array([0.05, 0.02, 0.03, 0.04])
-    saturated_vapour_pressure = np.tile([3.0, 2.5, 2.0, 2.0], (5, 1))
-    specific_humidity = np.tile([0.010, 0.012, 0.014, 0.015], (5, 1))
-    layer_thickness = np.array(
+    data = dummy_climate_data_varying_canopy
+    lystr = fixture_core_components.layer_structure
+    atm_index = lystr.index_filled_atmosphere
+    canopy_index = lystr.index_filled_canopy
+
+    heights = data["layer_heights"][atm_index].to_numpy()
+    heights_with_base = np.vstack([heights, np.zeros(heights.shape[1])])
+    above_ground_layer_thickness = -np.diff(heights_with_base, axis=0)
+
+    evapotranspiration = data["transpiration"] + data["canopy_evaporation"]
+    saturated_vapour_pressure = np.array(
         [
+            [2.5, 2.5, 2.5, 2.5],
+            [2.5, 2.5, 2.5, np.nan],
+            [2.0, 2.0, np.nan, np.nan],
+            [1.8, np.nan, np.nan, np.nan],
             [2.0, 2.0, 2.0, 2.0],
-            [10.0, 10.0, 10.0, 10.0],
-            [5.0, 5.0, 5.0, 5.0],
-            [2.0, 2.0, 2.0, 2.0],
-            [0.25, 0.25, 0.25, 0.25],
         ]
     )
-    atmospheric_pressure = np.tile([100.0, 95.0, 90.0, 90.0], (5, 1))
-    density_air = np.tile([1.2, 1.2, 1.2, 1.2], (5, 1))
-    mixing_coefficient = np.tile([0.001, 0.005, 0.01, 0.001], (5, 1))
-    ventilation_rate = np.array([0.01, 0.0, 0.0, 0.02])
-    wind_speed = np.array([1, 2, 0.5, 0.1])
+    specific_humidity = np.array(
+        [
+            [0.02, 0.02, 0.02, 0.02],
+            [0.012, 0.012, 0.012, np.nan],
+            [0.014, 0.014, np.nan, np.nan],
+            [0.015, np.nan, np.nan, np.nan],
+            [0.012, 0.012, 0.012, 0.012],
+        ]
+    )
 
-    molecular_weight_ratio_water_to_dry_air = 0.622
-    dry_air_factor = 1.0 - 0.622
-    cell_area = 10000.0
+    mixing_coefficient = np.array(
+        [
+            [0.001, 0.001, 0.001, 0.001],
+            [0.005, 0.005, 0.005, np.nan],
+            [0.01, 0.01, np.nan, np.nan],
+            [0.001, np.nan, np.nan, np.nan],
+            [0.012, 0.012, 0.012, 0.012],
+        ]
+    )
+    ventilation_rate = np.array([0.01, 0.01, 0.01, 0.01])
     time_interval = 3600.0
+    mask = np.isnan(specific_humidity)
 
     # Run function
     result = update_humidity_vpd(
-        evapotranspiration=evapotranspiration,
-        soil_evaporation=soil_evaporation,
+        evapotranspiration=evapotranspiration[canopy_index].to_numpy(),
+        soil_evaporation=data["soil_evaporation"].to_numpy(),
         saturated_vapour_pressure=saturated_vapour_pressure,
         specific_humidity=specific_humidity,
-        layer_thickness=layer_thickness,
-        atmospheric_pressure=atmospheric_pressure,
-        density_air=density_air,
+        layer_thickness=above_ground_layer_thickness,
+        atmospheric_pressure=data["atmospheric_pressure"][atm_index].to_numpy(),
+        density_air=data["density_air"][atm_index].to_numpy(),
         mixing_coefficient=mixing_coefficient,
         ventilation_rate=ventilation_rate,
-        wind_speed=wind_speed,
-        molecular_weight_ratio_water_to_dry_air=molecular_weight_ratio_water_to_dry_air,
-        dry_air_factor=dry_air_factor,
-        cell_area=cell_area,
+        wind_speed=data["wind_speed_ref"].isel(time_index=0).to_numpy(),
+        molecular_weight_ratio_water_to_dry_air=(
+            CoreConsts.molecular_weight_ratio_water_to_dry_air
+        ),
+        dry_air_factor=1 - CoreConsts.molecular_weight_ratio_water_to_dry_air,
+        cell_area=fixture_core_components.grid.cell_area,
         time_interval=time_interval,
     )
 
@@ -355,19 +430,17 @@ def test_update_humidity_vpd():
     ]:
         assert key in result
         assert isinstance(result[key], np.ndarray)
+        assert np.all(np.isnan(result[key][mask]))
 
-    # Expected trends: ET and mixing should raise humidity slightly
-    assert np.all(result["specific_humidity"] >= 0.00)
+    # Expected trends: ET and mixing should raise humidity slightly where is not NaN
+    assert np.all(result["specific_humidity"][~mask] >= 0.00)
 
     # VPD should be reduced where evapotranspiration or mixing adds moisture
-    assert np.all(result["vapour_pressure_deficit"] >= 0.0)
-    assert np.all(result["vapour_pressure"] <= saturated_vapour_pressure)
+    assert np.all(result["vapour_pressure_deficit"][~mask] >= 0.0)
+    assert np.all(result["vapour_pressure"][~mask] <= saturated_vapour_pressure[~mask])
 
     # RH should be between 0 and 100
     assert np.all(
-        (result["relative_humidity"] >= 0) & (result["relative_humidity"] <= 100)
-    )
-    np.testing.assert_allclose(result["relative_humidity"][0], np.array([0, 0, 0, 0]))
-    np.testing.assert_allclose(
-        result["relative_humidity"][1], np.array([100.0, 100.0, 100.0, 100.0])
+        (result["relative_humidity"][~mask] >= 0)
+        & (result["relative_humidity"][~mask] <= 100)
     )

--- a/tests/models/abiotic/test_microclimate.py
+++ b/tests/models/abiotic/test_microclimate.py
@@ -65,37 +65,32 @@ def test_run_microclimate(dummy_climate_data_varying_canopy, fixture_core_compon
     )
 
     # Check that all air temperature values fall within a reasonable expected range
-    # mask = np.isnan(
-    #     dummy_climate_data_varying_canopy["air_temperature"][
-    #         lyr_str.index_filled_atmosphere
-    #     ]
-    # )
-    # air_temp_result = result["air_temperature"][lyr_str.index_filled_atmosphere]
-    # assert np.all((air_temp_result[~mask] >= 16.0) & (air_temp_result[~mask] <= 36.0))
+    air_temp_result = result["air_temperature"].isel(
+        layers=lyr_str.index_filled_atmosphere
+    )
 
-    print(result["air_temperature"])
-    # np.array([[30.00023402, 30.00024546,         nan,         nan],
-    #    [29.83391357, 29.83371163,         nan,         nan],
-    #    [28.88179021,         nan,         nan,         nan],
-    #    [27.21446276,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [21.10594219, 21.07185157, 20.73094533, 20.73094533],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    # ]
-    # )
+    mask = ~np.isnan(
+        dummy_climate_data_varying_canopy["air_temperature"].isel(
+            layers=lyr_str.index_filled_atmosphere
+        )
+    )
+
+    # Use the mask as a DataArray for .where()
+    valid_values = air_temp_result.where(mask)
+
+    # Now drop the NaNs (i.e., masked values)
+    valid_values_clean = valid_values.dropna(
+        dim="layers", how="any"
+    )  # or "all" if you're doing 2D
+
+    # Now do the test
+    assert ((valid_values_clean >= 16.0) & (valid_values_clean <= 36.0)).all()
 
     exp_relhum = lyr_str.from_template()
     exp_relhum[lyr_str.index_filled_atmosphere] = np.array(
         [
-            [100, 100, np.nan, np.nan],
-            [100, 100, np.nan, np.nan],
+            [100, 100, 100, 100],
+            [100, 100, 100, 100],
             [100, np.nan, np.nan, np.nan],
             [100, np.nan, np.nan, np.nan],
             [100, 100, 100, 100],
@@ -131,25 +126,29 @@ def test_run_microclimate_subdaily(
         core_constants=CoreConsts(),
         pyrealm_const=PyrealmConst(),
     )
-    print(result["air_temperature"])
-    # np.array([[29.98536857, 29.99051257,         nan,         nan],
-    #    [33.7172163 , 31.35657893,         nan,         nan],
-    #    [34.28084653,         nan,         nan,         nan],
-    #    [32.64513234,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [21.87141268, 21.73480416, 20.36795001, 20.36795001],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan]])
 
     # Check that all air temperature values fall within a reasonable expected range
-    air_temp_result = result["air_temperature"][lyr_str.index_filled_atmosphere]
-    assert np.all((air_temp_result >= 16.0) & (air_temp_result <= 36.0))
+    # Check that all air temperature values fall within a reasonable expected range
+    air_temp_result = result["air_temperature"].isel(
+        layers=lyr_str.index_filled_atmosphere
+    )
+
+    mask = ~np.isnan(
+        dummy_climate_data_varying_canopy["air_temperature"].isel(
+            layers=lyr_str.index_filled_atmosphere
+        )
+    )
+
+    # Use the mask as a DataArray for .where()
+    valid_values = air_temp_result.where(mask)
+
+    # Now drop the NaNs (i.e., masked values)
+    valid_values_clean = valid_values.dropna(
+        dim="layers", how="any"
+    )  # or "all" if you're doing 2D
+
+    # Now do the test
+    assert ((valid_values_clean >= 16.0) & (valid_values_clean <= 36.0)).all()
 
 
 def test_run_microclimate_minutes(
@@ -172,21 +171,26 @@ def test_run_microclimate_minutes(
         core_constants=CoreConsts(),
         pyrealm_const=PyrealmConst(),
     )
-    print(result["air_temperature"])
-    # np.array([[30.00164585, 30.00056018,         nan,         nan],
-    #    [28.8318953 , 29.62049735,         nan,         nan],
-    #    [21.30954266,         nan,         nan,         nan],
-    #    [19.59780849,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan],
-    #    [21.10594219, 21.07185157, 20.73094533, 20.73094533],
-    #    [        nan,         nan,         nan,         nan],
-    #    [        nan,         nan,         nan,         nan]])
+
     # Check that all air temperature values fall within a reasonable expected range
-    air_temp_result = result["air_temperature"][lyr_str.index_filled_atmosphere]
-    assert np.all((air_temp_result >= 16.0) & (air_temp_result <= 36.0))
+    # Check that all air temperature values fall within a reasonable expected range
+    air_temp_result = result["air_temperature"].isel(
+        layers=lyr_str.index_filled_atmosphere
+    )
+
+    mask = ~np.isnan(
+        dummy_climate_data_varying_canopy["air_temperature"].isel(
+            layers=lyr_str.index_filled_atmosphere
+        )
+    )
+
+    # Use the mask as a DataArray for .where()
+    valid_values = air_temp_result.where(mask)
+
+    # Now drop the NaNs (i.e., masked values)
+    valid_values_clean = valid_values.dropna(
+        dim="layers", how="any"
+    )  # or "all" if you're doing 2D
+
+    # Now do the test
+    assert ((valid_values_clean >= 16.0) & (valid_values_clean <= 36.0)).all()

--- a/tests/models/abiotic/test_microclimate.py
+++ b/tests/models/abiotic/test_microclimate.py
@@ -8,7 +8,7 @@ from virtual_ecosystem.models.abiotic.constants import AbioticConsts
 
 
 # Test integration (TODO add structural and value range check)
-def test_run_microclimate(dummy_climate_data, fixture_core_components):
+def test_run_microclimate(dummy_climate_data_varying_canopy, fixture_core_components):
     """Test microclimate function."""
 
     from virtual_ecosystem.models.abiotic.microclimate import (
@@ -17,7 +17,7 @@ def test_run_microclimate(dummy_climate_data, fixture_core_components):
 
     lyr_str = fixture_core_components.layer_structure
     result = run_microclimate(
-        data=dummy_climate_data,
+        data=dummy_climate_data_varying_canopy,
         time_index=0,
         time_interval=86400 * 30,
         cell_area=10000,
@@ -50,9 +50,13 @@ def test_run_microclimate(dummy_climate_data, fixture_core_components):
     )
 
     exp_cantemp = lyr_str.from_template()
-    exp_cantemp[lyr_str.index_filled_canopy] = np.array([27.2234, 28.8712, 27.2064])[
-        :, None
-    ]
+    exp_cantemp[lyr_str.index_filled_canopy] = np.array(
+        [
+            [27.223404, 27.296955, 27.407225, 27.407225],
+            [28.871276, 28.871276, np.nan, np.nan],
+            [27.206485, np.nan, np.nan, np.nan],
+        ]
+    )
     np.testing.assert_allclose(
         result["canopy_temperature"][lyr_str.index_filled_canopy],
         exp_cantemp[lyr_str.index_filled_canopy],
@@ -61,13 +65,42 @@ def test_run_microclimate(dummy_climate_data, fixture_core_components):
     )
 
     # Check that all air temperature values fall within a reasonable expected range
-    air_temp_result = result["air_temperature"][lyr_str.index_filled_atmosphere]
-    assert np.all((air_temp_result >= 16.0) & (air_temp_result <= 36.0))
+    # mask = np.isnan(
+    #     dummy_climate_data_varying_canopy["air_temperature"][
+    #         lyr_str.index_filled_atmosphere
+    #     ]
+    # )
+    # air_temp_result = result["air_temperature"][lyr_str.index_filled_atmosphere]
+    # assert np.all((air_temp_result[~mask] >= 16.0) & (air_temp_result[~mask] <= 36.0))
+
+    print(result["air_temperature"])
+    # np.array([[30.00023402, 30.00024546,         nan,         nan],
+    #    [29.83391357, 29.83371163,         nan,         nan],
+    #    [28.88179021,         nan,         nan,         nan],
+    #    [27.21446276,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [21.10594219, 21.07185157, 20.73094533, 20.73094533],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    # ]
+    # )
 
     exp_relhum = lyr_str.from_template()
-    exp_relhum[lyr_str.index_filled_atmosphere] = np.array([100, 100, 100, 100, 100])[
-        :, None
-    ]
+    exp_relhum[lyr_str.index_filled_atmosphere] = np.array(
+        [
+            [100, 100, np.nan, np.nan],
+            [100, 100, np.nan, np.nan],
+            [100, np.nan, np.nan, np.nan],
+            [100, np.nan, np.nan, np.nan],
+            [100, 100, 100, 100],
+        ]
+    )
     np.testing.assert_allclose(
         result["relative_humidity"],
         exp_relhum,
@@ -76,7 +109,9 @@ def test_run_microclimate(dummy_climate_data, fixture_core_components):
     )
 
 
-def test_run_microclimate_subdaily(dummy_climate_data, fixture_core_components):
+def test_run_microclimate_subdaily(
+    dummy_climate_data_varying_canopy, fixture_core_components
+):
     """Test microclimate function iterates over hours - no time index."""
 
     # TODO this test returns different results on windows machines (around 1.5 K),
@@ -87,7 +122,7 @@ def test_run_microclimate_subdaily(dummy_climate_data, fixture_core_components):
 
     lyr_str = fixture_core_components.layer_structure
     result = run_microclimate(
-        data=dummy_climate_data,
+        data=dummy_climate_data_varying_canopy,
         time_index=0,
         time_interval=3600 * 4,
         cell_area=10000,
@@ -96,13 +131,30 @@ def test_run_microclimate_subdaily(dummy_climate_data, fixture_core_components):
         core_constants=CoreConsts(),
         pyrealm_const=PyrealmConst(),
     )
+    print(result["air_temperature"])
+    # np.array([[29.98536857, 29.99051257,         nan,         nan],
+    #    [33.7172163 , 31.35657893,         nan,         nan],
+    #    [34.28084653,         nan,         nan,         nan],
+    #    [32.64513234,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [21.87141268, 21.73480416, 20.36795001, 20.36795001],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan]])
 
     # Check that all air temperature values fall within a reasonable expected range
     air_temp_result = result["air_temperature"][lyr_str.index_filled_atmosphere]
     assert np.all((air_temp_result >= 16.0) & (air_temp_result <= 36.0))
 
 
-def test_run_microclimate_minutes(dummy_climate_data, fixture_core_components):
+def test_run_microclimate_minutes(
+    dummy_climate_data_varying_canopy, fixture_core_components
+):
     """Test microclimate function iterates once for <1h time interval."""
 
     from virtual_ecosystem.models.abiotic.microclimate import (
@@ -111,7 +163,7 @@ def test_run_microclimate_minutes(dummy_climate_data, fixture_core_components):
 
     lyr_str = fixture_core_components.layer_structure
     result = run_microclimate(
-        data=dummy_climate_data,
+        data=dummy_climate_data_varying_canopy,
         time_index=0,
         time_interval=60,
         cell_area=10000,
@@ -120,7 +172,21 @@ def test_run_microclimate_minutes(dummy_climate_data, fixture_core_components):
         core_constants=CoreConsts(),
         pyrealm_const=PyrealmConst(),
     )
-
+    print(result["air_temperature"])
+    # np.array([[30.00164585, 30.00056018,         nan,         nan],
+    #    [28.8318953 , 29.62049735,         nan,         nan],
+    #    [21.30954266,         nan,         nan,         nan],
+    #    [19.59780849,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan],
+    #    [21.10594219, 21.07185157, 20.73094533, 20.73094533],
+    #    [        nan,         nan,         nan,         nan],
+    #    [        nan,         nan,         nan,         nan]])
     # Check that all air temperature values fall within a reasonable expected range
     air_temp_result = result["air_temperature"][lyr_str.index_filled_atmosphere]
     assert np.all((air_temp_result >= 16.0) & (air_temp_result <= 36.0))

--- a/tests/models/abiotic/test_wind.py
+++ b/tests/models/abiotic/test_wind.py
@@ -162,7 +162,7 @@ def test_calculate_mixing_coefficients():
     np.testing.assert_allclose(result, expected, rtol=1e-6)
 
 
-def test_mix_and_ventilate(dummy_climate_data, fixture_core_components):
+def test_mix_and_ventilate(dummy_climate_data_varying_canopy, fixture_core_components):
     """Test mixing and ventilation."""
 
     from virtual_ecosystem.models.abiotic.wind import (
@@ -170,36 +170,42 @@ def test_mix_and_ventilate(dummy_climate_data, fixture_core_components):
     )
 
     lystr = fixture_core_components.layer_structure
-    data = dummy_climate_data
-    input_variable = data["relative_humidity"][lystr.index_filled_atmosphere].to_numpy()
+    data = dummy_climate_data_varying_canopy
+    atm_index = lystr.index_filled_atmosphere
 
-    layer_thickness = np.array(
+    heights = data["layer_heights"][atm_index].to_numpy()
+    heights_with_base = np.vstack([heights, np.zeros(heights.shape[1])])
+    above_ground_layer_thickness = -np.diff(heights_with_base, axis=0)
+
+    mixing_coefficient = np.array(
         [
-            [2.0, 2.0, 2.0, 2.0],
-            [10.0, 10.0, 10.0, 10.0],
-            [5.0, 5.0, 5.0, 5.0],
-            [2.0, 2.0, 2.0, 2.0],
-            [0.25, 0.25, 0.25, 0.25],
+            [0.001, 0.001, 0.001, 0.001],
+            [0.005, 0.005, np.nan, np.nan],
+            [0.01, 0.01, np.nan, np.nan],
+            [0.001, np.nan, np.nan, np.nan],
+            [0.012, 0.012, 0.012, 0.012],
         ]
     )
+    ventilation_rate = np.array([0.01, 0.01, 0.01, 0.01])
+
     exp_result = np.array(
         [
-            [77.700816, 65.401632, 53.102448, 40.803264],
+            [77.700816, 77.700816, 77.700816, 77.700816],
             [90.341644, 90.341644, 90.341644, 90.341644],
-            [92.70733, 92.70733, 92.70733, 92.70733],
-            [96.313381, 96.313381, 96.313381, 96.313381],
+            [92.233778, np.nan, np.nan, np.nan],
+            [96.503298, np.nan, np.nan, np.nan],
             [100.0, 100.0, 100.0, 100.0],
         ]
     )
 
     result = mix_and_ventilate(
-        input_variable=input_variable,
-        layer_thickness=layer_thickness,
-        mixing_coefficient=np.full((5, 4), 0.001),
-        ventilation_rate=np.array([0.01, 0.02, 0.03, 0.04]),
+        input_variable=data["relative_humidity"][atm_index].to_numpy(),
+        layer_thickness=above_ground_layer_thickness,
+        mixing_coefficient=mixing_coefficient,
+        ventilation_rate=ventilation_rate,
         time_interval=3600.0,
     )
-    np.testing.assert_allclose(result, exp_result)
+    np.testing.assert_allclose(result, exp_result, rtol=1e-6, atol=1e-6)
 
 
 def test_advect_from_toplayer():

--- a/tests/models/abiotic/test_wind.py
+++ b/tests/models/abiotic/test_wind.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 
-def test_calculate_zero_plane_displacement(dummy_climate_data):
+def test_calculate_zero_plane_displacement(dummy_climate_data_varying_canopy):
     """Test if calculated correctly and set to zero without vegetation."""
 
     from virtual_ecosystem.models.abiotic.wind import (
@@ -11,7 +11,7 @@ def test_calculate_zero_plane_displacement(dummy_climate_data):
     )
 
     result = calculate_zero_plane_displacement(
-        canopy_height=dummy_climate_data["layer_heights"][1].to_numpy(),
+        canopy_height=dummy_climate_data_varying_canopy["layer_heights"][1].to_numpy(),
         leaf_area_index=np.array([0.0, np.nan, 7.0, 7.0]),
         zero_plane_scaling_parameter=7.5,
     )
@@ -19,7 +19,7 @@ def test_calculate_zero_plane_displacement(dummy_climate_data):
     np.testing.assert_allclose(result, np.array([0.0, 0.0, 25.86256, 25.86256]))
 
 
-def test_calculate_roughness_length_momentum(dummy_climate_data):
+def test_calculate_roughness_length_momentum(dummy_climate_data_varying_canopy):
     """Test roughness length governing momentum transfer."""
 
     from virtual_ecosystem.models.abiotic.wind import (
@@ -27,7 +27,7 @@ def test_calculate_roughness_length_momentum(dummy_climate_data):
     )
 
     result = calculate_roughness_length_momentum(
-        canopy_height=dummy_climate_data["layer_heights"][1].to_numpy(),
+        canopy_height=dummy_climate_data_varying_canopy["layer_heights"][1].to_numpy(),
         leaf_area_index=np.array([np.nan, 0.0, 7, 7]),
         zero_plane_displacement=np.array([0.0, 0.0, 27.58673, 27.58673]),
         substrate_surface_drag_coefficient=0.003,
@@ -43,21 +43,20 @@ def test_calculate_roughness_length_momentum(dummy_climate_data):
     )
 
 
-def test_calculate_wind_profile(dummy_climate_data, fixture_core_components):
+def test_calculate_wind_profile(
+    dummy_climate_data_varying_canopy, fixture_core_components
+):
     """Test calculate wind profile."""
 
     from virtual_ecosystem.models.abiotic.wind import calculate_wind_profile
 
     lyr_str = fixture_core_components.layer_structure
+    data = dummy_climate_data_varying_canopy
 
     result = calculate_wind_profile(
-        reference_wind_speed=dummy_climate_data["wind_speed_ref"]
-        .isel(time_index=0)
-        .to_numpy(),
-        reference_height=dummy_climate_data["layer_heights"][0].to_numpy() + 10.0,
-        wind_heights=dummy_climate_data["layer_heights"][
-            lyr_str.index_filled_atmosphere
-        ].to_numpy(),
+        reference_wind_speed=data["wind_speed_ref"].isel(time_index=0).to_numpy(),
+        reference_height=data["layer_heights"][0].to_numpy() + 10.0,
+        wind_heights=data["layer_heights"][lyr_str.index_filled_atmosphere].to_numpy(),
         roughness_length=np.repeat(0.3, 4),
         zero_plane_displacement=np.array([0, 10, 25, 25]),
         min_wind_speed=0.001,
@@ -76,18 +75,18 @@ def test_calculate_wind_profile(dummy_climate_data, fixture_core_components):
     np.testing.assert_allclose(result, exp_wind, rtol=1e-3, atol=1e-3)
 
 
-def test_calculate_friction_velocity(dummy_climate_data):
+def test_calculate_friction_velocity(dummy_climate_data_varying_canopy):
     """Test calculating friction velocity."""
 
     from virtual_ecosystem.models.abiotic.wind import (
         calculate_friction_velocity,
     )
 
+    data = dummy_climate_data_varying_canopy
+
     result = calculate_friction_velocity(
-        reference_wind_speed=dummy_climate_data["wind_speed_ref"]
-        .isel(time_index=0)
-        .to_numpy(),
-        reference_height=dummy_climate_data["layer_heights"][0].to_numpy() + 10.0,
+        reference_wind_speed=data["wind_speed_ref"].isel(time_index=0).to_numpy(),
+        reference_height=data["layer_heights"][0].to_numpy() + 10.0,
         roughness_length=np.repeat(0.3, 4),
         zero_plane_displacement=np.array([0, 10, 25, 25]),
         von_karman_constant=0.4,

--- a/virtual_ecosystem/models/abiotic/abiotic_tools.py
+++ b/virtual_ecosystem/models/abiotic/abiotic_tools.py
@@ -198,10 +198,10 @@ def compute_layer_thickness_for_varying_canopy(
     .
 
     Args:
-        heights: 2D array (n_layers, n_columns) of layer heights [m]
+        heights: 2D array (n_layers, n_columns) of layer heights, [m]
 
     Returns:
-        thickness: 2D array of thickness [m], same shape as input
+        2D array of layer thickness, [m], same shape as input
     """
     n_layers, n_cols = heights.shape
     thickness = np.full_like(heights, np.nan)

--- a/virtual_ecosystem/models/abiotic/abiotic_tools.py
+++ b/virtual_ecosystem/models/abiotic/abiotic_tools.py
@@ -186,3 +186,43 @@ def set_unintended_nan_to_zero(
     arr_clean = np.where(np.isnan(input_array), 0.0, input_array)
     arr_clean[input_nan_mask] = np.nan
     return arr_clean
+
+
+def compute_layer_thickness_for_varying_canopy(
+    heights: NDArray[np.floating],
+) -> NDArray[np.floating]:
+    """Calculate layer thickness for varying canopy layers.
+
+    Calculate layer thickness by subtracting from the next valid layer below (skipping
+    NaNs), and for the last valid layer in each column subtract from zero (ground level)
+    .
+
+    Args:
+        heights: 2D array (n_layers, n_columns) of layer heights [m]
+
+    Returns:
+        thickness: 2D array of thickness [m], same shape as input
+    """
+    n_layers, n_cols = heights.shape
+    thickness = np.full_like(heights, np.nan)
+
+    for col in range(n_cols):
+        for row in range(n_layers):
+            current = heights[row, col]
+            if np.isnan(current):
+                continue
+
+            # Find next valid (non-NaN) layer below
+            next_valid_found = False
+            for lower_row in range(row + 1, n_layers):
+                below = heights[lower_row, col]
+                if not np.isnan(below):
+                    thickness[row, col] = current - below
+                    next_valid_found = True
+                    break
+
+            # If no valid lower layer found, thickness = current - 0 (ground)
+            if not next_valid_found:
+                thickness[row, col] = current - 0.0
+
+    return thickness

--- a/virtual_ecosystem/models/abiotic/abiotic_tools.py
+++ b/virtual_ecosystem/models/abiotic/abiotic_tools.py
@@ -168,3 +168,21 @@ def calculate_actual_vapour_pressure(
         core_const=pyrealm_const(),
     )
     return saturation_vapour_pressure_air * relative_humidity / 100.0
+
+
+def set_unintended_nan_to_zero(
+    input_array: NDArray[np.floating],
+    input_nan_mask: NDArray[np.bool],
+) -> NDArray[np.floating]:
+    """Clean up outputs: set unintended NaNs to 0, preserve intended NaNs.
+
+    Args:
+        input_array: Input array that may contain NaN
+        input_nan_mask: A mask of intended NaN
+
+    Returns:
+        Array with unintended NaN set to zero
+    """
+    arr_clean = np.where(np.isnan(input_array), 0.0, input_array)
+    arr_clean[input_nan_mask] = np.nan
+    return arr_clean

--- a/virtual_ecosystem/models/abiotic/energy_balance.py
+++ b/virtual_ecosystem/models/abiotic/energy_balance.py
@@ -554,10 +554,9 @@ def update_air_temperature(
     ) / aerodynamic_resistance
 
     # Update air temperature over a layer of height z (e.g., canopy height)
-    new_air_temperature = air_temperature + (sensible_heat_flux) / (
-        density_air * specific_heat_air * mixing_layer_thickness
+    new_air_temperature = air_temperature + (
+        -sensible_heat_flux / (density_air * specific_heat_air * mixing_layer_thickness)
     )
-
     return new_air_temperature
 
 

--- a/virtual_ecosystem/models/abiotic/energy_balance.py
+++ b/virtual_ecosystem/models/abiotic/energy_balance.py
@@ -47,6 +47,7 @@ from xarray import DataArray
 
 from virtual_ecosystem.core.core_components import LayerStructure
 from virtual_ecosystem.models.abiotic import wind
+from virtual_ecosystem.models.abiotic.abiotic_tools import set_unintended_nan_to_zero
 
 
 def initialise_canopy_and_soil_fluxes(
@@ -603,6 +604,9 @@ def update_humidity_vpd(
       ``specific_humidity``, ``vapour_pressure`` and ``vapour_pressure_deficit`` values.
     """
 
+    # Create a mask of where the input was NaN (no true canopy)
+    input_nan_mask = np.isnan(specific_humidity)
+
     # Convert evapotranspiration and soil evaporation [mm] to [kg m2 s-1] time interval
     evap_kg_m2 = evapotranspiration * 1e-3 / time_interval
     soil_evap_kg_m2 = soil_evaporation * 1e-3 / time_interval
@@ -661,10 +665,18 @@ def update_humidity_vpd(
     # Compute new VPD (Vapor Pressure Deficit) [kPa]
     vpd_updated = saturated_vapour_pressure - vapour_pressure_updated
 
-    # Return results
-    return {
+    # Map variable names to arrays
+    raw_outputs = {
         "relative_humidity": relative_humidity_updated,
         "vapour_pressure": vapour_pressure_updated,
         "vapour_pressure_deficit": vpd_updated,
         "specific_humidity": specific_humidity_updated,
     }
+
+    # Clean outputs while preserving intended NaNs
+    cleaned_outputs = {
+        key: set_unintended_nan_to_zero(arr, input_nan_mask)
+        for key, arr in raw_outputs.items()
+    }
+
+    return cleaned_outputs

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -69,9 +69,9 @@ def run_microclimate(
     ].to_numpy()
 
     # Calculate thickness of above ground layers and midpoints
-    # Add a row of zeros at the bottom to represent ground level (height = 0)
-    heights_with_base = np.vstack([wind_heights, np.zeros(wind_heights.shape[1])])
-    above_ground_layer_thickness = -np.diff(heights_with_base, axis=0)
+    above_ground_layer_thickness = (
+        abiotic_tools.compute_layer_thickness_for_varying_canopy(heights=wind_heights)
+    )
 
     # Compute cumulative thickness excluding the current layer (layer tops)
     layer_top = (


### PR DESCRIPTION
This PR updates the tests in the abiotic folder to run with a varying number of canopy layers. This required introducing a few extra functions that deal with NaN and fixing how the layer thickness is calculated. I also fixed a sign error in the temperature updated.

You will see some slightly convoluted masking in some of the tests, that is to check that the true values are not NaN.

I haven't introduced a non-vegetated grid cell, this will be addressed in #975 .

Fixes #973

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
