### PR TITLE
Implements disturbance model prototype

### DIFF
--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -896,8 +896,10 @@ def test__resolve_config_paths_file_locations(
             },
             does_not_raise(),
             {
-                "file1_path": str(Path("path/to/config/file.txt").absolute()),
-                "other_path": str(Path("path/to/config/file2.txt").absolute()),
+                "file1_path": str(Path("path/to/config/file.txt").resolve().absolute()),
+                "other_path": str(
+                    Path("path/to/config/file2.txt").resolve().absolute()
+                ),
                 "foo": "bar",
                 "baz": 6,
             },
@@ -913,8 +915,8 @@ def test__resolve_config_paths_file_locations(
             },
             does_not_raise(),
             {
-                "file1_path": str(Path("path/to/config/file.txt").absolute()),
-                "other_path": str(Path("path/file2.txt").absolute()),
+                "file1_path": str(Path("path/to/config/file.txt").resolve().absolute()),
+                "other_path": str(Path("path/file2.txt").resolve().absolute()),
                 "foo": "bar",
                 "baz": 6,
             },
@@ -929,9 +931,9 @@ def test__resolve_config_paths_file_locations(
             },
             does_not_raise(),
             {
-                "file1_path": str(Path("path/to/config/file.txt").absolute()),
+                "file1_path": str(Path("path/to/config/file.txt").resolve().absolute()),
                 "nested": {
-                    "other_path": str(Path("path/file2.txt").absolute()),
+                    "other_path": str(Path("path/file2.txt").resolve().absolute()),
                     "foo": "bar",
                 },
                 "baz": 6,

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -108,6 +108,7 @@ save_continuous_data = false
 save_final_state = false
 save_merged_config = false
 [testing]
+[disturbance_testing]
 """
         )
 

--- a/virtual_ecosystem/core/base_model.py
+++ b/virtual_ecosystem/core/base_model.py
@@ -760,3 +760,77 @@ class BaseModel(ABC):
             )
             LOGGER.error(error)
             raise error
+
+
+class BaseDisturbance(
+    BaseModel,
+    ABC,
+    model_name="_base_disturbance",
+    model_update_bounds=("1 day", "1 year"),
+    vars_required_for_init=tuple(),
+    vars_populated_by_init=tuple(),
+    vars_required_for_update=tuple(),
+    vars_updated=tuple(),
+    vars_populated_by_first_update=tuple(),
+):
+    """Base class for disturbances in the virtual ecosystem.
+
+    This class extends BaseModel to include disturbance-specific functionality and
+    configuration.
+    """
+
+    def __init_subclass__(
+        cls,
+        model_name,
+        model_update_bounds,
+        vars_required_for_init,
+        vars_updated,
+        vars_required_for_update,
+        vars_populated_by_init,
+        vars_populated_by_first_update,
+    ):
+        """Initialise subclasses deriving from BaseDisturbance."""
+        if vars_populated_by_first_update or vars_populated_by_init:
+            raise ValueError(
+                "Disturbance models cannot define "
+                "vars_populated_by_first_update or vars_populated_by_init."
+            )
+        super().__init_subclass__(
+            model_name,
+            model_update_bounds,
+            vars_required_for_init,
+            vars_updated,
+            vars_required_for_update,
+            tuple(),
+            tuple(),
+        )
+
+    def __init__(
+        self,
+        data: Data,
+        core_components: CoreComponents,
+        static: bool = False,
+        models: dict[str, BaseModel] | None = None,
+        **kwargs: Any,
+    ):
+        """Initialise the disturbance with shared data and core components.
+
+        Args:
+            data: A :class:`~virtual_ecosystem.core.data.Data` instance containing
+                variables to be used in the disturbance.
+            core_components: A
+                :class:`~virtual_ecosystem.core.core_components.CoreComponents`
+                instance containing shared core elements used throughout models.
+            static: A boolean flag indicating if the disturbance is static.
+            models: A dictionary of model instances that the disturbance will affect
+                directly, if any.
+            **kwargs: Further arguments to the disturbance.
+        """
+        if static:
+            raise ValueError(
+                "Disturbance models cannot be static. Please, use a non-static "
+                "disturbance model."
+            )
+        super().__init__(data, core_components, static, **kwargs)
+        self.models: dict[str, BaseModel] = models or {}
+        """A dictionary of model instances that the disturbance will affect directly."""

--- a/virtual_ecosystem/core/base_model.py
+++ b/virtual_ecosystem/core/base_model.py
@@ -779,6 +779,13 @@ class BaseDisturbance(
     configuration.
     """
 
+    disturbed_models: tuple[str, ...] = tuple()
+    """A tuple of model names that this disturbance will affect directly.
+
+    This is used to ensure that the disturbance is applied to the correct models and
+    to validate the disturbance configuration.
+    """
+
     def __init_subclass__(
         cls,
         model_name,
@@ -788,6 +795,7 @@ class BaseDisturbance(
         vars_required_for_update,
         vars_populated_by_init,
         vars_populated_by_first_update,
+        disturbed_models: tuple[str, ...] = tuple(),
     ):
         """Initialise subclasses deriving from BaseDisturbance."""
         if vars_populated_by_first_update or vars_populated_by_init:
@@ -804,6 +812,7 @@ class BaseDisturbance(
             tuple(),
             tuple(),
         )
+        cls.disturbed_models = disturbed_models
 
     def __init__(
         self,
@@ -814,6 +823,8 @@ class BaseDisturbance(
         **kwargs: Any,
     ):
         """Initialise the disturbance with shared data and core components.
+
+        This method **must** be called in the ``__init__`` method of all subclasses.
 
         Args:
             data: A :class:`~virtual_ecosystem.core.data.Data` instance containing
@@ -828,9 +839,30 @@ class BaseDisturbance(
         """
         if static:
             raise ValueError(
-                "Disturbance models cannot be static. Please, use a non-static "
-                "disturbance model."
+                "Disturbance models cannot be static. Please, set the static flag "
+                "to False."
             )
         super().__init__(data, core_components, static, **kwargs)
-        self.models: dict[str, BaseModel] = models or {}
+
+        models = models or {}
+        if not set(models.keys()).issubset(self.disturbed_models):
+            raise ValueError(
+                f"Disturbance model {self.model_name} is configured to affect "
+                f"{self.disturbed_models}, but the provided models are "
+                f"{list(models.keys())}."
+            )
+        self.models: dict[str, BaseModel] = {
+            name: models[name] for name in self.disturbed_models
+        }
         """A dictionary of model instances that the disturbance will affect directly."""
+
+    @classmethod
+    @abstractmethod
+    def from_config(
+        cls,
+        data: Data,
+        core_components: CoreComponents,
+        config: Config,
+        models: dict[str, BaseModel] | None = None,
+    ) -> BaseModel:
+        """Factory function to unpack config and initialise a model instance."""

--- a/virtual_ecosystem/core/base_model.py
+++ b/virtual_ecosystem/core/base_model.py
@@ -809,8 +809,8 @@ class BaseDisturbance(
             vars_required_for_init,
             vars_updated,
             vars_required_for_update,
-            tuple(),
-            tuple(),
+            vars_populated_by_init=(),
+            vars_populated_by_first_update=(),
         )
         cls.disturbed_models = disturbed_models
 

--- a/virtual_ecosystem/main.py
+++ b/virtual_ecosystem/main.py
@@ -47,16 +47,37 @@ def initialise_models(
 
     Raises:
         InitialisationError: If one or more models cannot be properly configured
+
+    Returns:
+        A dictionary of configured models, keyed by model name.
     """
+    from .core.base_model import BaseDisturbance
 
     LOGGER.info("Initialising models: {}".format(",".join(models.keys())))
 
     # Use factory methods to configure the desired models
     failed_models = []
     models_cfd = {}
+    disturbance_models: list[tuple[str, type[BaseDisturbance]]] = []
+
+    # Loop through the models and try to configure them
+    # If a model is a disturbance model, it will be configured later
     for model_name, model_class in models.items():
+        if issubclass(model_class, BaseDisturbance):
+            disturbance_models.append((model_name, model_class))
+            continue
         try:
             this_model = model_class.from_config(data, core_components, config)
+            models_cfd[model_name] = this_model
+        except (InitialisationError, ConfigurationError):
+            failed_models.append(model_name)
+
+    # If there are disturbance models, configure them now
+    for model_name, model_class in disturbance_models:
+        try:
+            this_model = model_class.from_config(
+                data, core_components, config, models_cfd
+            )
             models_cfd[model_name] = this_model
         except (InitialisationError, ConfigurationError):
             failed_models.append(model_name)

--- a/virtual_ecosystem/main.py
+++ b/virtual_ecosystem/main.py
@@ -172,6 +172,16 @@ def ve_run(
         for model_name in variables.get_model_order("init")
     }
 
+    # Add models not handled by the variable system, like those that do not init
+    # any variables or require any variables to be set up, eg. the testing model.
+    init_sequence.update(
+        {
+            model_name: model_class
+            for model_name, model_class in config.model_classes.items()
+            if model_name not in init_sequence
+        }
+    )
+
     models_init = initialise_models(
         config=config,
         data=data,

--- a/virtual_ecosystem/main.py
+++ b/virtual_ecosystem/main.py
@@ -116,6 +116,7 @@ def ve_run(
         progress: A Progress enum instance setting the level of output to be printed to
             the console when ve_run is running.
     """
+    from .core.base_model import BaseDisturbance
 
     # Mute the progress information when the log is written to stdout.
     if logfile is None:
@@ -225,6 +226,29 @@ def ve_run(
         model_name: models_init[model_name]
         for model_name in variables.get_model_order("update")
     }
+
+    # Add models not handled by the variable system, like those that do not update
+    # variables or require any variables to be updated, eg. disturbance models
+    # that just affect the state of a model
+    models_update.update(
+        {
+            model_name: model_instance
+            for model_name, model_instance in models_init.items()
+            if model_name not in models_update
+        }
+    )
+
+    # Ensure that all disturbance models are at the end of the update sequence
+    models_update = {
+        model_name: model_instance
+        for model_name, model_instance in models_update.items()
+        if not isinstance(model_instance, BaseDisturbance)
+    } | {
+        model_name: model_instance
+        for model_name, model_instance in models_update.items()
+        if isinstance(model_instance, BaseDisturbance)
+    }
+
     if progress > Progress.MINIMAL:
         print("* Starting simulation")
 

--- a/virtual_ecosystem/models/disturbance_testing/__init__.py
+++ b/virtual_ecosystem/models/disturbance_testing/__init__.py
@@ -1,0 +1,5 @@
+"""A minimal model for testing."""
+
+from virtual_ecosystem.models.disturbance_testing.disturbance_testing_model import (  # noqa: F401
+    DisturbanceTesting,
+)

--- a/virtual_ecosystem/models/disturbance_testing/disturbance_testing_model.py
+++ b/virtual_ecosystem/models/disturbance_testing/disturbance_testing_model.py
@@ -1,0 +1,91 @@
+"""A testing model to use in minimal ve_run testing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from virtual_ecosystem.core.base_model import BaseDisturbance, BaseModel
+from virtual_ecosystem.core.config import Config
+from virtual_ecosystem.core.core_components import CoreComponents
+from virtual_ecosystem.core.data import Data
+from virtual_ecosystem.core.logger import LOGGER
+
+
+class DisturbanceTesting(
+    BaseDisturbance,
+    model_name="disturbance_testing",
+    model_update_bounds=("1 day", "1 year"),
+    vars_required_for_init=tuple(),
+    vars_populated_by_init=tuple(),
+    vars_required_for_update=tuple(),
+    vars_updated=tuple(),
+    vars_populated_by_first_update=tuple(),
+    disturbed_models=("testing",),
+):
+    """A model that does literally nothing to run model testing.
+
+    Args:
+        data: The data object to be used in the model.
+        core_components: The core components used across models.
+        flora: A Flora instance of the plant functional types to be used in the model.
+        model_constants: Set of constants for the plants model.
+    """
+
+    def __init__(
+        self,
+        data: Data,
+        core_components: CoreComponents,
+        static: bool = False,
+        **kwargs: Any,
+    ):
+        """Plants init function.
+
+        The init function is used only to define class attributes. Any logic should be
+        handled in :fun:`~virtual_ecosystem.plants.plants_model._setup`.
+        """
+
+        super().__init__(data, core_components, static, **kwargs)
+
+    @classmethod
+    def from_config(
+        cls,
+        data: Data,
+        core_components: CoreComponents,
+        config: Config,
+        models: dict[str, BaseModel] | None = None,
+    ) -> DisturbanceTesting:
+        """Factory function to initialise a testing model from configuration.
+
+        Args:
+            data: A :class:`~virtual_ecosystem.core.data.Data` instance.
+            core_components: The core components used across models.
+            config: A validated Virtual Ecosystem model configuration object.
+            models: Models that this disturbance will act upon.
+                If None, the disturbance will not be applied to any models.
+        """
+
+        # Load in the relevant constants
+        static = config["testing"].get("static", False)
+
+        # Create the instance
+        inst = cls(
+            data=data,
+            core_components=core_components,
+            static=static,
+            models=models,
+        )
+
+        LOGGER.info("Disturbance testing model instance generated from configuration.")
+        return inst
+
+    def _setup(self, **kwargs: Any) -> None:
+        """Placeholder function to setup the testing model."""
+
+    def spinup(self) -> None:
+        """Placeholder function to spin up the testing model."""
+
+    def _update(self, time_index: int, **kwargs: Any) -> None:
+        """Placeholder function to update up the tesying model."""
+
+    def cleanup(self) -> None:
+        """Placeholder function for testing model cleanup."""

--- a/virtual_ecosystem/models/disturbance_testing/module_schema.json
+++ b/virtual_ecosystem/models/disturbance_testing/module_schema.json
@@ -1,0 +1,9 @@
+{
+    "type": "object",
+    "properties": {
+        "disturbance_testing": {}
+    },
+    "required": [
+        "disturbance_testing"
+    ]
+}

--- a/virtual_ecosystem/models/testing/testing_model.py
+++ b/virtual_ecosystem/models/testing/testing_model.py
@@ -58,7 +58,7 @@ class TestingModel(
         """
 
         # Load in the relevant constants
-        static = config["tesing"]["static"]
+        static = config["testing"].get("static", False)
 
         # Create the instance
         inst = cls(


### PR DESCRIPTION
# Description

Implements an initial proof of concept version of the disturbance framework. To keep it as general as unintrusive as possible, as well as benefitting from the whole infrastructure already in place to discover an initialise models, it has been implemented as a `DisturbanceBase` model, inheriting from `BaseModel`, and just imposing some restrictions/limitations. 

As a sort of summary, disturbance models (those inheriting from `DisturbanceBase`):

- Cannot be `static`: By definition, disturbances are dynamic, so it does not make much sense to make them static.
- Cannot initialise variables during init or first update: That's what normal models do - disturbances only disrupt what's already there. This is also important to define the execution order since other models should not depend on variables initialised by the disturbances.
- New `disturbed_models` class attribute: Take the list of models as input in the `from_config` method, so they can fetch those models that, potentially, they will be directly affecting, if any.

A `DisturbanceTesting` model has been added and included in the tests, using the existing `Testing` model as the model to disturb (even though it does nothing).

**NOTE**: While adding this functionality I've discovered and fixed a few bugs (37317734 and  28228f1e). If this PR is not merged, those commits will need to be incorporated added as a separate PR.

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
