### PR TITLE
536 add check for nan values before running the soil model

### DIFF
--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -40,7 +40,6 @@ REQUIRED_INIT_VAR_LOG = (
     (DEBUG, "soil model: required var 'soil_p_pool_secondary' checked"),
     (DEBUG, "soil model: required var 'soil_p_pool_labile' checked"),
     (DEBUG, "soil model: required var 'pH' checked"),
-    (DEBUG, "soil model: required var 'bulk_density' checked"),
     (DEBUG, "soil model: required var 'clay_fraction' checked"),
 )
 POST_SETUP_LOG = (

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -510,6 +510,27 @@ def test_integrate_soil_model(
     log_check(caplog, expected_log)
 
 
+def test_integrate_with_nans(caplog, fixture_soil_model):
+    """Test that integration fails if NaN values are in the input data."""
+
+    # Add Nan value to data and then clean up caplog
+    fixture_soil_model.data["pH"] = DataArray([3.3, np.nan, 5.6, 7.9], dims=["cell_id"])
+    caplog.clear()
+
+    with pytest.raises(ValueError):
+        _ = fixture_soil_model.integrate()
+
+    expected_log = (
+        (
+            ERROR,
+            "Soil model integration cannot proceed because the following variables "
+            "have unexpected NaN values: {'pH'}",
+        ),
+    )
+
+    log_check(caplog, expected_log)
+
+
 def test_order_independance(
     dummy_carbon_data,
     fixture_soil_model,
@@ -592,6 +613,87 @@ def test_order_independance(
     # Compare each final pool
     for pool_name in pool_names:
         assert np.allclose(output[pool_name], output_reversed[pool_name])
+
+
+@pytest.mark.parametrize(
+    argnames=["unexpected_nans", "variable_name", "input_data"],
+    argvalues=[
+        pytest.param(
+            False,
+            "pH",
+            DataArray([3.3, 4.3, 5.6, 7.9], dims=["cell_id"]),
+            id="no NaNs",
+        ),
+        pytest.param(
+            True,
+            "pH",
+            DataArray([3.3, np.nan, 5.6, 7.9], dims=["cell_id"]),
+            id="NaN",
+        ),
+    ],
+)
+def test_check_for_unexpected_nan_value_flat(
+    fixture_soil_model, unexpected_nans, variable_name, input_data
+):
+    """Test unexpected NaN checking values works for variables without layers."""
+
+    fixture_soil_model.data[variable_name] = input_data
+
+    assert unexpected_nans == fixture_soil_model.check_for_unexpected_nan_values(
+        var=variable_name
+    )
+
+
+@pytest.mark.parametrize(
+    argnames=["unexpected_nans", "variable_name", "layer_name", "input_data"],
+    argvalues=[
+        pytest.param(
+            False,
+            "air_temperature",
+            "index_surface",
+            np.array([3.3, 4.3, 5.6, 7.9]),
+            id="surface, good",
+        ),
+        pytest.param(
+            True,
+            "air_temperature",
+            "index_surface",
+            np.array([3.3, np.nan, 5.6, 7.9]),
+            id="surface, bad",
+        ),
+        pytest.param(
+            False,
+            "soil_temperature",
+            "index_all_soil",
+            np.array([[3.3, 4.3, 5.6, 7.9], [23.4, 26.1, 24.4, 29.8]]),
+            id="soil, good",
+        ),
+        pytest.param(
+            True,
+            "soil_temperature",
+            "index_all_soil",
+            np.array([[3.3, 4.3, 5.6, 7.9], [np.nan, 26.1, 24.4, 29.8]]),
+            id="soil, bad",
+        ),
+    ],
+)
+def test_check_for_unexpected_nan_value_layered(
+    fixture_soil_model,
+    fixture_core_components,
+    unexpected_nans,
+    variable_name,
+    layer_name,
+    input_data,
+):
+    """Test unexpected NaN checking values works for variables without layers."""
+
+    lyr_str = fixture_core_components.layer_structure
+    fixture_soil_model.data[variable_name] = lyr_str.from_template()
+    fixture_soil_model.data[variable_name][getattr(lyr_str, layer_name)] = input_data
+
+    assert unexpected_nans == fixture_soil_model.check_for_unexpected_nan_values(
+        var=variable_name
+    )
 
 
 def test_convert_fruiting_body_production_to_rate(fixture_soil_model):

--- a/virtual_ecosystem/models/soil/soil_model.py
+++ b/virtual_ecosystem/models/soil/soil_model.py
@@ -132,6 +132,7 @@ class SoilModel(
         "matric_potential",
         "vertical_flow",
         "soil_temperature",
+        "air_temperature",
         "soil_moisture",
         "litter_C_mineralisation_rate",
         "litter_N_mineralisation_rate",
@@ -397,6 +398,7 @@ class SoilModel(
 
         Raises:
             IntegrationError: When the integration cannot be successfully completed.
+            ValueError: If any of the variables used by the soil model have NaN values.
         """
 
         # Find number of grid cells integration is being performed over
@@ -432,12 +434,21 @@ class SoilModel(
             **{name: np.array([]) for name in self.refreshed_variables},
         }
 
-        # TODO - NEED TO CHECK FOR NAN VALUES HERE
-        # FIRST THING I NEED TO WORK OUT IS THE FULL LIST OF VARIABLES TO CHECK SHOULD
-        # BE `vars_required_for_update`
-        # SECOND THING, IS HOW TO SEPARATE OUT THE LAYERED OBJECTS, WHICH CAN HAVE NaNs
-        # FINAL THING, I REALLY WANT TO REPORT ALL ERRORS, SO NEED TO WRITE IT IN SUCH A
-        # WAY
+        # Check if any values used by the soil model integration have NaN values (these
+        # can stall the integration)
+        unexpected_nans = set()
+
+        for var in self.vars_required_for_update:
+            if self.check_for_unexpected_nan_values(var=var):
+                unexpected_nans.add(var)
+
+        if unexpected_nans:
+            to_raise_nan = ValueError(
+                "Soil model integration cannot proceed because the following "
+                f"variables have unexpected NaN values: {unexpected_nans}"
+            )
+            LOGGER.error(to_raise_nan)
+            raise to_raise_nan
 
         # Carry out simulation
         output = solve_ivp(
@@ -461,12 +472,12 @@ class SoilModel(
 
         # Check if integration failed
         if not output.success:
-            LOGGER.error(
-                "Integration of soil module failed with following message: {}".format(  # noqa: UP032
-                    str(output.message)
-                )
+            to_raise = IntegrationError(
+                "Integration of soil module failed with following message: "
+                f"{output.message!s}"
             )
-            raise IntegrationError()
+            LOGGER.error(to_raise)
+            raise to_raise
 
         # Construct index slices
         slices = make_slices(no_cells, round(len(y0) / no_cells))
@@ -478,6 +489,29 @@ class SoilModel(
         }
 
         return new_c_pools
+
+    def check_for_unexpected_nan_values(self, var: str) -> bool:
+        """Check if there are unexpected NaN values in the data for a specific variable.
+
+        The soil model needs the air_temperature variable to have non-NaN values at the
+        soil surface, and the other layer structured variables to be defined for every
+        soil layer. For these variables, this function takes the appropriate subset.
+
+        Args:
+            var: The name of the variable being checked
+
+        Returns:
+            Whether the data for the variable has any unexpected NaN values.
+        """
+
+        if var == "air_temperature":
+            subset = self.data[var].isel(layers=self.layer_structure.index_surface)
+        elif "layers" in self.data[var].dims:
+            subset = self.data[var].isel(layers=self.layer_structure.index_all_soil)
+        else:
+            subset = self.data[var]
+
+        return bool(subset.isnull().any())
 
     def convert_fruiting_body_production_to_rate(
         self, total_production: DataArray

--- a/virtual_ecosystem/models/soil/soil_model.py
+++ b/virtual_ecosystem/models/soil/soil_model.py
@@ -89,7 +89,6 @@ class SoilModel(
         "soil_p_pool_secondary",
         "soil_p_pool_labile",
         "pH",
-        "bulk_density",
         "clay_fraction",
     ),
     vars_populated_by_init=(
@@ -128,6 +127,8 @@ class SoilModel(
         "soil_p_pool_primary",
         "soil_p_pool_secondary",
         "soil_p_pool_labile",
+        "pH",
+        "clay_fraction",
         "matric_potential",
         "vertical_flow",
         "soil_temperature",
@@ -430,6 +431,13 @@ class SoilModel(
             },
             **{name: np.array([]) for name in self.refreshed_variables},
         }
+
+        # TODO - NEED TO CHECK FOR NAN VALUES HERE
+        # FIRST THING I NEED TO WORK OUT IS THE FULL LIST OF VARIABLES TO CHECK SHOULD
+        # BE `vars_required_for_update`
+        # SECOND THING, IS HOW TO SEPARATE OUT THE LAYERED OBJECTS, WHICH CAN HAVE NaNs
+        # FINAL THING, I REALLY WANT TO REPORT ALL ERRORS, SO NEED TO WRITE IT IN SUCH A
+        # WAY
 
         # Carry out simulation
         output = solve_ivp(


### PR DESCRIPTION
# Description

This PR adds a step to check for unexpected NaN values (which can stall the soil model integration) before the soil model integration starts. If NaNs are detected the an error is raised, informing the user which variables contain unexpected NaN values.

For variables that don't have a layer structure, unexpected NaN values are any NaN values. For variables that pertain to the soil layers, they are NaN values in any soil layer For the `soil_temperature` (the only above ground variable the soil model cares about), unexpected NaN values are any NaN values in the surface layer.

Fixes #536

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
