### PR TITLE
Updating stoichiometry names

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -165,7 +165,7 @@ nitpick_ignore = [
     ("py:class", "PModelConst"),
     ("py:class", "CoreConst"),
     ("py:class", "StemAllocation"),
-    ("py:class", "StemStochiometry"),
+    ("py:class", "StemStoichiometry"),
 ]
 intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),

--- a/tests/models/plants/test_stochiometry.py
+++ b/tests/models/plants/test_stochiometry.py
@@ -1,12 +1,12 @@
-"""Tests for the Stochiometry class."""
+"""Tests for the Stoichiometry class."""
 
 import numpy as np
 import pytest
 
 
 def test_FoliageTissue__init__(fxt_plants_model, extra_pft_traits):
-    """Test the foliage stochiometry."""
-    from virtual_ecosystem.models.plants.stochiometry import FoliageTissue
+    """Test the foliage stoichiometry."""
+    from virtual_ecosystem.models.plants.stoichiometry import FoliageTissue
 
     for cell_id in fxt_plants_model.communities.keys():
         community = fxt_plants_model.communities[cell_id]
@@ -33,7 +33,7 @@ def test_FoliageTissue__init__(fxt_plants_model, extra_pft_traits):
 
 def test_from_pft_default_ratios(fxt_plants_model):
     """Test the default ratios in FoliageTissue from PFT."""
-    from virtual_ecosystem.models.plants.stochiometry import FoliageTissue
+    from virtual_ecosystem.models.plants.stoichiometry import FoliageTissue
 
     for cell_id in fxt_plants_model.communities.keys():
         community = fxt_plants_model.communities[cell_id]
@@ -47,19 +47,19 @@ def test_from_pft_default_ratios(fxt_plants_model):
         assert isinstance(tissue_model, FoliageTissue)
 
 
-def test_stochiometry_from_defaults(fxt_plants_model):
-    """Test the stochiometry from defaults."""
-    from virtual_ecosystem.models.plants.stochiometry import StemStochiometry
+def test_stoichiometry_from_defaults(fxt_plants_model):
+    """Test the stoichiometry from defaults."""
+    from virtual_ecosystem.models.plants.stoichiometry import StemStoichiometry
 
     for cell_id in fxt_plants_model.communities.keys():
         community = fxt_plants_model.communities[cell_id]
 
-        stochiometry = StemStochiometry.default_init(
+        stoichiometry = StemStoichiometry.default_init(
             community,
             extra_pft_traits=fxt_plants_model.extra_pft_traits,
             element="N",
         )
-        assert isinstance(stochiometry, StemStochiometry)
+        assert isinstance(stoichiometry, StemStoichiometry)
 
 
 @pytest.mark.parametrize(
@@ -91,7 +91,7 @@ def test_Tissue_class_functions(
     """Test the carbon mass calculation in FoliageTissue."""
     from pyrealm.demography.tmodel import StemAllocation
 
-    from virtual_ecosystem.models.plants.stochiometry import FoliageTissue
+    from virtual_ecosystem.models.plants.stoichiometry import FoliageTissue
 
     fxt_plants_model.per_stem_gpp = {
         cell_id: np.array([55]) for cell_id in fxt_plants_model.communities.keys()
@@ -150,46 +150,46 @@ def test_Tissue_class_functions(
 
 
 @pytest.fixture
-def fxt_stochiometry_model(fxt_plants_model):
-    """Fixture for the Stochiometry class."""
+def fxt_stoichiometry_model(fxt_plants_model):
+    """Fixture for the Stoichiometry class."""
 
-    from virtual_ecosystem.models.plants.stochiometry import StemStochiometry
+    from virtual_ecosystem.models.plants.stoichiometry import StemStoichiometry
 
     cell_id = 0  # Assuming we are testing for the first cell
     community = fxt_plants_model.communities[cell_id]
 
     community = fxt_plants_model.communities[cell_id]
 
-    n_stochiometry = StemStochiometry.default_init(
+    n_stoichiometry = StemStoichiometry.default_init(
         community,
         extra_pft_traits=fxt_plants_model.extra_pft_traits,
         element="N",
     )
-    return n_stochiometry
+    return n_stoichiometry
 
 
-def test_Stochiometry__init__(fxt_stochiometry_model):
-    """Test the Stochiometry class initialization."""
+def test_Stoichiometry__init__(fxt_stoichiometry_model):
+    """Test the Stoichiometry class initialization."""
 
-    from virtual_ecosystem.models.plants.stochiometry import StemStochiometry
+    from virtual_ecosystem.models.plants.stoichiometry import StemStoichiometry
 
-    assert isinstance(fxt_stochiometry_model, StemStochiometry)
+    assert isinstance(fxt_stoichiometry_model, StemStoichiometry)
 
 
-def test_Stochiometry_total_element_mass(fxt_stochiometry_model):
-    """Test the total_element_mass method of the Stochiometry class."""
+def test_Stoichiometry_total_element_mass(fxt_stoichiometry_model):
+    """Test the total_element_mass method of the Stoichiometry class."""
 
     # Calculate the total element mass
-    total_mass = fxt_stochiometry_model.total_element_mass
+    total_mass = fxt_stoichiometry_model.total_element_mass
 
     assert np.allclose(total_mass, [1.42690028e05, 5.00222397e02, 1.01898381e00])
 
 
-def test_Stochiometry_tissue_deficit(fxt_stochiometry_model):
-    """Test the tissue_deficit method of the Stochiometry class."""
+def test_Stoichiometry_tissue_deficit(fxt_stoichiometry_model):
+    """Test the tissue_deficit method of the Stoichiometry class."""
 
     # Calculate the tissue deficit
-    tissue_deficit = fxt_stochiometry_model.tissue_deficit
+    tissue_deficit = fxt_stoichiometry_model.tissue_deficit
 
     expected_deficit = np.array([-3.48223990e04, -1.02544990e02, 4.02427444e-03])
     assert np.allclose(tissue_deficit, expected_deficit)
@@ -198,10 +198,10 @@ def test_Stochiometry_tissue_deficit(fxt_stochiometry_model):
 @pytest.mark.skip(
     reason="Negative growth problem. Return to this test when that problem is fixed."
 )
-def test_Stochiometry_account_for_growth(fxt_plants_model, fxt_stochiometry_model):
-    """Test the account_for_growth method of the Stochiometry class."""
+def test_Stoichiometry_account_for_growth(fxt_plants_model, fxt_stoichiometry_model):
+    """Test the account_for_growth method of the Stoichiometry class."""
 
-    from virtual_ecosystem.models.plants.stochiometry import StemAllocation
+    from virtual_ecosystem.models.plants.stoichiometry import StemAllocation
 
     # Create a StemAllocation object
     cell_id = 0  # Assuming we are testing for the first cell
@@ -216,25 +216,25 @@ def test_Stochiometry_account_for_growth(fxt_plants_model, fxt_stochiometry_mode
     )
 
     assert np.allclose(
-        fxt_stochiometry_model.total_element_mass,
+        fxt_stoichiometry_model.total_element_mass,
         [1.31887368e05, 4.35408760e02, 5.93227761e-01],
     )
 
     # Account for growth
-    fxt_stochiometry_model.account_for_growth(stem_allocation)
+    fxt_stoichiometry_model.account_for_growth(stem_allocation)
 
     assert np.all(
-        fxt_stochiometry_model.total_element_mass
+        fxt_stoichiometry_model.total_element_mass
         >= [1.31887368e05, 4.35408760e02, 5.93227761e-01]
     )
 
 
-def test_Stochiometry_account_for_element_loss_turnover(
-    fxt_plants_model, fxt_stochiometry_model
+def test_Stoichiometry_account_for_element_loss_turnover(
+    fxt_plants_model, fxt_stoichiometry_model
 ):
-    """Test the account_for_element_loss_turnover method of the Stochiometry class."""
+    """Test the account_for_element_loss_turnover method of the Stoichiometry class."""
 
-    from virtual_ecosystem.models.plants.stochiometry import StemAllocation
+    from virtual_ecosystem.models.plants.stoichiometry import StemAllocation
 
     # Create a StemAllocation object
     cell_id = 0  # Assuming we are testing for the first cell
@@ -248,33 +248,33 @@ def test_Stochiometry_account_for_element_loss_turnover(
         whole_crown_gpp=fxt_plants_model.per_stem_gpp[cell_id],
     )
 
-    assert np.allclose(fxt_stochiometry_model.element_surplus, [0.0, 0.0, 0.0])
-    fxt_stochiometry_model.account_for_element_loss_turnover(stem_allocation)
+    assert np.allclose(fxt_stoichiometry_model.element_surplus, [0.0, 0.0, 0.0])
+    fxt_stoichiometry_model.account_for_element_loss_turnover(stem_allocation)
 
     # The surplus should always be negative after accounting for turnover
-    assert np.all(fxt_stochiometry_model.element_surplus <= [0.0, 0.0, 0.0])
+    assert np.all(fxt_stoichiometry_model.element_surplus <= [0.0, 0.0, 0.0])
 
 
-def test_Stochiometry_distribute_deficit(fxt_stochiometry_model):
-    """Test the distribute_deficit method of the Stochiometry class.
+def test_Stoichiometry_distribute_deficit(fxt_stoichiometry_model):
+    """Test the distribute_deficit method of the Stoichiometry class.
 
     NOTE: This method should have a more robust test with a more deliberate test value.
     This will be easier to implement once growth is functioning.
     """
 
     # Distribute the deficit
-    fxt_stochiometry_model.distribute_deficit(0)
+    fxt_stoichiometry_model.distribute_deficit(0)
 
-    assert np.allclose(fxt_stochiometry_model.element_surplus[0], [0])
+    assert np.allclose(fxt_stoichiometry_model.element_surplus[0], [0])
 
 
-def test_Stochiometry_distrubte_surplus(fxt_stochiometry_model):
-    """Test the distribute_surplus method of the Stochiometry class.
+def test_Stoichiometry_distrubte_surplus(fxt_stoichiometry_model):
+    """Test the distribute_surplus method of the Stoichiometry class.
 
     NOTE: This method should have a more robust test with a more deliberate test value.
     This will be easier to implement once growth is functioning.
     """
 
-    fxt_stochiometry_model.distribute_surplus(0)
+    fxt_stoichiometry_model.distribute_surplus(0)
 
-    assert fxt_stochiometry_model.element_surplus[0] >= 0
+    assert fxt_stoichiometry_model.element_surplus[0] >= 0

--- a/virtual_ecosystem/models/animal/animal_model.py
+++ b/virtual_ecosystem/models/animal/animal_model.py
@@ -396,7 +396,7 @@ class AnimalModel(
         Args:
             functional_groups: The list of animal functional groups present in the
                 simulation.
-            microbial_c_n_p_ratios: Biomass stochiometry of each microbial functional
+            microbial_c_n_p_ratios: Biomass stoichiometry of each microbial functional
                 group.
             **kwargs: Further arguments to the setup method.
         """

--- a/virtual_ecosystem/models/plants/plants_model.py
+++ b/virtual_ecosystem/models/plants/plants_model.py
@@ -34,8 +34,8 @@ from virtual_ecosystem.models.plants.functional_types import (
     ExtraTraitsPFT,
     get_flora_from_config,
 )
-from virtual_ecosystem.models.plants.stochiometry import (
-    StemStochiometry,
+from virtual_ecosystem.models.plants.stoichiometry import (
+    StemStoichiometry,
 )
 
 
@@ -214,8 +214,8 @@ class PlantsModel(
         self.communities: PlantCommunities
         """An instance of PlantCommunities providing dictionary access keyed by cell id
         to PlantCommunity instances for each cell."""
-        self.stochiometries: dict[int, dict[str, StemStochiometry]]
-        """A dictionary keyed by cell id giving the stochiometry of each community."""
+        self.stochiometries: dict[int, dict[str, StemStoichiometry]]
+        """A dictionary keyed by cell id giving the stoichiometry of each community."""
         self.allocations: dict[int, StemAllocation]
         """A dictionary keyed by cell id giving the allocation of each community."""
         self._canopy_layer_indices: NDArray[np.bool_]
@@ -354,21 +354,21 @@ class PlantsModel(
             data=self.data, flora=self.flora, grid=self.grid
         )
 
-        # Initialize the stochiometries of each cohort. Each StemStochiometry object
+        # Initialize the stochiometries of each cohort. Each StemStoichiometry object
         # contains a list of StemTissue objects, which are the tissues that make up the
-        # stochiometry of the stem. The initial values for N and P are based on the
+        # stoichiometry of the stem. The initial values for N and P are based on the
         # ideal stochiometric ratios defined in the PlantsConsts class.
         # TODO: #697 - these need to be configurable
         self.stochiometries = {}
 
         for cell_id in self.communities.keys():
             self.stochiometries[cell_id] = {}
-            self.stochiometries[cell_id]["N"] = StemStochiometry.default_init(
+            self.stochiometries[cell_id]["N"] = StemStoichiometry.default_init(
                 self.communities[cell_id],
                 extra_pft_traits=self.extra_pft_traits,
                 element="N",
             )
-            self.stochiometries[cell_id]["P"] = StemStochiometry.default_init(
+            self.stochiometries[cell_id]["P"] = StemStoichiometry.default_init(
                 self.communities[cell_id],
                 extra_pft_traits=self.extra_pft_traits,
                 element="P",
@@ -892,8 +892,8 @@ class PlantsModel(
                 )
 
             # ALLOCATE N TO REGROW WHAT WAS LOST TO TURNOVER
-            for stochiometry in stochiometries.values():
-                stochiometry.account_for_element_loss_turnover(stem_allocation)
+            for stoichiometry in stochiometries.values():
+                stoichiometry.account_for_element_loss_turnover(stem_allocation)
 
             # ALLOCATE GPP TO ACTIVE NUTRIENT PATHWAYS:
             # Allocate the topsliced GPP to root exudates with remainder as active
@@ -920,8 +920,8 @@ class PlantsModel(
 
             # Subtract the N/P required from growth from the element store, and
             # redistribute it to the individual tissues.
-            for stochiometry in stochiometries.values():
-                stochiometry.account_for_growth(stem_allocation)
+            for stoichiometry in stochiometries.values():
+                stoichiometry.account_for_growth(stem_allocation)
 
             # Balance the N & P surplus/deficit with the symbiote carbon supply
             for element in ["N", "P"]:
@@ -940,17 +940,17 @@ class PlantsModel(
 
             # Cohort by cohort, distribute the surplus/deficit across the tissue types
             for cohort in range(len(cohorts.n_individuals)):
-                for stochiometry in stochiometries.values():
-                    if stochiometry.element_surplus[cohort] < 0:
+                for stoichiometry in stochiometries.values():
+                    if stoichiometry.element_surplus[cohort] < 0:
                         # Distribute deficit across the tissue types
-                        stochiometry.distribute_deficit(cohort)
+                        stoichiometry.distribute_deficit(cohort)
 
                     elif (
-                        stochiometry.element_surplus[cohort] > 0
-                        and stochiometry.tissue_deficit[cohort] > 0
+                        stoichiometry.element_surplus[cohort] > 0
+                        and stoichiometry.tissue_deficit[cohort] > 0
                     ):
                         # Distribute the surplus across the tissue types
-                        stochiometry.distribute_surplus(cohort)
+                        stoichiometry.distribute_surplus(cohort)
 
                     else:
                         # NO ADJUSTMENT REQUIRED - there is a surplus in the store, but
@@ -1001,7 +1001,7 @@ class PlantsModel(
         This function updates the C:N and C:P ratios of various plant tissues, including
         deadwood, leaf turnover, plant reproductive tissue turnover, and root turnover.
 
-        # TODO: Update this to use the Stochiometry class values.
+        # TODO: Update this to use the Stoichiometry class values.
 
         Warning:
             At present, this function just sets values to original constants.
@@ -1078,7 +1078,7 @@ class PlantsModel(
         This function calculates the rate a which plants take up inorganic nutrients
         (ammonium, nitrate, and labile phosphorus) from the soil. The function then
         assigns the N/P uptake values to the respective community through the
-        stochiometry class.
+        stoichiometry class.
 
         Warning:
             At present, this function just calculates uptake based on an entirely made

--- a/virtual_ecosystem/models/plants/plants_model.py
+++ b/virtual_ecosystem/models/plants/plants_model.py
@@ -214,7 +214,7 @@ class PlantsModel(
         self.communities: PlantCommunities
         """An instance of PlantCommunities providing dictionary access keyed by cell id
         to PlantCommunity instances for each cell."""
-        self.stochiometries: dict[int, dict[str, StemStoichiometry]]
+        self.stoichiometries: dict[int, dict[str, StemStoichiometry]]
         """A dictionary keyed by cell id giving the stoichiometry of each community."""
         self.allocations: dict[int, StemAllocation]
         """A dictionary keyed by cell id giving the allocation of each community."""
@@ -354,21 +354,21 @@ class PlantsModel(
             data=self.data, flora=self.flora, grid=self.grid
         )
 
-        # Initialize the stochiometries of each cohort. Each StemStoichiometry object
+        # Initialize the stoichiometries of each cohort. Each StemStoichiometry object
         # contains a list of StemTissue objects, which are the tissues that make up the
         # stoichiometry of the stem. The initial values for N and P are based on the
-        # ideal stochiometric ratios defined in the PlantsConsts class.
+        # ideal stoichiometric ratios defined in the PlantsConsts class.
         # TODO: #697 - these need to be configurable
-        self.stochiometries = {}
+        self.stoichiometries = {}
 
         for cell_id in self.communities.keys():
-            self.stochiometries[cell_id] = {}
-            self.stochiometries[cell_id]["N"] = StemStoichiometry.default_init(
+            self.stoichiometries[cell_id] = {}
+            self.stoichiometries[cell_id]["N"] = StemStoichiometry.default_init(
                 self.communities[cell_id],
                 extra_pft_traits=self.extra_pft_traits,
                 element="N",
             )
-            self.stochiometries[cell_id]["P"] = StemStoichiometry.default_init(
+            self.stoichiometries[cell_id]["P"] = StemStoichiometry.default_init(
                 self.communities[cell_id],
                 extra_pft_traits=self.extra_pft_traits,
                 element="P",
@@ -797,7 +797,7 @@ class PlantsModel(
         for cell_id in self.communities.keys():
             community = self.communities[cell_id]
             cohorts = community.cohorts
-            stochiometries = self.stochiometries[cell_id]
+            stoichiometries = self.stoichiometries[cell_id]
 
             # Calculate the allocation of GPP per stem and store it in the attribute
             stem_allocation = StemAllocation(
@@ -892,7 +892,7 @@ class PlantsModel(
                 )
 
             # ALLOCATE N TO REGROW WHAT WAS LOST TO TURNOVER
-            for stoichiometry in stochiometries.values():
+            for stoichiometry in stoichiometries.values():
                 stoichiometry.account_for_element_loss_turnover(stem_allocation)
 
             # ALLOCATE GPP TO ACTIVE NUTRIENT PATHWAYS:
@@ -920,7 +920,7 @@ class PlantsModel(
 
             # Subtract the N/P required from growth from the element store, and
             # redistribute it to the individual tissues.
-            for stoichiometry in stochiometries.values():
+            for stoichiometry in stoichiometries.values():
                 stoichiometry.account_for_growth(stem_allocation)
 
             # Balance the N & P surplus/deficit with the symbiote carbon supply
@@ -936,11 +936,11 @@ class PlantsModel(
                 element_available_per_stem = np.divide(
                     element_available_per_cohort, cohorts.n_individuals
                 )
-                stochiometries[element].element_surplus += element_available_per_stem
+                stoichiometries[element].element_surplus += element_available_per_stem
 
             # Cohort by cohort, distribute the surplus/deficit across the tissue types
             for cohort in range(len(cohorts.n_individuals)):
-                for stoichiometry in stochiometries.values():
+                for stoichiometry in stoichiometries.values():
                     if stoichiometry.element_surplus[cohort] < 0:
                         # Distribute deficit across the tissue types
                         stoichiometry.distribute_deficit(cohort)
@@ -1033,7 +1033,7 @@ class PlantsModel(
             pass
             # TODO: ask Jacob what he wants from these values
             # self.data["deadwood_c_n_ratio"][cell_id] = (
-            # self.stochiometries[cell_id]["N"]...
+            # self.stoichiometries[cell_id]["N"]...
 
     def calculate_turnover(self) -> None:
         """Calculate turnover of each plant biomass pool.
@@ -1098,7 +1098,7 @@ class PlantsModel(
         # TODO: scale by atmospheric pressure and temperature (#927)
 
         for cell_id in self.communities.keys():
-            self.stochiometries[cell_id]["N"].element_surplus += (
+            self.stoichiometries[cell_id]["N"].element_surplus += (
                 self.per_stem_transpiration[cell_id]
                 * 1.8015e-11
                 * (
@@ -1107,7 +1107,7 @@ class PlantsModel(
                 ).item()
                 * 1000
             )
-            self.stochiometries[cell_id]["P"].element_surplus += (
+            self.stoichiometries[cell_id]["P"].element_surplus += (
                 self.per_stem_transpiration[cell_id]
                 * (1.8015 * pow(10.0, -11))
                 * (self.data["plant_phosphorus_uptake"][cell_id]).item()

--- a/virtual_ecosystem/models/plants/stoichiometry.py
+++ b/virtual_ecosystem/models/plants/stoichiometry.py
@@ -1,5 +1,5 @@
-"""The :mod:`~virtual_ecosystem.models.plants.stochiometry` module contains the class
-for managing plant cohort stochiometry ratios. The carbon mass is stored in plant
+"""The :mod:`~virtual_ecosystem.models.plants.stoichiometry` module contains the class
+for managing plant cohort stoichiometry ratios. The carbon mass is stored in plant
 allometry or allocation, so this class uses those as the anchor weights and stores
 CN and CP ratios.
 
@@ -25,7 +25,7 @@ from virtual_ecosystem.models.plants.functional_types import ExtraTraitsPFT
 
 @dataclass
 class Tissue(ABC):
-    """A dataclass to hold tissue stochiometry data for a set of plant cohorts.
+    """A dataclass to hold tissue stoichiometry data for a set of plant cohorts.
 
     This class holds the current quantity of a given element (generally N or P) for a
     specific plant tissue type (generally foliage, wood, roots or reproductive tissue).
@@ -92,7 +92,7 @@ class Tissue(ABC):
 
 @dataclass
 class FoliageTissue(Tissue):
-    """A class to hold foliage stochiometry data for a set of plant cohorts."""
+    """A class to hold foliage stoichiometry data for a set of plant cohorts."""
 
     reclaim_ratio: NDArray[np.float64]
     """The ratio of the element that can be reclaimed from the senesced tissue."""
@@ -159,7 +159,7 @@ class FoliageTissue(Tissue):
 
 @dataclass
 class ReproductiveTissue(Tissue):
-    """Holds reproductive tissue stochiometry data for a set of plant cohorts."""
+    """Holds reproductive tissue stoichiometry data for a set of plant cohorts."""
 
     @classmethod
     def from_pft_default_ratios(
@@ -220,7 +220,7 @@ class ReproductiveTissue(Tissue):
 
 @dataclass
 class WoodTissue(Tissue):
-    """A class to hold wood stochiometry data for a set of plant cohorts."""
+    """A class to hold wood stoichiometry data for a set of plant cohorts."""
 
     @classmethod
     def from_pft_default_ratios(
@@ -278,7 +278,7 @@ class WoodTissue(Tissue):
 
 @dataclass
 class RootTissue(Tissue):
-    """A class to hold root stochiometry data for a set of plant cohorts."""
+    """A class to hold root stoichiometry data for a set of plant cohorts."""
 
     @classmethod
     def from_pft_default_ratios(
@@ -346,7 +346,7 @@ class RootTissue(Tissue):
 
 
 @dataclass
-class StemStochiometry(CohortMethods, PandasExporter):
+class StemStoichiometry(CohortMethods, PandasExporter):
     """A class holding elemental weights for a set of plant cohorts and tissues.
 
     This class holds the current ratios across tissue type for a community object, which
@@ -362,7 +362,7 @@ class StemStochiometry(CohortMethods, PandasExporter):
     tissues: list[Tissue]
     """Tissues for the associated cohorts."""
     community: Community
-    """The community object that the stochiometry is associated with."""
+    """The community object that the stoichiometry is associated with."""
     element_surplus: NDArray[np.float64] = field(init=False)
     """The surplus of the element per cohort."""
 
@@ -377,15 +377,15 @@ class StemStochiometry(CohortMethods, PandasExporter):
         extra_pft_traits: ExtraTraitsPFT,
         element: str,
     ):
-        """Create an instance of StemStochiometry from the PFT stochiometry ratios.
+        """Create an instance of StemStoichiometry from the PFT stoichiometry ratios.
 
         Args:
-            community: The community object that the stochiometry is associated with.
+            community: The community object that the stoichiometry is associated with.
             extra_pft_traits: Additional traits specific to the plant functional type.
             element: The name of the element (default is "N").
 
         Returns:
-            An instance of StemStochiometry with default tissues.
+            An instance of StemStoichiometry with default tissues.
         """
         foliage_tissue_model = FoliageTissue.from_pft_default_ratios(
             community=community,

--- a/virtual_ecosystem/models/soil/uptake.py
+++ b/virtual_ecosystem/models/soil/uptake.py
@@ -713,7 +713,7 @@ def calculate_maximum_uptake_rates(
     )
 
     # Find maximum possible uptake rates for organic nitrogen and phosphorus, based on
-    # LMWC pool stochiometry
+    # LMWC pool stoichiometry
     lmwc_c_n_ratio = soil_c_pool_lmwc / soil_n_pool_don
     lmwc_c_p_ratio = soil_c_pool_lmwc / soil_p_pool_dop
     organic_nitrogen_uptake_rate_max = carbon_uptake_rate_max / lmwc_c_n_ratio


### PR DESCRIPTION
# Description

Incredibly picky, but the plant stoichiometry code has a typo  `stochiometry -> stoichiometry` that we didn't spot. This also caught a couple of typos in comments elsewhere in the codebase. I've also fixed `stochiometric -> stoichiometric` and `stochiometries -> stoichiometries`.

Fixes #1026

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
