### PR TITLE
Move plants over to the new configuration

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,8 +86,8 @@ autodoc_default_flags = ["members"]
 autosummary_generate = True
 
 # autodoc_typehints = "description"
-# autodoc_typehints_format = "short"
-# python_use_unqualified_type_names = True
+autodoc_typehints_format = "short"
+python_use_unqualified_type_names = True
 # autodoc_type_aliases = {
 #   "FILEPATH_PLACEHOLDER": "virtual_ecosystem.core.configuration.FILEPATH_PLACEHOLDER",
 # }
@@ -194,6 +194,11 @@ nitpick_ignore = [
     ("py:class", "NegativeFloat"),
     ("py:class", "date"),
     ("py:class", "_PydanticGeneralMetadata"),
+    ("py:class", "dir"),
+    # FOR PITY'S SAKE, SPHINX - why can you not find DIRPATH_PLACEHOLDER when you _can_
+    # find FILEPATH_PLACEHOLDER, which is defined in the same way, in the same file and
+    # when both do actually appear in the API docs? It's right there.
+    ("py:class", "DIRPATH_PLACEHOLDER"),
 ]
 
 intersphinx_mapping = {

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -10,8 +10,8 @@ import tomli_w
 from pydantic import create_model
 
 
-def test_pydantic(tmp_path):
-    """Builds a combined config model from all models and then dumps and reloads it."""
+def test_pydantic_models(tmp_path):
+    """Build a combined config model from all models and then dump and reload it."""
 
     modules = (
         ("virtual_ecosystem.core", "CoreConfiguration"),
@@ -44,7 +44,8 @@ def test_pydantic(tmp_path):
 
     with open(config_path) as tomlfile:
         content = tomlfile.read()
-        content = content.replace('"<PLACEHOLDER>"', f"'{tmp_file!s}'")
+        content = content.replace('"<FILEPATH_PLACEHOLDER>"', f"'{tmp_file!s}'")
+        content = content.replace('"<DIRPATH_PLACEHOLDER>"', f"'{tmp_path!s}'")
         content_parsed = tomllib.loads(content)
         config = combined().model_validate_json(json.dumps(content_parsed))
 
@@ -60,14 +61,18 @@ def test_filepath_placeholder(tmp_path):
     """Validate the FILEPATH_PLACEHOLDER custom field."""
     from pydantic import TypeAdapter, ValidationError
 
-    from virtual_ecosystem.core.configuration import FILEPATH_PLACEHOLDER
+    from virtual_ecosystem.core.configuration import (
+        DIRPATH_PLACEHOLDER,
+        FILEPATH_PLACEHOLDER,
+    )
 
     filepath_placeholder_field = TypeAdapter(FILEPATH_PLACEHOLDER)
+    dirpath_placeholder_field = TypeAdapter(DIRPATH_PLACEHOLDER)
 
-    # Object early to <PLACEHOLDER> in input
+    # Object early to <..._PLACEHOLDER> patterns in input
     with pytest.raises(ValidationError) as err:
-        filepath_placeholder_field.validate_python("<PLACEHOLDER>")
-
+        filepath_placeholder_field.validate_python("<FILEPATH_PLACEHOLDER>")
+        dirpath_placeholder_field.validate_python("<DIRPATH_PLACEHOLDER>")
         assert str(err) == "Path placeholder value in configuration."
 
     # Object to file path not existing

--- a/tests/models/plants/conftest.py
+++ b/tests/models/plants/conftest.py
@@ -7,21 +7,21 @@ from xarray import DataArray
 
 
 @pytest.fixture
-def flora(fixture_config):
+def flora(fixture_configuration):
     """Construct a minimal Flora object."""
     from virtual_ecosystem.models.plants.functional_types import get_flora_from_config
 
-    flora, _ = get_flora_from_config(fixture_config)
+    flora, _ = get_flora_from_config(config=fixture_configuration.plants)
 
     return flora
 
 
 @pytest.fixture
-def extra_pft_traits(fixture_config):
+def extra_pft_traits(fixture_configuration):
     """Construct a minimal Flora object."""
     from virtual_ecosystem.models.plants.functional_types import get_flora_from_config
 
-    _, extra_pft_traits = get_flora_from_config(fixture_config)
+    _, extra_pft_traits = get_flora_from_config(config=fixture_configuration.plants)
 
     return extra_pft_traits
 
@@ -45,7 +45,7 @@ def fixture_pyrealm_constants():
 
 
 @pytest.fixture
-def fixture_exporter(fixture_config):
+def fixture_exporter(tmpdir, fixture_configuration):
     """Construct a minimal CommunityDataExporter object.
 
     This exporter uses the default exporter settings that do not output plant community
@@ -53,8 +53,14 @@ def fixture_exporter(fixture_config):
     initialise a PlantsModel.
     """
     from virtual_ecosystem.models.plants.exporter import CommunityDataExporter
+    from virtual_ecosystem.models.plants.model_config import PlantsConfiguration
 
-    exporter = CommunityDataExporter.from_config(fixture_config)
+    plants_config = fixture_configuration.get_subconfiguration(
+        "plants", PlantsConfiguration
+    )
+    exporter = CommunityDataExporter.from_config(
+        output_directory=tmpdir, config=plants_config.community_data_export
+    )
 
     return exporter
 

--- a/tests/models/plants/test_exporter.py
+++ b/tests/models/plants/test_exporter.py
@@ -191,30 +191,6 @@ def test_CommunityDataExporter_check_attribute_subsets(
         ),
         pytest.param(
             dict(
-                path="bad/path/",
-                required=["cohorts", "community_canopy", "stem_canopy"],
-                cohort_attrs=[],
-                ccan_attrs=[],
-                scan_attrs=[],
-            ),
-            pytest.raises(ConfigurationError),
-            "The plant community data output directory does not exist or",
-            id="bad_path",
-        ),
-        pytest.param(
-            dict(
-                path="",
-                required=["cohorts", "community_canopies", "stem_canopy"],
-                cohort_attrs=[],
-                ccan_attrs=[],
-                scan_attrs=[],
-            ),
-            pytest.raises(ConfigurationError),
-            "The required_data setting contains unknown data output options",
-            id="bad required",
-        ),
-        pytest.param(
-            dict(
                 path="",
                 required=["cohorts", "community_canopy", "stem_canopy"],
                 cohort_attrs=["dbh", "crown_area"],
@@ -242,30 +218,24 @@ def test_CommunityDataExporter_check_attribute_subsets(
 def test_CommunityDataExporter_from_config(tmp_path, inputs, outcome, msg):
     """Test the from_config factory method."""
 
-    from virtual_ecosystem.core.config import Config
     from virtual_ecosystem.models.plants.exporter import CommunityDataExporter
+    from virtual_ecosystem.models.plants.model_config import PlantsExportConfig
 
     # Note that the single quotes around the out_path are _required_ here: TOML uses
     # single quotes to indicate raw strings and hence protect the backslashes in Windows
     # path names from being interpreted as escape sequences.
 
-    toml = f"""[core.data_output_options]
-    out_path = '{tmp_path / inputs["path"]}'
-    [plants]
-    pft_definitions_path = "does/not/need/to/exist"
-    cohort_data_path = "also/does/not/need/to/exist"
+    cfg_data = dict(
+        required_data=inputs["required"],
+        cohort_attributes=inputs["cohort_attrs"],
+        community_canopy_attributes=inputs["ccan_attrs"],
+        stem_canopy_attributes=inputs["scan_attrs"],
+    )
 
-    [plants.community_data_export]
-    required_data = {inputs["required"]}
-    cohort_attributes = {inputs["cohort_attrs"]}
-    community_canopy_attributes = {inputs["ccan_attrs"]}
-    stem_canopy_attributes ={inputs["scan_attrs"]}
-    """
-
-    config = Config(cfg_strings=toml)
+    config = PlantsExportConfig().model_validate(cfg_data)
 
     with outcome as excep:
-        CommunityDataExporter.from_config(config=config)
+        CommunityDataExporter.from_config(output_directory=tmp_path, config=config)
 
     if excep:
         assert str(excep.value).startswith(msg)
@@ -602,25 +572,18 @@ class TestExporterDump:
     ):
         """Test the from_config factory method."""
 
-        from virtual_ecosystem.core.config import Config
         from virtual_ecosystem.models.plants.exporter import CommunityDataExporter
+        from virtual_ecosystem.models.plants.model_config import PlantsExportConfig
 
         # Note that the single quotes around the out_path are _required_ here: TOML uses
         # single quotes to indicate raw strings and hence protect the backslashes in
         # Windows path names from being interpreted as escape sequences.
 
-        toml = f"""
-        [core.data_output_options]
-        out_path = '{tmp_path!s}'
-        [plants]
-        pft_definitions_path = "does/not/need/to/exist"
-        cohort_data_path = "also/does/not/need/to/exist"
-        [plants.community_data_export]
-        required_data = {list(required)}
-        """
+        config = PlantsExportConfig(required_data=required)
 
-        config = Config(cfg_strings=toml)
-        exporter = CommunityDataExporter.from_config(config=config)
+        exporter = CommunityDataExporter.from_config(
+            output_directory=tmp_path, config=config
+        )
 
         if required:
             assert exporter._active

--- a/tests/models/plants/test_functional_types.py
+++ b/tests/models/plants/test_functional_types.py
@@ -6,7 +6,7 @@ This module tests the functionality of the plant functional types submodule.
 from virtual_ecosystem.models.plants.functional_types import ExtraTraitsPFT
 
 
-def test_get_flora_from_config(fixture_config):
+def test_get_flora_from_config(fixture_configuration):
     """Testing the pyrealm flora loading mechanism.
 
     This tests the loader in two different configurations (data in TOML, data in CSV)
@@ -18,7 +18,7 @@ def test_get_flora_from_config(fixture_config):
     from virtual_ecosystem.models.plants.functional_types import get_flora_from_config
 
     # Initial fixture_config uses PFT definitions in the file
-    flora, extra_traits = get_flora_from_config(fixture_config)
+    flora, extra_traits = get_flora_from_config(config=fixture_configuration.plants)
 
     assert isinstance(flora, Flora)
     assert flora.n_pfts == 2

--- a/tests/models/plants/test_plants_model.py
+++ b/tests/models/plants/test_plants_model.py
@@ -413,11 +413,16 @@ def test_PlantsModel_calculate_turnover(fxt_plants_model):
 def test_PlantsModel_calculate_turnover_constant_override(
     plants_data, fixture_config, fixture_configuration, fixture_core_components
 ):
-    """Test that the turnover constants can be overridden by values in config."""
+    """Test that the turnover constants can be overridden by values in config.
+
+    TODO - not sure what this actually tests?
+    """
 
     from virtual_ecosystem.models.plants.plants_model import PlantsModel
 
-    fixture_config["plants"]["constants"] = {"PlantsConsts": {"leaf_lignin": 100.0}}
+    # Force setting of new value on frozen pydantic configuration class.
+    fixture_configuration.plants.constants.__dict__["leaf_lignin"] = 100.0
+
     plants_model = PlantsModel.from_config(
         data=plants_data,
         configuration=fixture_configuration,

--- a/virtual_ecosystem/core/configuration.py
+++ b/virtual_ecosystem/core/configuration.py
@@ -56,6 +56,11 @@ def placeholder_validator(path: str) -> str:
     return path
 
 
+# TODO: Fix autodoc
+#       These generate a bizarre set of autodoc link failures that try and build links
+#       from the text elements from the Annotated pattern. Currently tackled using
+#       nitpick ignore.
+
 FILEPATH_PLACEHOLDER: TypeAlias = Annotated[
     FilePath,
     Field(default=Path("<FILEPATH_PLACEHOLDER>")),
@@ -63,15 +68,12 @@ FILEPATH_PLACEHOLDER: TypeAlias = Annotated[
 ]
 """Custom type for file paths in configurations. This enforces the FilePath validation
 to check that paths in configuration data actually point to existing paths. It also
-provides custom validation to allow a "<PLACEHOLDER>" default value. This can be written
-to file - because the field does not use ``validate_defaults`` - but the custom
-validation specifically rejects incoming values that have been left with that default.
+provides custom validation to allow a ``<FILEPATH_PLACEHOLDER>`` default value. This can
+be written to file - because the field does not use ``validate_defaults`` - but the
+custom validation specifically rejects incoming values that have been left with that
+default.
 """
 
-# TODO: Fix autodoc
-#       These generate a bizarre set of autodoc link failures that try and build links
-#       from the text elements from the Annotated pattern. Currently tackled using
-#       nitpick ignore.
 
 DIRPATH_PLACEHOLDER: TypeAlias = Annotated[
     DirectoryPath,
@@ -80,9 +82,10 @@ DIRPATH_PLACEHOLDER: TypeAlias = Annotated[
 ]
 """Custom type for directory paths in configurations. This enforces the DirectoryPath
 validation to check that paths in configuration data actually point to existing paths.
-It also provides custom validation to allow a "<PLACEHOLDER>" default value. This can be
-written to file - because the field does not use ``validate_defaults`` - but the custom
-validation specifically rejects incoming values that have been left with that default.
+It also provides custom validation to allow a ``<DIRPATH_PLACEHOLDER>`` default value.
+This can be written to file - because the field does not use ``validate_defaults`` - but
+the custom validation specifically rejects incoming values that have been left with that
+default.
 """
 
 

--- a/virtual_ecosystem/core/configuration.py
+++ b/virtual_ecosystem/core/configuration.py
@@ -42,8 +42,15 @@ RST_TO_MD = [
 
 
 def placeholder_validator(path: str) -> str:
-    """A custom validator to reject "<PLACEHOLDER>" when loading file paths."""
-    if path == "<PLACEHOLDER>":
+    """Check for path placeholders.
+
+    This custom validator rejects ``<FILEPATH_PLACEHOLDER>`` and
+    ``<DIRPATH_PLACEHOLDER>``  values when loading file paths.
+
+    Args:
+        path: A field path value to validate.
+    """
+    if path in ("<FILEPATH_PLACEHOLDER>", "<DIRPATH_PLACEHOLDER>"):
         raise ValueError("Path placeholder value in configuration.")
 
     return path
@@ -51,7 +58,7 @@ def placeholder_validator(path: str) -> str:
 
 FILEPATH_PLACEHOLDER: TypeAlias = Annotated[
     FilePath,
-    Field(default=Path("<PLACEHOLDER>")),
+    Field(default=Path("<FILEPATH_PLACEHOLDER>")),
     BeforeValidator(placeholder_validator),
 ]
 """Custom type for file paths in configurations. This enforces the FilePath validation
@@ -68,7 +75,7 @@ validation specifically rejects incoming values that have been left with that de
 
 DIRPATH_PLACEHOLDER: TypeAlias = Annotated[
     DirectoryPath,
-    Field(default=Path("<PLACEHOLDER>")),
+    Field(default=Path("<DIRPATH_PLACEHOLDER>")),
     BeforeValidator(placeholder_validator),
 ]
 """Custom type for directory paths in configurations. This enforces the DirectoryPath

--- a/virtual_ecosystem/core/configuration.py
+++ b/virtual_ecosystem/core/configuration.py
@@ -19,7 +19,14 @@ from pathlib import Path
 from typing import Annotated, TypeAlias, TypeVar
 
 import tomli_w
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, FilePath
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    DirectoryPath,
+    Field,
+    FilePath,
+)
 from pydantic._internal._model_construction import ModelMetaclass
 from pydantic_core import PydanticUndefined
 
@@ -32,6 +39,44 @@ RST_TO_MD = [
     (":attr:", "{attr}"),
 ]
 """Tags to replace when converting RST descriptions of fields to Markdown."""
+
+
+def placeholder_validator(path: str) -> str:
+    """A custom validator to reject "<PLACEHOLDER>" when loading file paths."""
+    if path == "<PLACEHOLDER>":
+        raise ValueError("Path placeholder value in configuration.")
+
+    return path
+
+
+FILEPATH_PLACEHOLDER: TypeAlias = Annotated[
+    FilePath,
+    Field(default=Path("<PLACEHOLDER>")),
+    BeforeValidator(placeholder_validator),
+]
+"""Custom type for file paths in configurations. This enforces the FilePath validation
+to check that paths in configuration data actually point to existing paths. It also
+provides custom validation to allow a "<PLACEHOLDER>" default value. This can be written
+to file - because the field does not use ``validate_defaults`` - but the custom
+validation specifically rejects incoming values that have been left with that default.
+"""
+
+# TODO: Fix autodoc
+#       These generate a bizarre set of autodoc link failures that try and build links
+#       from the text elements from the Annotated pattern. Currently tackled using
+#       nitpick ignore.
+
+DIRPATH_PLACEHOLDER: TypeAlias = Annotated[
+    DirectoryPath,
+    Field(default=Path("<PLACEHOLDER>")),
+    BeforeValidator(placeholder_validator),
+]
+"""Custom type for directory paths in configurations. This enforces the DirectoryPath
+validation to check that paths in configuration data actually point to existing paths.
+It also provides custom validation to allow a "<PLACEHOLDER>" default value. This can be
+written to file - because the field does not use ``validate_defaults`` - but the custom
+validation specifically rejects incoming values that have been left with that default.
+"""
 
 
 class Configuration(BaseModel):
@@ -112,32 +157,6 @@ class ModelConfigurationRoot(Configuration):
 
     static: bool = False
     """The model static mode setting."""
-
-
-def placeholder_validator(path: str) -> str:
-    """A custom validator to reject "<PLACEHOLDER>" when loading file paths."""
-    if path == "<PLACEHOLDER>":
-        raise ValueError("Path placeholder value in configuration.")
-
-    return path
-
-
-FILEPATH_PLACEHOLDER: TypeAlias = Annotated[
-    FilePath,
-    Field(default=Path("<PLACEHOLDER>")),
-    BeforeValidator(placeholder_validator),
-]
-"""Pydantic type that provides a default '<PLACEHOLDER>' text for writing configuration
-templates, but screens input before the standard validation to refuse unreplaced
-placeholder values. The type then uses FilePath, which validates that a path actually
-exists on the file system. The field does not set ``validate_defaults`` so the
-placeholder value can be written despite not being an existing file.
-
-.. TODO: Fix autodoc
-    This generates a bizarre set of autodoc link failures that try and build links from
-    the text elements from the Annotated pattern. Currently tackled using nitpick 
-    ignore.
-"""
 
 
 def model_config_to_html(

--- a/virtual_ecosystem/core/model_config.py
+++ b/virtual_ecosystem/core/model_config.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from datetime import date
 from functools import cached_property
+from pathlib import Path
 from typing import ClassVar
 
 import numpy as np
@@ -22,7 +23,7 @@ from pydantic import (
 )
 from scipy import constants
 
-from virtual_ecosystem.core.configuration import Configuration
+from virtual_ecosystem.core.configuration import FILEPATH_PLACEHOLDER, Configuration
 
 
 class CoreConstants(Configuration):
@@ -223,8 +224,8 @@ class DataOutputConfiguration(Configuration):
     "Whether the final state should be saved"
     save_merged_config: bool = True
     "Whether to save a merged TOML file containing all config options"
-    out_path: str = "."
-    "File path for output files"
+    out_path: FILEPATH_PLACEHOLDER = Path("<PLACEHOLDER>")
+    "Directory path for output files"
     out_initial_file_name: str = "initial_state.nc"
     """File name for initial state output file"""
     out_folder_continuous: str = "."

--- a/virtual_ecosystem/core/model_config.py
+++ b/virtual_ecosystem/core/model_config.py
@@ -1,8 +1,6 @@
-"""The `models.animal.constants` module contains a set of dataclasses containing
-constants" (fitting relationships taken from the literature) required by the broader
-:mod:`~virtual_ecosystem.models.animal` module
-
-"""  # noqa: D205, D415
+"""The `core.model_config` module contains pydantic models defining the configuration
+settings required for the Core model in a Virtual Ecosystem simulation.
+"""  # noqa: D205
 
 from __future__ import annotations
 

--- a/virtual_ecosystem/core/model_config.py
+++ b/virtual_ecosystem/core/model_config.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from datetime import date
 from functools import cached_property
-from pathlib import Path
 from typing import ClassVar
 
 import numpy as np
@@ -227,7 +226,7 @@ class DataOutputConfiguration(Configuration):
     "Whether the final state should be saved"
     save_merged_config: bool = True
     "Whether to save a merged TOML file containing all config options"
-    out_path: DIRPATH_PLACEHOLDER = Path("<PLACEHOLDER>")
+    out_path: DIRPATH_PLACEHOLDER  # = Path("<DIRPATH_PLACEHOLDER>")
     "Directory path for output files"
     out_initial_file_name: str = "initial_state.nc"
     """File name for initial state output file"""

--- a/virtual_ecosystem/core/model_config.py
+++ b/virtual_ecosystem/core/model_config.py
@@ -23,7 +23,10 @@ from pydantic import (
 )
 from scipy import constants
 
-from virtual_ecosystem.core.configuration import FILEPATH_PLACEHOLDER, Configuration
+from virtual_ecosystem.core.configuration import (
+    DIRPATH_PLACEHOLDER,
+    Configuration,
+)
 
 
 class CoreConstants(Configuration):
@@ -224,7 +227,7 @@ class DataOutputConfiguration(Configuration):
     "Whether the final state should be saved"
     save_merged_config: bool = True
     "Whether to save a merged TOML file containing all config options"
-    out_path: FILEPATH_PLACEHOLDER = Path("<PLACEHOLDER>")
+    out_path: DIRPATH_PLACEHOLDER = Path("<PLACEHOLDER>")
     "Directory path for output files"
     out_initial_file_name: str = "initial_state.nc"
     """File name for initial state output file"""

--- a/virtual_ecosystem/models/plants/exporter.py
+++ b/virtual_ecosystem/models/plants/exporter.py
@@ -20,10 +20,10 @@ from pyrealm.demography.canopy import Canopy, CohortCanopyData, CommunityCanopyD
 from pyrealm.demography.community import Cohorts
 from pyrealm.demography.tmodel import StemAllocation, StemAllometry
 
-from virtual_ecosystem.core.config import Config
 from virtual_ecosystem.core.exceptions import ConfigurationError
 from virtual_ecosystem.core.logger import LOGGER
 from virtual_ecosystem.models.plants.communities import PlantCommunities
+from virtual_ecosystem.models.plants.model_config import PlantsExportConfig
 
 
 class CommunityDataExporter:
@@ -218,38 +218,29 @@ class CommunityDataExporter:
                 raise ConfigurationError(msg)
 
     @classmethod
-    def from_config(cls, config: Config) -> CommunityDataExporter:
-        """Factory class to create a CommunityDataExporter from a configuration.
+    def from_config(
+        cls, output_directory: Path, config: PlantsExportConfig
+    ) -> CommunityDataExporter:
+        """Factory class to create a CommunityDataExporter from configuration data.
 
-        The configuration requires that the following details are present in the plants
-        model section of the configuration;
+        See the documentation of
+        :class:`~virtual_ecosystem.models.plants.model_config.PlantsExportConfig`
+        for details of the configuration settings for this method.
 
-        .. code-block:: toml
+        Args:
+            output_directory: The path to the output directory for the files
+            config: An instance of ``PlantsExportConfig``
 
-            [plants.community_data_export]
-            required_data = ["cohorts", "community_canopy", "stem_canopy"]
-            cohort_attributes = []
-            community_canopy_attributes = []
-            stem_canopy_attributes = []
-
-        The ``required_data`` section specifies which community data files are to be
-        exported. If the "attributes" sections are empty arrays, then all attributes are
-        written to file, but specific fields may be named here to reduce the amount of
-        data exported.
         """
 
         # Try and build the arguments as a dictionary from the config, substituting
         # explicit None values for empty strings
         try:
-            out_path = config["core"]["data_output_options"]["out_path"]
-            xcfg = config["plants"]["community_data_export"]
-
-            # Get arguments and convert inputs
-            output_directory = Path(out_path)
-            required_data = set(xcfg["required_data"])
-            cohort_attributes = set(xcfg["cohort_attributes"])
-            community_canopy_attributes = set(xcfg["community_canopy_attributes"])
-            stem_canopy_attributes = set(xcfg["stem_canopy_attributes"])
+            # Get arguments and convert inputs - reduce Literals to plain strings.
+            required_data = set([str(x) for x in config.required_data])
+            cohort_attributes = set(config.cohort_attributes)
+            community_canopy_attributes = set(config.community_canopy_attributes)
+            stem_canopy_attributes = set(config.stem_canopy_attributes)
         except KeyError as excep:
             LOGGER.error(excep)
             raise

--- a/virtual_ecosystem/models/plants/functional_types.py
+++ b/virtual_ecosystem/models/plants/functional_types.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 import pandas as pd
 from pyrealm.demography.flora import Flora
 
-from virtual_ecosystem.core.config import Config, ConfigurationError
-from virtual_ecosystem.core.logger import LOGGER
+from virtual_ecosystem.models.plants.model_config import PlantsConfiguration
 
 
 class ExtraTraitsPFT:
@@ -59,11 +58,11 @@ class ExtraTraitsPFT:
         return cls._from_file_data(traits)
 
 
-def get_flora_from_config(config: Config) -> tuple[Flora, ExtraTraitsPFT]:
+def get_flora_from_config(config: PlantsConfiguration) -> tuple[Flora, ExtraTraitsPFT]:
     """Generate a Flora object from a Virtual Ecosystem configuration.
 
     Args:
-        config: A validated Virtual Ecosystem model configuration object.
+        config: A validated PlantsConfiguration instance.
 
     Returns:
         A tuple containing a populated :class:`pyrealm.demography.flora.Flora` instance
@@ -83,20 +82,9 @@ def get_flora_from_config(config: Config) -> tuple[Flora, ExtraTraitsPFT]:
         "foliage_c_p_ratio",
     ]
 
-    # Double check the configuration setting is present.
-    if "plants" not in config:
-        msg = "Model configuration for plants model not found."
-        LOGGER.critical(msg)
-        raise ConfigurationError(msg)
-
-    if "pft_definitions_path" not in config["plants"]:
-        msg = "PFT definition path not set in plants model configuration."
-        LOGGER.critical(msg)
-        raise ConfigurationError(msg)
-
     # Read the file, handling file IO and parsing errors.
     try:
-        df = pd.read_csv(config["plants"]["pft_definitions_path"])
+        df = pd.read_csv(config.pft_definitions_path)
     except (FileNotFoundError, pd.errors.ParserError) as excep:
         raise excep
 

--- a/virtual_ecosystem/models/plants/model_config.py
+++ b/virtual_ecosystem/models/plants/model_config.py
@@ -1,5 +1,7 @@
 """Configuration for the plants model."""
 
+from typing import Literal
+
 from virtual_ecosystem.core.configuration import (
     FILEPATH_PLACEHOLDER,
     Configuration,
@@ -107,12 +109,46 @@ class PlantsConstants(Configuration):
 
 
 class PlantsExportConfig(Configuration):
-    """Configuration class for plant export options."""
+    """Configuration class for plant export options.
 
-    required_data: tuple[str, ...] = ()
-    """An array giving the required attributes to be exported."""
+    The plants model only writes a relatively small amount of data to the central data
+    store. These variables are typically about the light environment within vertical
+    layers and plant biomasses and stoichiometry within grid cells.
+
+    However, the model also contains a great deal of demographic and allometric data
+    about the plant communities within grid cells. If you want to look in detail at the
+    plant communities in a simulation, then you can use this configuration section to
+    output a wider range of plant model data at each model update.
+
+    There are three possible output files:
+
+    * Cohort data: details about the stems in each cohort, including the stem allometry
+      and the GPP allocation of the stem. The stem GPP allocation is not defined during
+      the model setup, so these attributes are set to ``np.nan`` for the initial output.
+      This data is exported to the file ``plants_cohort_data.csv``.
+
+    * Community canopy data: community wide data on the canopy structure, such as the
+      heights of the canopy layers and the light transmission profile. This data is
+      exported to the file ``plants_community_canopy_data.csv``.
+
+    * Stem canopy data: details of contribution in leaf area and fAPAR from each stem to
+      the community canopy model. This data is exported to the file
+      ``plants_stem_canopy_data.csv``.
+
+    By default, the exporter does not export any data, but you can configure which of
+    these files to export. You can also configure which attributes to export for each
+    data file. For each of the three files, the default is to not specify a subset of
+    attributes, but you may not require all of this data and so can set specific
+    attribute names to include in the file..
+    """
+
+    required_data: tuple[
+        Literal["cohorts", "community_canopy", "stem_canopy"], ...
+    ] = ()
+    """A list of the required data files to be exported, using `cohorts`,
+    `community_canopy` and `stem_canopy`."""
     cohort_attributes: tuple[str, ...] = ()
-    """The cohort attributes that should be exported."""
+    """A list of the cohort attributes that should be exported."""
     community_canopy_attributes: tuple[str, ...] = ()
     """The community canopy attributes that should be exported."""
     stem_canopy_attributes: tuple[str, ...] = ()

--- a/virtual_ecosystem/models/plants/plants_model.py
+++ b/virtual_ecosystem/models/plants/plants_model.py
@@ -22,23 +22,25 @@ from pyrealm.pmodel import PModel, PModelEnvironment
 from virtual_ecosystem.core.base_model import BaseModel
 from virtual_ecosystem.core.config import Config
 from virtual_ecosystem.core.configuration import CompiledConfiguration
-from virtual_ecosystem.core.constants_loader import load_constants
 from virtual_ecosystem.core.core_components import CoreComponents
 from virtual_ecosystem.core.data import Data
-from virtual_ecosystem.core.exceptions import ConfigurationError, InitialisationError
+from virtual_ecosystem.core.exceptions import InitialisationError
 from virtual_ecosystem.core.logger import LOGGER
+from virtual_ecosystem.core.model_config import CoreConfiguration
 from virtual_ecosystem.models.plants.canopy import (
     calculate_canopies,
     initialise_canopy_layers,
 )
 from virtual_ecosystem.models.plants.communities import PlantCommunities
-from virtual_ecosystem.models.plants.constants import PlantsConsts
 from virtual_ecosystem.models.plants.exporter import CommunityDataExporter
 from virtual_ecosystem.models.plants.functional_types import (
     ExtraTraitsPFT,
     get_flora_from_config,
 )
-from virtual_ecosystem.models.plants.model_config import PlantsConfiguration
+from virtual_ecosystem.models.plants.model_config import (
+    PlantsConfiguration,
+    PlantsConstants,
+)
 from virtual_ecosystem.models.plants.stoichiometry import (
     StemStoichiometry,
 )
@@ -262,7 +264,7 @@ class PlantsModel(
         """The extra traits for each plant functional type, keyed by PFT name."""
 
         #
-        self.model_constant: PlantsConsts
+        self.model_constant: PlantsConstants
         """Set of constants for the plants model"""
         self.communities: PlantCommunities
         """An instance of PlantCommunities providing dictionary access keyed by cell id
@@ -316,7 +318,7 @@ class PlantsModel(
         data: Data,
         configuration: CompiledConfiguration,
         core_components: CoreComponents,
-        config: Config,
+        config: Config,  # TO BE DELETED
     ) -> PlantsModel:
         """Factory function to initialise a plants model from configuration.
 
@@ -330,40 +332,32 @@ class PlantsModel(
             config: A validated Virtual Ecosystem model configuration object.
         """
 
-        # Extract the validated model configuration from the complete compiled
-        # configuration. This syntax is odd but required to support static typing
+        # Extract subconfigurations from the complete compiled configuration.
         model_configuration: PlantsConfiguration = configuration.get_subconfiguration(
             "plants", PlantsConfiguration
         )
-
-        # Load in the relevant constants
-        model_constants = load_constants(config, "plants", "PlantsConsts")
-        static = model_configuration.static
+        core_configuration: CoreConfiguration = configuration.get_subconfiguration(
+            "core", CoreConfiguration
+        )
 
         # Generate the flora
-        flora, extra_traits = get_flora_from_config(config=config)
+        flora, extra_traits = get_flora_from_config(config=model_configuration)
 
-        # Load the initial cohort data
-        cohort_data_path = config["plants"].get("cohort_data_path")
-        if cohort_data_path is None:
-            msg = "Plant configuration error: cohort_data_path not provided"
-            LOGGER.error(msg)
-            raise ConfigurationError(msg)
-
+        # Load the initial cohort data - use of FILEPATH_PLACEHOLDER guarantees that
+        # this path has been set and exists.
         try:
-            with open(cohort_data_path) as csv_data:
+            with open(model_configuration.cohort_data_path) as csv_data:
                 cohort_data = pandas.read_csv(csv_data)
-        except FileNotFoundError:
-            msg = "Plant configuration error: cohort_data_path not found."
-            LOGGER.error(msg)
-            raise ConfigurationError(msg)
         except pandas.errors.ParserError as excep:
             msg = "Plant configuration error: cannot parse cohort data " + str(excep)
             LOGGER.error(msg)
             raise InitialisationError(msg)
 
         # Create a CommunityDataExporter instance from config
-        exporter = CommunityDataExporter.from_config(config=config)
+        exporter = CommunityDataExporter.from_config(
+            output_directory=core_configuration.data_output_options.out_path,
+            config=model_configuration.community_data_export,
+        )
 
         # Try and create the instance - safeguard against exceptions from __init__
         try:
@@ -373,9 +367,9 @@ class PlantsModel(
                 flora=flora,
                 cohort_data=cohort_data,
                 extra_pft_traits=extra_traits,
-                model_constants=model_constants,
+                model_constants=model_configuration.constants,
                 exporter=exporter,
-                static=static,
+                static=model_configuration.static,
             )
         except Exception as excep:
             LOGGER.critical(
@@ -391,7 +385,7 @@ class PlantsModel(
         flora: Flora,
         cohort_data: pandas.DataFrame,
         extra_pft_traits: ExtraTraitsPFT,
-        model_constants: PlantsConsts = PlantsConsts(),
+        model_constants: PlantsConstants = PlantsConstants(),
         **kwargs: Any,
     ) -> None:
         """Setup implementation for the Plants Model.

--- a/virtual_ecosystem/models/plants/subcanopy.py
+++ b/virtual_ecosystem/models/plants/subcanopy.py
@@ -67,7 +67,7 @@ class Nutrient:
             masses: The carbon biomasses of cells for the tissue.
         """
 
-        ideal_ratio = getattr(PlantsConstants, f"{tissue_name}_c_{element}_ratio")
+        ideal_ratio = getattr(constants, f"{tissue_name}_c_{element}_ratio")
         return cls(name=element, ideal_ratio=ideal_ratio, masses=masses / ideal_ratio)
 
 

--- a/virtual_ecosystem/models/plants/subcanopy.py
+++ b/virtual_ecosystem/models/plants/subcanopy.py
@@ -33,7 +33,7 @@ from xarray import DataArray, full_like
 
 from virtual_ecosystem.core.core_components import ModelTiming
 from virtual_ecosystem.core.data import Data
-from virtual_ecosystem.models.plants.constants import PlantsConsts
+from virtual_ecosystem.models.plants.model_config import PlantsConstants
 
 
 @dataclass
@@ -55,7 +55,7 @@ class Nutrient:
         cls,
         tissue_name: str,
         element: str,
-        constants: PlantsConsts,
+        constants: PlantsConstants,
         masses: NDArray[np.floating],
     ) -> Nutrient:
         """Factory method for Nutrient instances from the ideal ratio in constants.
@@ -67,7 +67,7 @@ class Nutrient:
             masses: The carbon biomasses of cells for the tissue.
         """
 
-        ideal_ratio = getattr(PlantsConsts, f"{tissue_name}_c_{element}_ratio")
+        ideal_ratio = getattr(PlantsConstants, f"{tissue_name}_c_{element}_ratio")
         return cls(name=element, ideal_ratio=ideal_ratio, masses=masses / ideal_ratio)
 
 
@@ -102,7 +102,7 @@ class SubcanopyBiomass:
         cls,
         tissue_name: str,
         elements: tuple[str, ...],
-        constants: PlantsConsts,
+        constants: PlantsConstants,
         masses: NDArray[np.floating],
     ) -> SubcanopyBiomass:
         """Factory method to generate a SubcanopyBiomass object from constants.
@@ -237,14 +237,14 @@ class Subcanopy:
         self,
         data: Data,
         pmodel_core_constants: CoreConst,
-        model_constants: PlantsConsts,
+        model_constants: PlantsConstants,
         layer_index: int,
         model_timing: ModelTiming,
     ) -> None:
         # Init attributes
         self.data: Data = data
         self.pmodel_core_constants: CoreConst = pmodel_core_constants
-        self.model_constants: PlantsConsts = model_constants
+        self.model_constants: PlantsConstants = model_constants
         self.model_timing: ModelTiming = model_timing
         self.layer_index: int = layer_index
 


### PR DESCRIPTION
# Description

This PR:

* Moves the `plants` model over to using the new configuration system.
* Adds a new pydantic type alias to support placeholder directory values in configs as well as placeholder file paths.


Fixes #1102

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
