### PR TITLE
Move  both abiotic models over to the new configuration system

### DIFF
--- a/docs/source/_toc.yaml
+++ b/docs/source/_toc.yaml
@@ -132,6 +132,8 @@ subtrees:
             entries:
               - file: api/models/abiotic/abiotic_model
                 title: The abiotic model submodule
+              - file: api/models/abiotic/model_config
+                title: The model_config submodule                
               - file: api/models/abiotic/abiotic_constants
                 title: The abiotic constants submodule
               - file: api/models/abiotic/abiotic_tools
@@ -149,6 +151,8 @@ subtrees:
                 title: The abiotic_simple_constants submodule
               - file: api/models/abiotic_simple/abiotic_simple_model
                 title: The abiotic simple_model submodule
+              - file: api/models/abiotic_simple/model_config
+                title: The model_config submodule
               - file: api/models/abiotic_simple/microclimate_simple
                 title: The simple microclimate submodule
           - file: api/models/animal

--- a/docs/source/api/models/abiotic/model_config.md
+++ b/docs/source/api/models/abiotic/model_config.md
@@ -1,0 +1,34 @@
+---
+jupytext:
+  cell_metadata_filter: -all
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.18.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
+# API documentation for the {mod}`~virtual_ecosystem.models.abiotic.model_config` module
+
+```{eval-rst}
+.. automodule:: virtual_ecosystem.models.abiotic.model_config
+    :autosummary:
+    :members:
+    :exclude-members: model_config
+```

--- a/docs/source/api/models/abiotic_simple/model_config.md
+++ b/docs/source/api/models/abiotic_simple/model_config.md
@@ -1,0 +1,35 @@
+---
+jupytext:
+  cell_metadata_filter: -all
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.18.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
+<!-- markdownlint-disable-next-line MD013-->
+# API documentation for the {mod}`~virtual_ecosystem.models.abiotic_simple.model_config` module
+
+```{eval-rst}
+.. automodule:: virtual_ecosystem.models.abiotic_simple.model_config
+    :autosummary:
+    :members:
+    :exclude-members: model_config
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -204,6 +204,7 @@ nitpick_ignore = [
     # find FILEPATH_PLACEHOLDER, which is defined in the same way, in the same file and
     # when both do actually appear in the API docs? It's right there.
     ("py:class", "DIRPATH_PLACEHOLDER"),
+    ("py:class", "PyrealmConst"),
 ]
 
 intersphinx_mapping = {

--- a/docs/source/virtual_ecosystem/implementation/abiotic_simple_implementation.md
+++ b/docs/source/virtual_ecosystem/implementation/abiotic_simple_implementation.md
@@ -75,7 +75,7 @@ The linear regression for below canopy values (1.5 m) is based on
 $$y = m * LAI + c$$
 
 where $y$ is the variable of interest, $m$ is the gradient
-(see {py:class}`~virtual_ecosystem.models.abiotic_simple.constants.AbioticSimpleBounds`)
+(see {py:class}`~virtual_ecosystem.models.abiotic_simple.model_config.AbioticSimpleBounds`)
 and $c$ is the intersect which we set to the external data values,
 see {numref}`abiotic_simple_step1`.
 We assume that the gradient remains constant throughout the simulation.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -291,6 +291,7 @@ def generate_config_strings(
 {(fixture_root_data_dir / "animal_functional_groups.csv")!s}'''
 
         [hydrology]
+        [abiotic]
     """
 
     return [cfg_string, additional_toml]
@@ -337,6 +338,49 @@ def animal_fixture_configuration():
     config_data = ConfigurationLoader(cfg_strings=generate_config_strings(nx=3, ny=3))
 
     return generate_configuration(config_data.data)
+
+
+@pytest.fixture
+def fixture_core_constants(fixture_configuration):
+    """Get the core constants instance from the config."""
+
+    return fixture_configuration.core.constants
+
+
+@pytest.fixture
+def fixture_soil_constants(fixture_configuration):
+    """Get the soil constants instance from the config."""
+
+    return fixture_configuration.soil.constants
+
+
+@pytest.fixture
+def fixture_hydrology_constants(fixture_configuration):
+    """Get the hydrology constants instance from the config."""
+
+    return fixture_configuration.hydrology.constants
+
+
+@pytest.fixture
+def fixture_abiotic_constants(fixture_configuration):
+    """Get the abiotic constants instance from the config."""
+
+    return fixture_configuration.abiotic.constants
+
+
+@pytest.fixture
+def fixture_abiotic_simple_configuration():
+    """Get an abiotic_simple configuration instance to provide bounds and constants.
+
+    The abiotic simple model is not used in the fixture_configuration so this fixture
+    creates one from scratch.
+    """
+
+    from virtual_ecosystem.models.abiotic_simple.model_config import (
+        AbioticSimpleConfiguration,
+    )
+
+    return AbioticSimpleConfiguration()
 
 
 @pytest.fixture

--- a/tests/models/abiotic/test_abiotic_model.py
+++ b/tests/models/abiotic/test_abiotic_model.py
@@ -1,7 +1,7 @@
 """Test module for abiotic.abiotic_model.py."""
 
 from contextlib import nullcontext as does_not_raise
-from logging import CRITICAL, DEBUG, ERROR, INFO
+from logging import DEBUG, ERROR, INFO
 from unittest.mock import patch
 
 import numpy as np
@@ -45,12 +45,14 @@ SETUP_MANIPULATIONS = (
 
 
 def test_abiotic_model_initialization(
-    caplog, dummy_climate_data_varying_canopy, fixture_core_components
+    caplog,
+    dummy_climate_data_varying_canopy,
+    fixture_core_components,
+    fixture_abiotic_constants,
 ):
     """Test `AbioticModel` initialization."""
     from virtual_ecosystem.core.base_model import BaseModel
     from virtual_ecosystem.models.abiotic.abiotic_model import AbioticModel
-    from virtual_ecosystem.models.abiotic.constants import AbioticConsts
 
     # Initialize model
     with (
@@ -61,7 +63,7 @@ def test_abiotic_model_initialization(
         model = AbioticModel(
             dummy_climate_data_varying_canopy,
             core_components=fixture_core_components,
-            model_constants=AbioticConsts(),
+            model_constants=fixture_abiotic_constants,
         )
         mock_update.assert_called_once()
         mock_bypass_setup.assert_called_once()
@@ -79,13 +81,14 @@ def test_abiotic_model_initialization(
     )
 
 
-def test_abiotic_model_initialization_no_data(caplog, fixture_core_components):
+def test_abiotic_model_initialization_no_data(
+    caplog, fixture_core_components, fixture_abiotic_constants
+):
     """Test `AbioticModel` initialization with no data."""
 
     from virtual_ecosystem.core.data import Data
     from virtual_ecosystem.core.grid import Grid
     from virtual_ecosystem.models.abiotic.abiotic_model import AbioticModel
-    from virtual_ecosystem.models.abiotic.constants import AbioticConsts
 
     with pytest.raises(ValueError):
         # Make four cell grid
@@ -96,7 +99,7 @@ def test_abiotic_model_initialization_no_data(caplog, fixture_core_components):
         _ = AbioticModel(
             empty_data,
             core_components=fixture_core_components,
-            model_constants=AbioticConsts(),
+            model_constants=fixture_abiotic_constants,
         )
 
     # Final check that expected logging entries are produced
@@ -129,14 +132,12 @@ def test_abiotic_model_initialization_no_data(caplog, fixture_core_components):
 
 
 @pytest.mark.parametrize(
-    "cfg_string, drag_coeff, raises, expected_log_entries",
+    "cfg_string, raises, expected_log_entries",
     [
         pytest.param(
             "[core]\n[core.timing]\nupdate_interval = '12 hours'\n[abiotic]\n",
-            0.2,
             does_not_raise(),
             (
-                (INFO, "Initialised abiotic.AbioticConsts from config"),
                 (
                     INFO,
                     "Information required to initialise the abiotic model successfully "
@@ -148,11 +149,9 @@ def test_abiotic_model_initialization_no_data(caplog, fixture_core_components):
         ),
         pytest.param(
             "[core]\n[core.timing]\nupdate_interval = '12 hours'\n"
-            "[abiotic.constants.AbioticConsts]\ndrag_coefficient = 0.05\n",
-            0.05,
+            "[abiotic.constants]\ndrag_coefficient = 0.05\n",
             does_not_raise(),
             (
-                (INFO, "Initialised abiotic.AbioticConsts from config"),
                 (
                     INFO,
                     "Information required to initialise the abiotic model successfully "
@@ -162,55 +161,30 @@ def test_abiotic_model_initialization_no_data(caplog, fixture_core_components):
             ),
             id="modified_config_correct",
         ),
-        pytest.param(
-            "[core]\n[core.timing]\nupdate_interval = '12 hours'\n"
-            "[abiotic.constants.AbioticConsts]\ndrag_coefficients = 0.05\n",
-            None,
-            pytest.raises(ConfigurationError),
-            (
-                (ERROR, "Unknown names supplied for AbioticConsts: drag_coefficients"),
-                (INFO, "Valid names are: "),
-                (CRITICAL, "Could not initialise abiotic.AbioticConsts from config"),
-            ),
-            id="modified_config_incorrect",
-        ),
     ],
 )
 def test_generate_abiotic_model(
     caplog,
     dummy_climate_data_varying_canopy,
     cfg_string,
-    drag_coeff,
     raises,
     expected_log_entries,
 ):
     """Test that the function to initialise the abiotic model behaves as expected."""
 
-    from virtual_ecosystem.core.config import Config
     from virtual_ecosystem.core.config_builder import (
         ConfigurationLoader,
         generate_configuration,
     )
     from virtual_ecosystem.core.core_components import CoreComponents
     from virtual_ecosystem.models.abiotic.abiotic_model import AbioticModel
-    from virtual_ecosystem.models.abiotic.constants import AbioticConsts
 
-    # Build the config object and core components
-    config = Config(cfg_strings=cfg_string)
-
-    # TODO - this is a temporary fix for #1103- the abiotic constants validation is
-    # currently being handled by Config, but will move into generate_configuration.
-    # The config strings are different, so hard code for now.
-    config_data = ConfigurationLoader(
-        cfg_strings="[core]\n[core.timing]\nupdate_interval = '12 hours'\n[abiotic]\n"
-    )
+    config_data = ConfigurationLoader(cfg_strings=cfg_string)
     configuration = generate_configuration(config_data.data)
-
     core_components = CoreComponents(configuration.core)
     caplog.clear()
 
     # We patch the _setup step as it is tested separately
-    expected_constants = AbioticConsts(drag_coefficient=drag_coeff)
     object_to_patch = "virtual_ecosystem.models.abiotic.abiotic_model.AbioticModel"
     with (
         patch_run_update(AbioticModel) as mock_update,
@@ -224,9 +198,9 @@ def test_generate_abiotic_model(
                 data=dummy_climate_data_varying_canopy,
                 configuration=configuration,
                 core_components=core_components,
-                config=config,
+                config=configuration,
             )
-            mock_setup.assert_called_once_with(model_constants=expected_constants)
+            mock_setup.assert_called_once()
             mock_bypass_setup.assert_called_once()
             mock_update.assert_called_once()
 
@@ -241,7 +215,6 @@ def test_generate_abiotic_model(
             "[core]\n[core.timing]\nupdate_interval = '1 year'\n[abiotic]\n",
             pytest.raises(ConfigurationError),
             (
-                (INFO, "Initialised abiotic.AbioticConsts from config"),
                 (
                     INFO,
                     "Information required to initialise the abiotic model "

--- a/tests/models/abiotic/test_abiotic_tools.py
+++ b/tests/models/abiotic/test_abiotic_tools.py
@@ -4,12 +4,9 @@ import numpy as np
 import pytest
 from pyrealm.constants import CoreConst as PyrealmConst
 
-from virtual_ecosystem.core.constants import CoreConsts
-from virtual_ecosystem.models.abiotic.constants import AbioticConsts
-
 
 def test_calculate_molar_density_air(
-    dummy_climate_data_varying_canopy, fixture_core_components
+    dummy_climate_data_varying_canopy, fixture_core_components, fixture_core_constants
 ):
     """Test calculate temperature-dependent molar desity of air."""
 
@@ -23,9 +20,9 @@ def test_calculate_molar_density_air(
     result = calculate_molar_density_air(
         temperature=data["air_temperature"][atm_index].to_numpy(),
         atmospheric_pressure=data["atmospheric_pressure"][atm_index].to_numpy(),
-        standard_mole=CoreConsts.standard_mole,
-        standard_pressure=CoreConsts.standard_pressure,
-        celsius_to_kelvin=CoreConsts.zero_Celsius,
+        standard_mole=fixture_core_constants.standard_mole,
+        standard_pressure=fixture_core_constants.standard_pressure,
+        celsius_to_kelvin=fixture_core_constants.zero_Celsius,
     )
 
     exp_result = np.array(
@@ -41,21 +38,20 @@ def test_calculate_molar_density_air(
 
 
 def test_calculate_air_density(
-    dummy_climate_data_varying_canopy, fixture_core_components
+    dummy_climate_data_varying_canopy, fixture_core_components, fixture_core_constants
 ):
     """Test calculate the density of air."""
 
     from virtual_ecosystem.models.abiotic.abiotic_tools import calculate_air_density
 
-    consts = CoreConsts()
     data = dummy_climate_data_varying_canopy
     atm_index = fixture_core_components.layer_structure.index_filled_atmosphere
 
     result = calculate_air_density(
         air_temperature=data["air_temperature"][atm_index].to_numpy(),
         atmospheric_pressure=data["atmospheric_pressure"][atm_index].to_numpy(),
-        specific_gas_constant_dry_air=consts.specific_gas_constant_dry_air,
-        celsius_to_kelvin=consts.zero_Celsius,
+        specific_gas_constant_dry_air=fixture_core_constants.specific_gas_constant_dry_air,
+        celsius_to_kelvin=fixture_core_constants.zero_Celsius,
     )
 
     exp_result = np.array(
@@ -71,7 +67,10 @@ def test_calculate_air_density(
 
 
 def test_calculate_latent_heat_vapourisation(
-    dummy_climate_data_varying_canopy, fixture_core_components
+    dummy_climate_data_varying_canopy,
+    fixture_core_components,
+    fixture_abiotic_constants,
+    fixture_core_constants,
 ):
     """Test calculation of latent heat of vapourization."""
 
@@ -81,11 +80,11 @@ def test_calculate_latent_heat_vapourisation(
 
     data = dummy_climate_data_varying_canopy
     atm_index = fixture_core_components.layer_structure.index_filled_atmosphere
-    constants = AbioticConsts()
+    constants = fixture_abiotic_constants
 
     result = calculate_latent_heat_vapourisation(
         temperature=data["air_temperature"][atm_index].to_numpy(),
-        celsius_to_kelvin=CoreConsts.zero_Celsius,
+        celsius_to_kelvin=fixture_core_constants.zero_Celsius,
         latent_heat_vap_equ_factors=constants.latent_heat_vap_equ_factors,
     )
     exp_result = np.array(
@@ -130,7 +129,9 @@ def test_find_last_valid_row(input_array, expected):
 
 
 def test_calculate_slope_of_saturated_pressure_curve(
-    dummy_climate_data_varying_canopy, fixture_core_components
+    dummy_climate_data_varying_canopy,
+    fixture_core_components,
+    fixture_abiotic_constants,
 ):
     """Test calculation of slope of saturated pressure curve."""
 
@@ -140,11 +141,10 @@ def test_calculate_slope_of_saturated_pressure_curve(
 
     data = dummy_climate_data_varying_canopy
     atm_index = fixture_core_components.layer_structure.index_filled_atmosphere
-    const = AbioticConsts()
 
     result = calculate_slope_of_saturated_pressure_curve(
         temperature=data["air_temperature"][atm_index].to_numpy(),
-        saturated_pressure_slope_parameters=const.saturated_pressure_slope_parameters,
+        saturated_pressure_slope_parameters=fixture_abiotic_constants.saturated_pressure_slope_parameters,
     )
 
     exp_result = np.array(

--- a/tests/models/abiotic/test_energy_balance.py
+++ b/tests/models/abiotic/test_energy_balance.py
@@ -3,11 +3,9 @@
 import numpy as np
 import pytest
 
-from virtual_ecosystem.core.constants import CoreConsts
 from virtual_ecosystem.models.abiotic.abiotic_tools import (
     compute_layer_thickness_for_varying_canopy,
 )
-from virtual_ecosystem.models.abiotic.constants import AbioticConsts
 
 
 def test_initialise_canopy_and_soil_fluxes(
@@ -53,7 +51,10 @@ def test_initialise_canopy_and_soil_fluxes(
 
 
 def test_calculate_longwave_emission(
-    dummy_climate_data_varying_canopy, fixture_core_components
+    dummy_climate_data_varying_canopy,
+    fixture_core_components,
+    fixture_abiotic_constants,
+    fixture_core_constants,
 ):
     """Test that longwave radiation is calculated correctly."""
 
@@ -67,9 +68,9 @@ def test_calculate_longwave_emission(
 
     result = calculate_longwave_emission(
         temperature=data["air_temperature"][canopy_index].to_numpy()
-        + CoreConsts.zero_Celsius,
-        emissivity=AbioticConsts.soil_emissivity,
-        stefan_boltzmann=CoreConsts.stefan_boltzmann_constant,
+        + fixture_core_constants.zero_Celsius,
+        emissivity=fixture_abiotic_constants.soil_emissivity,
+        stefan_boltzmann=fixture_core_constants.stefan_boltzmann_constant,
     )
 
     exp_result = np.array(
@@ -185,7 +186,10 @@ def test_update_soil_temperature(g, soil_temp, dz, k, rho, cp, dt, exp_n, exp_te
 
 
 def test_energy_balance_residual_only(
-    dummy_climate_data_varying_canopy, fixture_core_components
+    dummy_climate_data_varying_canopy,
+    fixture_core_components,
+    fixture_abiotic_constants,
+    fixture_core_constants,
 ):
     """Test energy balance residual without flux return."""
     from virtual_ecosystem.models.abiotic.energy_balance import (
@@ -210,10 +214,10 @@ def test_energy_balance_residual_only(
         latent_heat_vapourisation=data["latent_heat_vapourisation"][
             canopy_index
         ].to_numpy(),
-        leaf_emissivity=AbioticConsts.leaf_emissivity,
-        stefan_boltzmann_constant=CoreConsts.stefan_boltzmann_constant,
-        zero_Celsius=CoreConsts.zero_Celsius,
-        seconds_to_hour=CoreConsts.seconds_to_hour,
+        leaf_emissivity=fixture_abiotic_constants.leaf_emissivity,
+        stefan_boltzmann_constant=fixture_core_constants.stefan_boltzmann_constant,
+        zero_Celsius=fixture_core_constants.zero_Celsius,
+        seconds_to_hour=fixture_core_constants.seconds_to_hour,
         return_fluxes=False,
     )
 
@@ -223,7 +227,10 @@ def test_energy_balance_residual_only(
 
 
 def test_energy_balance_return_fluxes(
-    dummy_climate_data_varying_canopy, fixture_core_components
+    dummy_climate_data_varying_canopy,
+    fixture_core_components,
+    fixture_abiotic_constants,
+    fixture_core_constants,
 ):
     """Test energy balance residual with flux return."""
     from virtual_ecosystem.models.abiotic.energy_balance import (
@@ -248,10 +255,10 @@ def test_energy_balance_return_fluxes(
         latent_heat_vapourisation=data["latent_heat_vapourisation"][
             canopy_index
         ].to_numpy(),
-        leaf_emissivity=AbioticConsts.leaf_emissivity,
-        stefan_boltzmann_constant=CoreConsts.stefan_boltzmann_constant,
-        zero_Celsius=CoreConsts.zero_Celsius,
-        seconds_to_hour=CoreConsts.seconds_to_hour,
+        leaf_emissivity=fixture_abiotic_constants.leaf_emissivity,
+        stefan_boltzmann_constant=fixture_core_constants.stefan_boltzmann_constant,
+        zero_Celsius=fixture_core_constants.zero_Celsius,
+        seconds_to_hour=fixture_core_constants.seconds_to_hour,
         return_fluxes=True,
     )
 
@@ -269,7 +276,7 @@ def test_energy_balance_return_fluxes(
 
 
 def test_solve_canopy_temperature(
-    dummy_climate_data_varying_canopy, fixture_core_components
+    dummy_climate_data_varying_canopy, fixture_core_components, fixture_core_constants
 ):
     """Test solving canopy temperature with Newton method."""
 
@@ -296,9 +303,9 @@ def test_solve_canopy_temperature(
             canopy_index
         ].to_numpy(),
         emissivity_leaf=0.96,
-        stefan_boltzmann_constant=CoreConsts.stefan_boltzmann_constant,
-        zero_Celsius=CoreConsts.zero_Celsius,
-        seconds_to_hour=CoreConsts.seconds_to_hour,
+        stefan_boltzmann_constant=fixture_core_constants.stefan_boltzmann_constant,
+        zero_Celsius=fixture_core_constants.zero_Celsius,
+        seconds_to_hour=fixture_core_constants.seconds_to_hour,
         return_fluxes=False,
         maxiter=100,
     )
@@ -354,7 +361,7 @@ def test_update_air_temperature(
 
 
 def test_update_humidity_vpd(
-    dummy_climate_data_varying_canopy, fixture_core_components
+    dummy_climate_data_varying_canopy, fixture_core_components, fixture_core_constants
 ):
     """Test update atmospheric humidity."""
 
@@ -416,9 +423,10 @@ def test_update_humidity_vpd(
         mixing_coefficient=mixing_coefficient,
         ventilation_rate=ventilation_rate,
         molecular_weight_ratio_water_to_dry_air=(
-            CoreConsts.molecular_weight_ratio_water_to_dry_air
+            fixture_core_constants.molecular_weight_ratio_water_to_dry_air
         ),
-        dry_air_factor=1 - CoreConsts.molecular_weight_ratio_water_to_dry_air,
+        dry_air_factor=1
+        - fixture_core_constants.molecular_weight_ratio_water_to_dry_air,
         cell_area=fixture_core_components.grid.cell_area,
         limits=(0, 60),
         time_interval=time_interval,

--- a/tests/models/abiotic/test_microclimate.py
+++ b/tests/models/abiotic/test_microclimate.py
@@ -3,12 +3,14 @@
 import numpy as np
 from pyrealm.constants import CoreConst as PyrealmConst
 
-from virtual_ecosystem.core.constants import CoreConsts
-from virtual_ecosystem.models.abiotic.constants import AbioticConsts
-from virtual_ecosystem.models.abiotic_simple.constants import AbioticSimpleBounds
 
-
-def test_run_microclimate(dummy_climate_data_varying_canopy, fixture_core_components):
+def test_run_microclimate(
+    dummy_climate_data_varying_canopy,
+    fixture_core_components,
+    fixture_core_constants,
+    fixture_abiotic_constants,
+    fixture_abiotic_simple_configuration,
+):
     """Test microclimate function."""
 
     from virtual_ecosystem.models.abiotic.microclimate import (
@@ -22,10 +24,10 @@ def test_run_microclimate(dummy_climate_data_varying_canopy, fixture_core_compon
         time_interval=86400 * 30,
         cell_area=10000,
         layer_structure=lyr_str,
-        abiotic_constants=AbioticConsts(),
-        core_constants=CoreConsts(),
+        abiotic_constants=fixture_abiotic_constants,
+        core_constants=fixture_core_constants,
         pyrealm_const=PyrealmConst(),
-        abiotic_bounds=AbioticSimpleBounds(),
+        abiotic_bounds=fixture_abiotic_simple_configuration.bounds,
     )
 
     for var in [
@@ -85,7 +87,11 @@ def test_run_microclimate(dummy_climate_data_varying_canopy, fixture_core_compon
 
 
 def test_run_microclimate_subdaily(
-    dummy_climate_data_varying_canopy, fixture_core_components
+    dummy_climate_data_varying_canopy,
+    fixture_core_components,
+    fixture_core_constants,
+    fixture_abiotic_constants,
+    fixture_abiotic_simple_configuration,
 ):
     """Test microclimate function iterates over hours - no time index."""
 
@@ -110,10 +116,10 @@ def test_run_microclimate_subdaily(
         time_interval=3600 * 4,
         cell_area=10000,
         layer_structure=lyr_str,
-        abiotic_constants=AbioticConsts(),
-        core_constants=CoreConsts(),
+        abiotic_constants=fixture_abiotic_constants,
+        core_constants=fixture_core_constants,
         pyrealm_const=PyrealmConst(),
-        abiotic_bounds=AbioticSimpleBounds(),
+        abiotic_bounds=fixture_abiotic_simple_configuration.bounds,
     )
 
     for var in [
@@ -173,7 +179,11 @@ def test_run_microclimate_subdaily(
 
 
 def test_run_microclimate_minutes(
-    dummy_climate_data_varying_canopy, fixture_core_components
+    dummy_climate_data_varying_canopy,
+    fixture_core_components,
+    fixture_core_constants,
+    fixture_abiotic_constants,
+    fixture_abiotic_simple_configuration,
 ):
     """Test microclimate function iterates once for <1h time interval."""
 
@@ -196,10 +206,10 @@ def test_run_microclimate_minutes(
         time_interval=60,
         cell_area=10000,
         layer_structure=lyr_str,
-        abiotic_constants=AbioticConsts(),
-        core_constants=CoreConsts(),
+        abiotic_constants=fixture_abiotic_constants,
+        core_constants=fixture_core_constants,
         pyrealm_const=PyrealmConst(),
-        abiotic_bounds=AbioticSimpleBounds(),
+        abiotic_bounds=fixture_abiotic_simple_configuration.bounds,
     )
 
     # Check that values fall within a reasonable expected range

--- a/tests/models/abiotic_simple/test_abiotic_simple_model.py
+++ b/tests/models/abiotic_simple/test_abiotic_simple_model.py
@@ -34,10 +34,10 @@ def test_abiotic_simple_model_initialization(
     fixture_core_components,
     raises,
     expected_log_entries,
+    fixture_abiotic_constants,
 ):
     """Test `AbioticSimpleModel` initialization."""
     from virtual_ecosystem.core.base_model import BaseModel
-    from virtual_ecosystem.models.abiotic.model_config import AbioticConstants
     from virtual_ecosystem.models.abiotic_simple.abiotic_simple_model import (
         AbioticSimpleModel,
     )
@@ -58,7 +58,7 @@ def test_abiotic_simple_model_initialization(
                 data=dummy_climate_data_varying_canopy,
                 core_components=fixture_core_components,
                 model_configuration=default_config,
-                abiotic_constants=AbioticConstants(),
+                abiotic_constants=fixture_abiotic_constants,
             )
 
             # In cases where it passes then checks that the object has the right
@@ -161,10 +161,13 @@ def test_generate_abiotic_simple_model(
     log_check(caplog, expected_log_entries)
 
 
-def test_setup(dummy_climate_data_varying_canopy, fixture_core_components):
+def test_setup(
+    dummy_climate_data_varying_canopy,
+    fixture_core_components,
+    fixture_abiotic_constants,
+):
     """Test set up and update."""
 
-    from virtual_ecosystem.models.abiotic.model_config import AbioticConstants
     from virtual_ecosystem.models.abiotic_simple.abiotic_simple_model import (
         AbioticSimpleModel,
     )
@@ -184,7 +187,7 @@ def test_setup(dummy_climate_data_varying_canopy, fixture_core_components):
             data=dummy_climate_data_varying_canopy,
             core_components=fixture_core_components,
             model_configuration=AbioticSimpleConfiguration(),
-            abiotic_constants=AbioticConstants(),
+            abiotic_constants=fixture_abiotic_constants,
         )
 
     exp_soil_temp = lyr_strct.from_template()

--- a/tests/models/abiotic_simple/test_abiotic_simple_model.py
+++ b/tests/models/abiotic_simple/test_abiotic_simple_model.py
@@ -1,7 +1,7 @@
 """Test module for abiotic_simple.abiotic_simple_model.py."""
 
 from contextlib import nullcontext as does_not_raise
-from logging import CRITICAL, DEBUG, ERROR, INFO
+from logging import DEBUG, INFO
 from unittest.mock import patch
 
 import numpy as np
@@ -10,7 +10,6 @@ import xarray as xr
 from xarray import DataArray
 
 from tests.conftest import log_check, patch_bypass_setup, patch_run_update
-from virtual_ecosystem.core.exceptions import ConfigurationError
 
 # Global set of messages from model required var checks
 MODEL_VAR_CHECK_LOG = [
@@ -38,13 +37,15 @@ def test_abiotic_simple_model_initialization(
 ):
     """Test `AbioticSimpleModel` initialization."""
     from virtual_ecosystem.core.base_model import BaseModel
+    from virtual_ecosystem.models.abiotic.model_config import AbioticConstants
     from virtual_ecosystem.models.abiotic_simple.abiotic_simple_model import (
         AbioticSimpleModel,
     )
-    from virtual_ecosystem.models.abiotic_simple.constants import (
-        AbioticSimpleBounds,
-        AbioticSimpleConsts,
+    from virtual_ecosystem.models.abiotic_simple.model_config import (
+        AbioticSimpleConfiguration,
     )
+
+    default_config = AbioticSimpleConfiguration()
 
     with (
         patch_run_update(AbioticSimpleModel),
@@ -56,7 +57,8 @@ def test_abiotic_simple_model_initialization(
             model = AbioticSimpleModel(
                 data=dummy_climate_data_varying_canopy,
                 core_components=fixture_core_components,
-                model_constants=AbioticSimpleConsts(),
+                model_configuration=default_config,
+                abiotic_constants=AbioticConstants(),
             )
 
             # In cases where it passes then checks that the object has the right
@@ -64,7 +66,7 @@ def test_abiotic_simple_model_initialization(
             assert isinstance(model, BaseModel)
             assert model.model_name == "abiotic_simple"
             assert repr(model) == "AbioticSimpleModel(update_interval=1209600 seconds)"
-            assert model.bounds == AbioticSimpleBounds()
+            assert model.bounds == default_config.bounds
 
     # Final check that expected logging entries are produced
     log_check(caplog, expected_log_entries)
@@ -81,10 +83,6 @@ def test_abiotic_simple_model_initialization(
                 [
                     (
                         INFO,
-                        "Initialised abiotic_simple.AbioticSimpleConsts from config",
-                    ),
-                    (
-                        INFO,
                         "Information required to initialise the abiotic simple model "
                         "successfully extracted.",
                     ),
@@ -95,16 +93,12 @@ def test_abiotic_simple_model_initialization(
         ),
         pytest.param(
             "[core.timing]\nupdate_interval = '1 week'\n"
-            "[abiotic_simple.constants.AbioticSimpleConsts]\n"
+            "[abiotic_simple.constants]\n"
             "saturation_vapour_pressure_factors = [1.0, 2.0, 3.0]\n",
             [1.0, 2.0, 3.0],
             does_not_raise(),
             tuple(
                 [
-                    (
-                        INFO,
-                        "Initialised abiotic_simple.AbioticSimpleConsts from config",
-                    ),
                     (
                         INFO,
                         "Information required to initialise the abiotic simple model "
@@ -114,27 +108,6 @@ def test_abiotic_simple_model_initialization(
                 ],
             ),
             id="modified_config_correct",
-        ),
-        pytest.param(
-            "[core.timing]\nupdate_interval = '1 week'\n"
-            "[abiotic_simple.constants.AbioticSimpleConsts]\n"
-            "saturation_vapour_pressure_factorx = [1.0, 2.0, 3.0]\n",
-            None,
-            pytest.raises(ConfigurationError),
-            (
-                (
-                    ERROR,
-                    "Unknown names supplied for AbioticSimpleConsts: "
-                    "saturation_vapour_pressure_factorx",
-                ),
-                (INFO, "Valid names are: "),
-                (
-                    CRITICAL,
-                    "Could not initialise abiotic_simple.AbioticSimpleConsts "
-                    "from config",
-                ),
-            ),
-            id="modified_config_incorrect",
         ),
     ],
 )
@@ -147,7 +120,6 @@ def test_generate_abiotic_simple_model(
     expected_log_entries,
 ):
     """Test that the initialisation of the simple abiotic model works as expected."""
-    from virtual_ecosystem.core.config import Config
     from virtual_ecosystem.core.config_builder import (
         ConfigurationLoader,
         generate_configuration,
@@ -156,25 +128,14 @@ def test_generate_abiotic_simple_model(
     from virtual_ecosystem.models.abiotic_simple.abiotic_simple_model import (
         AbioticSimpleModel,
     )
-    from virtual_ecosystem.models.abiotic_simple.constants import AbioticSimpleConsts
 
-    # Build the config object and core components
-    config = Config(cfg_strings=cfg_string)
-
-    # TODO - This test is currently mixing the old AbioticSimpleConsts validation with
-    # what will be replaced by configuration.abiotic_simple.constants. So for now, fake
-    # it with a hardcoded config and let the errors run through to the old system
-
-    config_data = ConfigurationLoader(
-        cfg_strings="[core.timing]\nupdate_interval = '1 week'\n[abiotic_simple]\n"
-    )
+    config_data = ConfigurationLoader(cfg_strings=cfg_string)
     configuration = generate_configuration(config_data.data)
     core_components = CoreComponents(configuration.core)
 
     caplog.clear()
 
     # We patch the _setup step as it is tested separately
-    expected_const = AbioticSimpleConsts(saturation_vapour_pressure_factors=satvap1)
     object_to_patch = (
         "virtual_ecosystem.models.abiotic_simple.abiotic_simple_model"
         ".AbioticSimpleModel"
@@ -191,9 +152,10 @@ def test_generate_abiotic_simple_model(
                 data=dummy_climate_data_varying_canopy,
                 configuration=configuration,
                 core_components=core_components,
-                config=config,
+                config=configuration,
             )
-            mock_setup.assert_called_once_with(model_constants=expected_const)
+
+            mock_setup.assert_called_once()
 
     # Final check that expected logging entries are produced
     log_check(caplog, expected_log_entries)
@@ -202,10 +164,13 @@ def test_generate_abiotic_simple_model(
 def test_setup(dummy_climate_data_varying_canopy, fixture_core_components):
     """Test set up and update."""
 
+    from virtual_ecosystem.models.abiotic.model_config import AbioticConstants
     from virtual_ecosystem.models.abiotic_simple.abiotic_simple_model import (
         AbioticSimpleModel,
     )
-    from virtual_ecosystem.models.abiotic_simple.constants import AbioticSimpleConsts
+    from virtual_ecosystem.models.abiotic_simple.model_config import (
+        AbioticSimpleConfiguration,
+    )
 
     lyr_strct = fixture_core_components.layer_structure
 
@@ -218,7 +183,8 @@ def test_setup(dummy_climate_data_varying_canopy, fixture_core_components):
         model = AbioticSimpleModel(
             data=dummy_climate_data_varying_canopy,
             core_components=fixture_core_components,
-            model_constants=AbioticSimpleConsts(),
+            model_configuration=AbioticSimpleConfiguration(),
+            abiotic_constants=AbioticConstants(),
         )
 
     exp_soil_temp = lyr_strct.from_template()

--- a/tests/models/abiotic_simple/test_microclimate_simple.py
+++ b/tests/models/abiotic_simple/test_microclimate_simple.py
@@ -5,9 +5,6 @@ import xarray as xr
 from pyrealm.constants import CoreConst as PyrealmConst
 from xarray import DataArray
 
-from virtual_ecosystem.core.constants import CoreConsts
-from virtual_ecosystem.models.abiotic.constants import AbioticConsts
-
 
 def test_varying_canopy_log_interpolation(
     dummy_climate_data_varying_canopy, fixture_core_components
@@ -73,14 +70,14 @@ def test_varying_canopy_calculate_vapour_pressure_deficit(
 
 
 def test_run_microclimate_varying_canopy(
-    dummy_climate_data_varying_canopy, fixture_core_components
+    dummy_climate_data_varying_canopy,
+    fixture_core_components,
+    fixture_abiotic_constants,
+    fixture_core_constants,
+    fixture_abiotic_simple_configuration,
 ):
     """Test interpolation of all variables with varying canopy arrays."""
 
-    from virtual_ecosystem.models.abiotic_simple.constants import (
-        AbioticSimpleBounds,
-        AbioticSimpleConsts,
-    )
     from virtual_ecosystem.models.abiotic_simple.microclimate_simple import (
         run_simple_microclimate,
     )
@@ -92,10 +89,10 @@ def test_run_microclimate_varying_canopy(
         data=data,
         layer_structure=lyr_strct,
         time_index=0,
-        simple_constants=AbioticSimpleConsts(),
-        abiotic_constants=AbioticConsts(),
-        core_constants=CoreConsts(),
-        bounds=AbioticSimpleBounds(),
+        simple_constants=fixture_abiotic_simple_configuration.constants,
+        abiotic_constants=fixture_abiotic_constants,
+        core_constants=fixture_core_constants,
+        bounds=fixture_abiotic_simple_configuration.bounds,
     )
 
     exp_air_temp = lyr_strct.from_template()

--- a/tests/models/soil/conftest.py
+++ b/tests/models/soil/conftest.py
@@ -144,27 +144,6 @@ def fixture_soil_configuration(microbial_groups_cfg):
 
 
 @pytest.fixture
-def fixture_core_constants(fixture_soil_configuration):
-    """Get the core constants instance from the config."""
-
-    return fixture_soil_configuration.core.constants
-
-
-@pytest.fixture
-def fixture_soil_constants(fixture_soil_configuration):
-    """Get the soil constants instance from the config."""
-
-    return fixture_soil_configuration.soil.constants
-
-
-@pytest.fixture
-def fixture_hydrology_constants(fixture_soil_configuration):
-    """Get the hydrology constants instance from the config."""
-
-    return fixture_soil_configuration.hydrology.constants
-
-
-@pytest.fixture
 def fixture_soil_core_components(fixture_soil_configuration):
     """Create a core components from the fixture_soil_config."""
     from virtual_ecosystem.core.core_components import CoreComponents

--- a/virtual_ecosystem/models/abiotic/abiotic_model.py
+++ b/virtual_ecosystem/models/abiotic/abiotic_model.py
@@ -125,6 +125,8 @@ class AbioticModel(
         """Set of constants for simple abiotic model."""
         self.simple_bounds: AbioticSimpleBounds
         """Set of bound for simple abiotic model."""
+        self.pyrealm_constants: PyrealmConst
+        """Pyrealm constants."""
 
     @classmethod
     def from_config(
@@ -153,7 +155,9 @@ class AbioticModel(
             "abiotic", AbioticConfiguration
         )
 
+        # Hard coding these here until we figure out how to resolve config issues
         abiotic_simple_configuration = AbioticSimpleConfiguration()
+        pyrealm_consts = PyrealmConst()
 
         LOGGER.info(
             "Information required to initialise the abiotic model successfully "
@@ -165,12 +169,14 @@ class AbioticModel(
             static=model_configuration.static,
             model_constants=model_configuration.constants,
             simple_config=abiotic_simple_configuration,
+            pyrealm_consts=pyrealm_consts,
         )
 
     def _setup(
         self,
         model_constants: AbioticConstants = AbioticConstants(),
         simple_config: AbioticSimpleConfiguration = AbioticSimpleConfiguration(),
+        pyrealm_constants: PyrealmConst = PyrealmConst(),
         **kwargs,
     ) -> None:
         """Function to set up the abiotic model.
@@ -183,12 +189,14 @@ class AbioticModel(
         Args:
             model_constants: Set of constants for the abiotic model.
             simple_config: Configuration options for the abiotic simple model.
+            pyrealm_constants: Additional configuration options to the pyrealm package.
             **kwargs: Further arguments to the setup method.
         """
 
         self.model_constants = model_constants
         self.simple_constants = simple_config.constants
         self.simple_bounds = simple_config.bounds
+        self.pyrealm_constants = pyrealm_constants
 
         # create soil temperature array
         self.data["soil_temperature"] = self.layer_structure.from_template()
@@ -254,7 +262,7 @@ class AbioticModel(
             layer_structure=self.layer_structure,
             abiotic_constants=self.model_constants,
             core_constants=self.core_constants,
-            pyrealm_const=PyrealmConst,
+            pyrealm_const=self.pyrealm_constants,
             abiotic_bounds=self.simple_bounds,
         )
 

--- a/virtual_ecosystem/models/abiotic/abiotic_model.py
+++ b/virtual_ecosystem/models/abiotic/abiotic_model.py
@@ -13,23 +13,25 @@ from pyrealm.constants import CoreConst as PyrealmConst
 from virtual_ecosystem.core.base_model import BaseModel
 from virtual_ecosystem.core.config import Config
 from virtual_ecosystem.core.configuration import CompiledConfiguration
-from virtual_ecosystem.core.constants_loader import load_constants
 from virtual_ecosystem.core.core_components import CoreComponents
 from virtual_ecosystem.core.data import Data
 from virtual_ecosystem.core.logger import LOGGER
-from virtual_ecosystem.models.abiotic.constants import AbioticConsts
 from virtual_ecosystem.models.abiotic.energy_balance import (
     initialise_canopy_and_soil_fluxes,
 )
 from virtual_ecosystem.models.abiotic.microclimate import run_microclimate
-from virtual_ecosystem.models.abiotic.model_config import AbioticConfiguration
-from virtual_ecosystem.models.abiotic_simple.constants import (
-    AbioticSimpleBounds,
-    AbioticSimpleConsts,
+from virtual_ecosystem.models.abiotic.model_config import (
+    AbioticConfiguration,
+    AbioticConstants,
 )
 from virtual_ecosystem.models.abiotic_simple.microclimate_simple import (
     calculate_vapour_pressure_deficit,
     run_simple_microclimate,
+)
+from virtual_ecosystem.models.abiotic_simple.model_config import (
+    AbioticSimpleBounds,
+    AbioticSimpleConfiguration,
+    AbioticSimpleConstants,
 )
 
 
@@ -117,10 +119,12 @@ class AbioticModel(
 
         super().__init__(data, core_components, static, **kwargs)
 
-        self.model_constants: AbioticConsts
+        self.model_constants: AbioticConstants
         """Set of constants for the abiotic model."""
-        self.simple_constants: AbioticSimpleConsts
+        self.simple_constants: AbioticSimpleConstants
         """Set of constants for simple abiotic model."""
+        self.simple_bounds: AbioticSimpleBounds
+        """Set of bound for simple abiotic model."""
 
     @classmethod
     def from_config(
@@ -149,23 +153,25 @@ class AbioticModel(
             "abiotic", AbioticConfiguration
         )
 
-        # Load in the relevant constants
-        model_constants = load_constants(config, "abiotic", "AbioticConsts")
-        static = model_configuration.static
+        abiotic_simple_configuration = AbioticSimpleConfiguration()
 
         LOGGER.info(
             "Information required to initialise the abiotic model successfully "
             "extracted."
         )
         return cls(
-            data,
+            data=data,
             core_components=core_components,
-            static=static,
-            model_constants=model_constants,
+            static=model_configuration.static,
+            model_constants=model_configuration.constants,
+            simple_config=abiotic_simple_configuration,
         )
 
     def _setup(
-        self, model_constants: AbioticConsts = AbioticConsts(), **kwargs
+        self,
+        model_constants: AbioticConstants = AbioticConstants(),
+        simple_config: AbioticSimpleConfiguration = AbioticSimpleConfiguration(),
+        **kwargs,
     ) -> None:
         """Function to set up the abiotic model.
 
@@ -176,11 +182,13 @@ class AbioticModel(
 
         Args:
             model_constants: Set of constants for the abiotic model.
+            simple_config: Configuration options for the abiotic simple model.
             **kwargs: Further arguments to the setup method.
         """
 
         self.model_constants = model_constants
-        self.simple_constants = AbioticSimpleConsts()
+        self.simple_constants = simple_config.constants
+        self.simple_bounds = simple_config.bounds
 
         # create soil temperature array
         self.data["soil_temperature"] = self.layer_structure.from_template()
@@ -209,7 +217,7 @@ class AbioticModel(
             simple_constants=self.simple_constants,
             abiotic_constants=self.model_constants,
             core_constants=self.core_constants,
-            bounds=AbioticSimpleBounds(),
+            bounds=self.simple_bounds,
         )
 
         # Generate initial profiles of canopy temperature and heat fluxes from soil and
@@ -247,7 +255,7 @@ class AbioticModel(
             abiotic_constants=self.model_constants,
             core_constants=self.core_constants,
             pyrealm_const=PyrealmConst,
-            abiotic_bounds=AbioticSimpleBounds(),
+            abiotic_bounds=self.simple_bounds,
         )
 
         self.data.add_from_dict(output_dict=update_dict)

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -7,13 +7,13 @@ from pyrealm.constants import CoreConst as PyrealmConst
 from pyrealm.core.hygro import calc_specific_heat, calc_vp_sat
 from xarray import DataArray
 
-from virtual_ecosystem.core.constants import CoreConsts
 from virtual_ecosystem.core.core_components import LayerStructure
 from virtual_ecosystem.core.data import Data
 from virtual_ecosystem.core.logger import LOGGER
+from virtual_ecosystem.core.model_config import CoreConstants
 from virtual_ecosystem.models.abiotic import abiotic_tools, energy_balance, wind
-from virtual_ecosystem.models.abiotic.constants import AbioticConsts
-from virtual_ecosystem.models.abiotic_simple.constants import AbioticSimpleBounds
+from virtual_ecosystem.models.abiotic.model_config import AbioticConstants
+from virtual_ecosystem.models.abiotic_simple.model_config import AbioticSimpleBounds
 
 
 def run_microclimate(
@@ -22,8 +22,8 @@ def run_microclimate(
     time_interval: float,
     cell_area: float,
     layer_structure: LayerStructure,
-    abiotic_constants: AbioticConsts,
-    core_constants: CoreConsts,
+    abiotic_constants: AbioticConstants,
+    core_constants: CoreConstants,
     pyrealm_const: PyrealmConst,
     abiotic_bounds: AbioticSimpleBounds,
 ) -> dict[str, DataArray]:

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -373,7 +373,7 @@ def run_microclimate(
             molecular_weight_ratio_water_to_dry_air=(
                 core_constants.molecular_weight_ratio_water_to_dry_air
             ),
-            pyrealm_const=PyrealmConst(),
+            pyrealm_const=pyrealm_const,
         )
 
         # Calculate specific humidity at saturation

--- a/virtual_ecosystem/models/abiotic_simple/abiotic_simple_model.py
+++ b/virtual_ecosystem/models/abiotic_simple/abiotic_simple_model.py
@@ -17,21 +17,18 @@ from pyrealm.constants import CoreConst as PyrealmConst
 from virtual_ecosystem.core.base_model import BaseModel
 from virtual_ecosystem.core.config import Config
 from virtual_ecosystem.core.configuration import CompiledConfiguration
-from virtual_ecosystem.core.constants_loader import load_constants
 from virtual_ecosystem.core.core_components import CoreComponents
 from virtual_ecosystem.core.data import Data
 from virtual_ecosystem.core.logger import LOGGER
-from virtual_ecosystem.models.abiotic.constants import AbioticConsts
-from virtual_ecosystem.models.abiotic_simple.constants import (
-    AbioticSimpleBounds,
-    AbioticSimpleConsts,
-)
+from virtual_ecosystem.models.abiotic.model_config import AbioticConstants
 from virtual_ecosystem.models.abiotic_simple.microclimate_simple import (
     calculate_vapour_pressure_deficit,
     run_simple_microclimate,
 )
 from virtual_ecosystem.models.abiotic_simple.model_config import (
+    AbioticSimpleBounds,
     AbioticSimpleConfiguration,
+    AbioticSimpleConstants,
 )
 
 
@@ -101,10 +98,12 @@ class AbioticSimpleModel(
 
         super().__init__(data, core_components, static, **kwargs)
 
-        self.model_constants: AbioticSimpleConsts
+        self.model_constants: AbioticSimpleConstants
         """Set of constants for the abiotic simple model"""
         self.bounds: AbioticSimpleBounds
         """Upper and lower bounds for abiotic variables."""
+        self.abiotic_constants: AbioticConstants
+        """Abiotic constants required for some calculations"""
 
     @classmethod
     def from_config(
@@ -128,18 +127,15 @@ class AbioticSimpleModel(
         """
 
         # Extract the validated model configuration from the complete compiled
-        # configuration. This syntax is odd but required to support static typing
+        # configuration
         model_configuration: AbioticSimpleConfiguration = (
             configuration.get_subconfiguration(
                 "abiotic_simple", AbioticSimpleConfiguration
             )
         )
 
-        # Load in the relevant constants
-        model_constants = load_constants(
-            config, "abiotic_simple", "AbioticSimpleConsts"
-        )
-        static = model_configuration.static
+        # Hard coding abiotic constants here until we resolve the config setup
+        abiotic_constants: AbioticConstants = AbioticConstants()
 
         LOGGER.info(
             "Information required to initialise the abiotic simple model successfully "
@@ -148,11 +144,17 @@ class AbioticSimpleModel(
         return cls(
             data=data,
             core_components=core_components,
-            static=static,
-            model_constants=model_constants,
+            static=model_configuration.static,
+            model_configuration=model_configuration,
+            abiotic_constants=abiotic_constants,
         )
 
-    def _setup(self, model_constants: AbioticSimpleConsts, **kwargs) -> None:
+    def _setup(
+        self,
+        model_configuration: AbioticSimpleConfiguration,
+        abiotic_constants: AbioticConstants,
+        **kwargs,
+    ) -> None:
         """Function to set up the abiotic simple model.
 
         This function initializes soil temperature for all soil layers and calculates
@@ -160,11 +162,14 @@ class AbioticSimpleModel(
         added directly to the self.data object.
 
         Args:
-            model_constants: Set of constants for the abiotic simple model.
+            model_configuration: Configuration object from the abiotic_simple model.
+            abiotic_constants: Provides required abiotic constants.
             **kwargs: Further arguments to the setup method.
         """
-        self.model_constants = model_constants
-        self.bounds = AbioticSimpleBounds()
+        # Populate model attributes
+        self.model_constants = model_configuration.constants
+        self.bounds = model_configuration.bounds
+        self.abiotic_constants = abiotic_constants
 
         # create soil temperature array
         self.data["soil_temperature"] = self.layer_structure.from_template()
@@ -206,7 +211,7 @@ class AbioticSimpleModel(
             layer_structure=self.layer_structure,
             time_index=time_index,
             simple_constants=self.model_constants,
-            abiotic_constants=AbioticConsts(),
+            abiotic_constants=self.abiotic_constants,
             core_constants=self.core_constants,
             bounds=self.bounds,
         )

--- a/virtual_ecosystem/models/abiotic_simple/constants.py
+++ b/virtual_ecosystem/models/abiotic_simple/constants.py
@@ -25,7 +25,7 @@ class AbioticSimpleConsts(ConstantsDataclass):
 
 
 @dataclass(frozen=True)
-class AbioticSimpleBounds(ConstantsDataclass):
+class AbioticSimpleBoundsOld(ConstantsDataclass):
     """Upper and lower bounds for abiotic variables.
 
     When a values falls outside these bounds, it is set to the bound value.

--- a/virtual_ecosystem/models/abiotic_simple/microclimate_simple.py
+++ b/virtual_ecosystem/models/abiotic_simple/microclimate_simple.py
@@ -18,14 +18,14 @@ from pyrealm.constants import CoreConst as PyrealmConst
 from pyrealm.core.hygro import calc_vp_sat
 from xarray import DataArray
 
-from virtual_ecosystem.core.constants import CoreConsts
 from virtual_ecosystem.core.core_components import LayerStructure
 from virtual_ecosystem.core.data import Data
+from virtual_ecosystem.core.model_config import CoreConstants
 from virtual_ecosystem.models.abiotic import energy_balance
-from virtual_ecosystem.models.abiotic.constants import AbioticConsts
-from virtual_ecosystem.models.abiotic_simple.constants import (
+from virtual_ecosystem.models.abiotic.model_config import AbioticConstants
+from virtual_ecosystem.models.abiotic_simple.model_config import (
     AbioticSimpleBounds,
-    AbioticSimpleConsts,
+    AbioticSimpleConstants,
 )
 
 
@@ -33,9 +33,9 @@ def run_simple_microclimate(
     data: Data,
     layer_structure: LayerStructure,
     time_index: int,  # could be datetime?
-    simple_constants: AbioticSimpleConsts,
-    abiotic_constants: AbioticConsts,
-    core_constants: CoreConsts,
+    simple_constants: AbioticSimpleConstants,
+    abiotic_constants: AbioticConstants,
+    core_constants: CoreConstants,
     bounds: AbioticSimpleBounds,
 ) -> dict[str, DataArray]:
     r"""Calculate simple microclimate.

--- a/virtual_ecosystem/models/abiotic_simple/microclimate_simple.py
+++ b/virtual_ecosystem/models/abiotic_simple/microclimate_simple.py
@@ -51,7 +51,7 @@ def run_simple_microclimate(
     :math:`y = m * LAI + c`
 
     where :math:`y` is the variable of interest, :math:`m` is the gradient
-    (:data:`~virtual_ecosystem.models.abiotic_simple.constants.AbioticSimpleConsts`)
+    (:data:`~virtual_ecosystem.models.abiotic_simple.model_config.AbioticSimpleConstants`)
     and :math:`c` is the intersect which we set to the external data values. We assume
     that the gradient remains constant.
 


### PR DESCRIPTION
# Description

It turned out to be difficult to tackle these separately as they share code, so this PR updates `abiotic` and `abiotic_simple`:

* Throughout the model code and tests, swaps out:
   * `abiotic.constants.AbioticConsts` for `abiotic.model_config.AbioticConstants`
   * `abiotic.simple.constants.AbioticSimpleConsts` -> `abiotic_simple.model_config.AbioticConstants`
   * `abiotic.simple.constants.AbioticSimpleBounds` -> `abiotic_simple.model_config.AbioticSimpleBounds` (and to avoid name clashes, renames the old version to `abiotic.simple.constants.AbioticSimpleBoundsOld`).

* Now configures both models off the new CompiledConfiguration object
* Adds in some more constants fixtures, to avoid having to import constants classes so much in multiple tests.

As with Hydrology, there is a hanging issue in that both models rely on each others constants classes and Pyrealm constant classes. In both models, I've pushed the source of these classes all the way back to the `__init__` / `from_config` stage rather than having them hardcoded deeper within the model core. Now when we do fix this, we can fix it in one place.

Fixes #1112 
Fixes #1111

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
