### PR TITLE
Move animals over to the new configuration system

### DIFF
--- a/docs/source/_toc.yaml
+++ b/docs/source/_toc.yaml
@@ -158,6 +158,8 @@ subtrees:
                 title: The animal_cohorts submodule
               - file: api/models/animal/animal_model
                 title: The animal_model submodule
+              - file: api/models/animal/model_config
+                title: The model_config submodule
               - file: api/models/animal/animal_traits
                 title: The animal_traits submodule
               - file: api/models/animal/constants

--- a/docs/source/api/models/animal/model_config.md
+++ b/docs/source/api/models/animal/model_config.md
@@ -1,0 +1,34 @@
+---
+jupytext:
+  cell_metadata_filter: -all
+  formats: md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.18.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
+# API documentation for the {mod}`~virtual_ecosystem.models.animal.model_config` module
+
+```{eval-rst}
+.. automodule:: virtual_ecosystem.models.animal.model_config
+    :autosummary:
+    :members:
+    :exclude-members: model_config
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -204,6 +204,11 @@ nitpick_ignore = [
     # find FILEPATH_PLACEHOLDER, which is defined in the same way, in the same file and
     # when both do actually appear in the API docs? It's right there.
     ("py:class", "DIRPATH_PLACEHOLDER"),
+    # Typing on animal.model_config
+    ("py:class", "virtual_ecosystem.models.animal.animal_traits.Annotated"),
+    ("py:class", "virtual_ecosystem.models.animal.model_config.serialise_diet_type"),
+    ("py:class", "virtual_ecosystem.models.animal.model_config.deserialise_diet_type"),
+    ("py:class", "always"),
 ]
 
 intersphinx_mapping = {

--- a/docs/source/using_the_ve/virtual_ecosystem_in_static_mode.md
+++ b/docs/source/using_the_ve/virtual_ecosystem_in_static_mode.md
@@ -1,6 +1,4 @@
 ---
-execution:
-  timeout: 210
 jupytext:
   formats: md:myst
   main_language: python
@@ -13,16 +11,9 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
-language_info:
-  codemirror_mode:
-    name: ipython
-    version: 3
-  file_extension: .py
-  mimetype: text/x-python
-  name: python
-  nbconvert_exporter: python
-  pygments_lexer: ipython3
-  version: 3.11.14
+mystnb:
+  execution_timeout: 60
+  execution_mode: 'off'
 ---
 
 # Running the Virtual Ecosystem in Static Mode

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -360,6 +360,13 @@ def fixture_core_components(fixture_configuration):
 
 
 @pytest.fixture
+def fixture_core_constants(fixture_configuration):
+    """A core constants instance for use in testing."""
+
+    return fixture_configuration.core.constants
+
+
+@pytest.fixture
 def dummy_litter_data(fixture_core_components):
     """Creates a dummy litter data object for use in tests."""
 

--- a/tests/models/animals/conftest.py
+++ b/tests/models/animals/conftest.py
@@ -425,6 +425,7 @@ def animal_model_instance(
     from copy import deepcopy
 
     from virtual_ecosystem.models.animal.animal_model import AnimalModel
+    from virtual_ecosystem.models.animal.model_config import AnimalConstants
 
     # Make sure each call gets a fresh copy
     clean_data = deepcopy(dummy_animal_data)
@@ -432,7 +433,7 @@ def animal_model_instance(
     return AnimalModel(
         data=clean_data,
         core_components=fixture_core_components,
-        density_scaling_method="madingley",
+        model_constants=AnimalConstants(density_scaling_method="madingley"),
         functional_groups=functional_group_list_instance,
         microbial_c_n_p_ratios=microbial_c_n_p_ratios,
     )
@@ -449,6 +450,7 @@ def animal_model_damuth_instance(
     from copy import deepcopy
 
     from virtual_ecosystem.models.animal.animal_model import AnimalModel
+    from virtual_ecosystem.models.animal.model_config import AnimalConstants
 
     # Make sure each call gets a fresh copy
     clean_data = deepcopy(dummy_animal_data)
@@ -456,7 +458,7 @@ def animal_model_damuth_instance(
     return AnimalModel(
         data=clean_data,
         core_components=fixture_core_components,
-        density_scaling_method="damuth",
+        model_constants=AnimalConstants(density_scaling_method="damuth"),
         functional_groups=functional_group_list_instance,
         microbial_c_n_p_ratios=microbial_c_n_p_ratios,
     )

--- a/tests/models/animals/conftest.py
+++ b/tests/models/animals/conftest.py
@@ -388,9 +388,9 @@ def animal_data_for_cohorts_instance(fixture_core_components):
 @pytest.fixture
 def constants_instance():
     """Fixture for an instance of animal constants."""
-    from virtual_ecosystem.models.animal.constants import AnimalConsts
+    from virtual_ecosystem.models.animal.model_config import AnimalConstants
 
-    return AnimalConsts(density_scaling_method="madingley")
+    return AnimalConstants(density_scaling_method="madingley")
 
 
 @pytest.fixture

--- a/tests/models/animals/test_animal_cohorts.py
+++ b/tests/models/animals/test_animal_cohorts.py
@@ -990,7 +990,7 @@ class TestAnimalCohort:
         """Testing for calculate alpha."""
         # Assuming necessary imports and setup based on previous examples
         from virtual_ecosystem.models.animal.animal_cohorts import AnimalCohort
-        from virtual_ecosystem.models.animal.constants import AnimalConsts
+        from virtual_ecosystem.models.animal.model_config import AnimalConstants
 
         # Mock the scaling function to control its return value
         mocker.patch(
@@ -999,7 +999,7 @@ class TestAnimalCohort:
         )
 
         # Setup constants and functional group mock
-        constants = AnimalConsts()
+        constants = AnimalConstants()
         functional_group_mock = herbivore_functional_group_instance
 
         # Initialize the AnimalCohort instance with test parameters

--- a/tests/models/animals/test_animal_constants.py
+++ b/tests/models/animals/test_animal_constants.py
@@ -1,19 +1,20 @@
 """Test module for animal_traits.py."""
 
 import pytest
+from pydantic import ValidationError
 
 from virtual_ecosystem.models.animal.animal_traits import DietType, TaxaType
-from virtual_ecosystem.models.animal.constants import AnimalConsts
+from virtual_ecosystem.models.animal.model_config import AnimalConstants
 
 
-class TestAnimalConsts:
-    """Tests for the AnimalConsts dataclass methods."""
+class TestAnimalConstants:
+    """Tests for the AnimalConstants dataclass methods."""
 
     def test_get_population_density_terms_damuth(self):
         """Test Damuth method returns correct terms."""
 
         # Create instance with damuth method
-        animal_consts = AnimalConsts(density_scaling_method="damuth")
+        animal_consts = AnimalConstants(density_scaling_method="damuth")
 
         # Get terms for Mammal Herbivore
         result = animal_consts.get_population_density_terms(
@@ -30,7 +31,7 @@ class TestAnimalConsts:
         """Test Madingley method returns correct terms."""
 
         # Create instance with madingley method
-        animal_consts = AnimalConsts(density_scaling_method="madingley")
+        animal_consts = AnimalConstants(density_scaling_method="madingley")
 
         # Get terms (taxa/diet ignored in madingley)
         result = animal_consts.get_population_density_terms(
@@ -43,11 +44,6 @@ class TestAnimalConsts:
     def test_get_population_density_terms_invalid_method(self):
         """Test invalid scaling method raises ValueError."""
 
-        # Create instance with invalid method
-        animal_consts = AnimalConsts(density_scaling_method="invalid_method")
-
-        # Ensure ValueError is raised
-        with pytest.raises(ValueError):
-            animal_consts.get_population_density_terms(
-                TaxaType.MAMMAL, DietType.HERBIVORE
-            )
+        # Ensure ValidationError is raised
+        with pytest.raises(ValidationError):
+            AnimalConstants(density_scaling_method="invalid_method")

--- a/tests/models/animals/test_animal_model.py
+++ b/tests/models/animals/test_animal_model.py
@@ -74,7 +74,6 @@ class TestAnimalModel:
             pytest.param(
                 does_not_raise(),
                 (
-                    (INFO, "Initialised animal.AnimalConsts from config"),
                     (
                         INFO,
                         "Information required to initialise the animal model"
@@ -207,7 +206,6 @@ class TestAnimalModel:
         self,
         scaling_method,
         dummy_animal_data,
-        animal_fixture_config,
         animal_fixture_configuration,
         fixture_core_components,
     ):
@@ -215,17 +213,17 @@ class TestAnimalModel:
         from virtual_ecosystem.models.animal.animal_model import AnimalModel
 
         # Update the config to include the scaling method
-        animal_fixture_config["animal"]["density_scaling_method"] = scaling_method
-
         # Configuration classes are frozen so update via the __dict__ entries
-        animal_fixture_configuration.animal.__dict__["density_scaling_method"]
+        animal_fixture_configuration.animal.__dict__["density_scaling_method"] = (
+            scaling_method
+        )
 
         # Create the model using from_config
         model = AnimalModel.from_config(
             data=dummy_animal_data,
             configuration=animal_fixture_configuration,
             core_components=fixture_core_components,
-            config=animal_fixture_config,
+            config=dict(),
         )
 
         # Check that the model has the correct scaling method set
@@ -638,6 +636,7 @@ class TestAnimalModel:
         self,
         litter_soil_data_instance,
         fixture_core_components,
+        fixture_core_constants,
         functional_group_list_instance,
         constants_instance,
         microbial_c_n_p_ratios,
@@ -647,7 +646,6 @@ class TestAnimalModel:
 
         import numpy as np
 
-        from virtual_ecosystem.core.constants import CoreConsts
         from virtual_ecosystem.models.animal.animal_model import AnimalModel
         from virtual_ecosystem.models.animal.decay import SoilPool
 
@@ -724,7 +722,7 @@ class TestAnimalModel:
                     cell_id=cid,
                     data=new_data,
                     cell_area=cell_area,
-                    max_depth_microbial_activity=CoreConsts.max_depth_of_microbial_activity,
+                    max_depth_microbial_activity=fixture_core_constants.max_depth_of_microbial_activity,
                     c_n_p_ratios=microbial_c_n_p_ratios,
                 )
                 for pool_name in pool_names
@@ -982,8 +980,8 @@ class TestAnimalModel:
 
         from math import ceil
 
-        from virtual_ecosystem.models.animal.constants import AnimalConsts
         from virtual_ecosystem.models.animal.functional_group import FunctionalGroup
+        from virtual_ecosystem.models.animal.model_config import AnimalConstants
 
         # Always patch damuths_law to return predictable 42.0
         mock_damuth = mocker.patch(
@@ -1016,7 +1014,7 @@ class TestAnimalModel:
             vertical_occupancy="ground",
             birth_mass=0.1,
             adult_mass=10.0,
-            constants=AnimalConsts(density_scaling_method=scaling_method),
+            constants=AnimalConstants(density_scaling_method=scaling_method),
             density_individuals_m2=density,
         )
 

--- a/tests/models/animals/test_animal_model.py
+++ b/tests/models/animals/test_animal_model.py
@@ -49,13 +49,14 @@ class TestAnimalModel:
         """Test `AnimalModel` initialization with both scaling methods."""
         from virtual_ecosystem.core.base_model import BaseModel
         from virtual_ecosystem.models.animal.animal_model import AnimalModel
+        from virtual_ecosystem.models.animal.model_config import AnimalConstants
 
         # Initialize the model
         model = AnimalModel(
             data=dummy_animal_data,
             core_components=fixture_core_components,
             functional_groups=functional_group_list_instance,
-            density_scaling_method=scaling_method,
+            model_constants=AnimalConstants(density_scaling_method=scaling_method),
             microbial_c_n_p_ratios=microbial_c_n_p_ratios,
         )
 
@@ -212,11 +213,11 @@ class TestAnimalModel:
         """Test that AnimalModel.from_config correctly sets density_scaling_method."""
         from virtual_ecosystem.models.animal.animal_model import AnimalModel
 
-        # Update the config to include the scaling method
+        # Update the constants to set the scaling method
         # Configuration classes are frozen so update via the __dict__ entries
-        animal_fixture_configuration.animal.__dict__["density_scaling_method"] = (
-            scaling_method
-        )
+        animal_fixture_configuration.animal.constants.__dict__[
+            "density_scaling_method"
+        ] = scaling_method
 
         # Create the model using from_config
         model = AnimalModel.from_config(

--- a/tests/models/animals/test_decay.py
+++ b/tests/models/animals/test_decay.py
@@ -212,11 +212,10 @@ def test_find_decay_consumed_split(decay_rate, scavenging_rate, expected_split):
 class TestFungalFruitPool:
     """Test the FungalFruitPool class."""
 
-    def test_initialization(self, mocker):
+    def test_initialization(self, mocker, fixture_core_constants):
         """Test initialization of FungalFruitPool."""
         import numpy as np
 
-        from virtual_ecosystem.core.constants import CoreConsts
         from virtual_ecosystem.core.data import Data
         from virtual_ecosystem.models.animal.decay import FungalFruitPool
 
@@ -236,8 +235,8 @@ class TestFungalFruitPool:
             cell_id=cell_id,
             data=mock_data,
             cell_area=cell_area,
-            c_n_ratio=CoreConsts.fungal_fruiting_bodies_c_n_ratio,
-            c_p_ratio=CoreConsts.fungal_fruiting_bodies_c_p_ratio,
+            c_n_ratio=fixture_core_constants.fungal_fruiting_bodies_c_n_ratio,
+            c_p_ratio=fixture_core_constants.fungal_fruiting_bodies_c_p_ratio,
         )
 
         c_mass = fungi_mass[cell_id] * cell_area
@@ -262,11 +261,10 @@ class TestFungalFruitPool:
 
         assert result == 12.34
 
-    def test_get_eaten(self, mocker, dummy_animal_data):
+    def test_get_eaten(self, mocker, dummy_animal_data, fixture_core_constants):
         """Test FungalFruitPool.get_eaten for correct nutrient consumption."""
         import numpy as np
 
-        from virtual_ecosystem.core.constants import CoreConsts
         from virtual_ecosystem.models.animal.decay import FungalFruitPool
 
         cell_area = 1.0
@@ -276,8 +274,8 @@ class TestFungalFruitPool:
             cell_id=cell_id,
             data=dummy_animal_data,
             cell_area=cell_area,
-            c_n_ratio=CoreConsts.fungal_fruiting_bodies_c_n_ratio,
-            c_p_ratio=CoreConsts.fungal_fruiting_bodies_c_p_ratio,
+            c_n_ratio=fixture_core_constants.fungal_fruiting_bodies_c_n_ratio,
+            c_p_ratio=fixture_core_constants.fungal_fruiting_bodies_c_p_ratio,
         )
 
         detritivore = mocker.MagicMock()
@@ -308,11 +306,10 @@ class TestFungalFruitPool:
                 f" got {nutrients[key]}"
             )
 
-    def test_apply_decay(self, dummy_animal_data):
+    def test_apply_decay(self, dummy_animal_data, fixture_core_constants):
         """Test FungalFruitPool.get_eaten for correct nutrient consumption."""
         import numpy as np
 
-        from virtual_ecosystem.core.constants import CoreConsts
         from virtual_ecosystem.models.animal.decay import FungalFruitPool
 
         cell_area = 100.0
@@ -322,12 +319,12 @@ class TestFungalFruitPool:
             cell_id=cell_id,
             data=dummy_animal_data,
             cell_area=cell_area,
-            c_n_ratio=CoreConsts.fungal_fruiting_bodies_c_n_ratio,
-            c_p_ratio=CoreConsts.fungal_fruiting_bodies_c_p_ratio,
+            c_n_ratio=fixture_core_constants.fungal_fruiting_bodies_c_n_ratio,
+            c_p_ratio=fixture_core_constants.fungal_fruiting_bodies_c_p_ratio,
         )
 
         total_decay = fungal_fruit.apply_decay(
-            decay_constant=CoreConsts.fungal_fruiting_bodies_decay_rate,
+            decay_constant=fixture_core_constants.fungal_fruiting_bodies_decay_rate,
             time_period=30.0,
         )
         assert np.isclose(total_decay, 51.036906692032936)
@@ -475,6 +472,7 @@ class TestSoilPool:
     def test_initialization(
         self,
         litter_soil_data_instance,
+        fixture_core_constants,
         microbial_c_n_p_ratios,
         pool_name,
         expected_mass,
@@ -483,7 +481,6 @@ class TestSoilPool:
         """Test initialization of LitterPool."""
         import numpy as np
 
-        from virtual_ecosystem.core.constants import CoreConsts
         from virtual_ecosystem.models.animal.decay import SoilPool
 
         with expected_error:
@@ -492,7 +489,7 @@ class TestSoilPool:
                 cell_id=2,
                 data=litter_soil_data_instance,
                 cell_area=100.0,
-                max_depth_microbial_activity=CoreConsts.max_depth_of_microbial_activity,
+                max_depth_microbial_activity=fixture_core_constants.max_depth_of_microbial_activity,
                 c_n_p_ratios=microbial_c_n_p_ratios,
             )
 
@@ -516,11 +513,16 @@ class TestSoilPool:
 
         assert result == 12.34
 
-    def test_get_eaten(self, mocker, litter_soil_data_instance, microbial_c_n_p_ratios):
+    def test_get_eaten(
+        self,
+        mocker,
+        litter_soil_data_instance,
+        fixture_core_constants,
+        microbial_c_n_p_ratios,
+    ):
         """Test `get_eaten` method of SoilPool for correct nutrient consumption."""
         import numpy as np
 
-        from virtual_ecosystem.core.constants import CoreConsts
         from virtual_ecosystem.models.animal.decay import SoilPool
 
         pool_name = "pom"
@@ -532,7 +534,7 @@ class TestSoilPool:
             cell_id=cell_id,
             data=litter_soil_data_instance,
             cell_area=cell_area,
-            max_depth_microbial_activity=CoreConsts.max_depth_of_microbial_activity,
+            max_depth_microbial_activity=fixture_core_constants.max_depth_of_microbial_activity,
             c_n_p_ratios=microbial_c_n_p_ratios,
         )
 

--- a/tests/models/animals/test_functional_group.py
+++ b/tests/models/animals/test_functional_group.py
@@ -109,8 +109,8 @@ class TestFunctionalGroup:
             TaxaType,
             VerticalOccupancy,
         )
-        from virtual_ecosystem.models.animal.constants import AnimalConstants
         from virtual_ecosystem.models.animal.functional_group import FunctionalGroup
+        from virtual_ecosystem.models.animal.model_config import AnimalConstants
 
         func_group = FunctionalGroup(
             name,

--- a/tests/models/animals/test_functional_group.py
+++ b/tests/models/animals/test_functional_group.py
@@ -109,7 +109,7 @@ class TestFunctionalGroup:
             TaxaType,
             VerticalOccupancy,
         )
-        from virtual_ecosystem.models.animal.constants import AnimalConsts
+        from virtual_ecosystem.models.animal.constants import AnimalConstants
         from virtual_ecosystem.models.animal.functional_group import FunctionalGroup
 
         func_group = FunctionalGroup(
@@ -127,7 +127,7 @@ class TestFunctionalGroup:
             vertical_occupancy,
             birth_mass,
             adult_mass,
-            constants=AnimalConsts(density_scaling_method="damuth"),
+            constants=AnimalConstants(density_scaling_method="damuth"),
         )
         assert func_group.name == name
         assert func_group.taxa == TaxaType(taxa)
@@ -418,14 +418,14 @@ def test_import_functional_groups(
         TaxaType,
         VerticalOccupancy,
     )
-    from virtual_ecosystem.models.animal.constants import AnimalConsts
     from virtual_ecosystem.models.animal.functional_group import (
         FunctionalGroup,
         import_functional_groups,
     )
+    from virtual_ecosystem.models.animal.model_config import AnimalConstants
 
     file = shared_datadir / "example_functional_group_import.csv"
-    fg_list = import_functional_groups(file, constants=AnimalConsts())
+    fg_list = import_functional_groups(file, constants=AnimalConstants())
 
     fg = fg_list[index]
     assert isinstance(fg, FunctionalGroup)

--- a/tests/models/animals/test_model_config.py
+++ b/tests/models/animals/test_model_config.py
@@ -1,0 +1,43 @@
+"""Test the custom validation and serialisation on the animals.model_config module."""
+
+import pytest
+
+from virtual_ecosystem.models.animal.animal_traits import DietType
+
+
+@pytest.mark.parametrize(
+    argnames="deserialised,serialised",
+    argvalues=(
+        (DietType.CARNIVORE, "CARNIVORE"),
+        (DietType.FRUIT | DietType.NECTAR, "FRUIT|NECTAR"),
+    ),
+)
+def test_DietType_serialisation(deserialised, serialised):
+    """Check the DietType serialisation functions."""
+    from virtual_ecosystem.models.animal.model_config import (
+        deserialise_diet_type,
+        serialise_diet_type,
+    )
+
+    as_json = serialise_diet_type(deserialised)
+    as_diet_type = deserialise_diet_type(serialised)
+
+    assert as_json == serialised
+    assert as_diet_type == deserialised
+
+
+def test_AnimalConstants_dump_and_load():
+    """Test the AnimalConstants writes and reads as expected."""
+
+    from virtual_ecosystem.models.animal.model_config import AnimalConstants
+
+    model = AnimalConstants()
+
+    json_data = model.model_dump_json()
+
+    # Check a DietType has been correctly serialised as text
+    assert "CARNIVORE" in json_data
+
+    new_model = AnimalConstants.model_validate_json(json_data)
+
+    assert model == new_model

--- a/virtual_ecosystem/models/animal/animal_cohorts.py
+++ b/virtual_ecosystem/models/animal/animal_cohorts.py
@@ -15,7 +15,6 @@ from virtual_ecosystem.core.grid import Grid
 from virtual_ecosystem.core.logger import LOGGER
 from virtual_ecosystem.models.animal.animal_traits import VerticalOccupancy
 from virtual_ecosystem.models.animal.cnp import CNP
-from virtual_ecosystem.models.animal.constants import AnimalConsts
 from virtual_ecosystem.models.animal.decay import (
     CarcassPool,
     ExcrementPool,
@@ -25,6 +24,7 @@ from virtual_ecosystem.models.animal.decay import (
     find_decay_consumed_split,
 )
 from virtual_ecosystem.models.animal.functional_group import FunctionalGroup
+from virtual_ecosystem.models.animal.model_config import AnimalConstants
 from virtual_ecosystem.models.animal.protocols import Resource
 
 _T = TypeVar("_T")
@@ -41,7 +41,7 @@ class AnimalCohort:
         individuals: int,
         centroid_key: int,
         grid: Grid,
-        constants: AnimalConsts = AnimalConsts(),
+        constants: AnimalConstants = AnimalConstants(),
     ) -> None:
         if age < 0:
             raise ValueError("Age must be a positive number.")

--- a/virtual_ecosystem/models/animal/animal_model.py
+++ b/virtual_ecosystem/models/animal/animal_model.py
@@ -33,10 +33,8 @@ from xarray import DataArray
 from virtual_ecosystem.core.base_model import BaseModel
 from virtual_ecosystem.core.config import Config
 from virtual_ecosystem.core.configuration import CompiledConfiguration
-from virtual_ecosystem.core.constants_loader import load_constants
 from virtual_ecosystem.core.core_components import CoreComponents
 from virtual_ecosystem.core.data import Data
-from virtual_ecosystem.core.exceptions import ConfigurationError
 from virtual_ecosystem.core.logger import LOGGER
 from virtual_ecosystem.models.animal.animal_cohorts import AnimalCohort
 from virtual_ecosystem.models.animal.animal_traits import (
@@ -45,7 +43,6 @@ from virtual_ecosystem.models.animal.animal_traits import (
     ReproductiveEnvironment,
 )
 from virtual_ecosystem.models.animal.cnp import CNP, find_microbial_stoichiometries
-from virtual_ecosystem.models.animal.constants import AnimalConsts
 from virtual_ecosystem.models.animal.decay import (
     CarcassPool,
     ExcrementPool,
@@ -59,7 +56,11 @@ from virtual_ecosystem.models.animal.functional_group import (
     get_functional_group_by_name,
     import_functional_groups,
 )
-from virtual_ecosystem.models.animal.model_config import AnimalConfiguration
+from virtual_ecosystem.models.animal.model_config import (
+    DENSITY_SCALING_METHODS,
+    AnimalConfiguration,
+    AnimalConstants,
+)
 from virtual_ecosystem.models.animal.plant_resources import PlantResources
 from virtual_ecosystem.models.animal.protocols import Resource
 from virtual_ecosystem.models.animal.scaling_functions import (
@@ -164,7 +165,7 @@ class AnimalModel(
         data: Data,
         core_components: CoreComponents,
         static: bool = False,
-        density_scaling_method: str = "madingley",
+        density_scaling_method: DENSITY_SCALING_METHODS = "madingley",
         **kwargs: Any,
     ):
         """Animal init function.
@@ -175,7 +176,7 @@ class AnimalModel(
 
         self.density_scaling_method = density_scaling_method
         """Which density scaling equations are used, "damuth" or "madingley"."""
-        self.model_constants: AnimalConsts = AnimalConsts(
+        self.model_constants: AnimalConstants = AnimalConstants(
             density_scaling_method=self.density_scaling_method
         )
         """Animal constants."""
@@ -356,33 +357,14 @@ class AnimalModel(
         """
 
         # Extract the validated model configuration from the complete compiled
-        # configuration. This syntax is odd but required to support static typing
+        # configuration.
         model_configuration: AnimalConfiguration = configuration.get_subconfiguration(
             "animal", AnimalConfiguration
         )
 
-        # Load in the relevant constants
-        model_constants = load_constants(config, "animal", "AnimalConsts")
-        static = model_configuration.static
-
-        density_scaling_method = config["animal"].get(
-            "density_scaling_method", "madingley"
-        )
-
-        # Load functional groups
-        functional_groups_path = config["animal"].get(
-            "functional_group_definitions_path", None
-        )
-        if functional_groups_path is None:
-            msg = (
-                "Animal model configuration does not provide the "
-                "'functional_group_definitions_path' setting"
-            )
-            LOGGER.error(msg)
-            raise ConfigurationError(msg)
-
         functional_groups = import_functional_groups(
-            fg_csv_file=functional_groups_path, constants=model_constants
+            fg_csv_file=model_configuration.functional_group_definitions_path,
+            constants=model_configuration.constants,
         )
 
         # Find microbial stoichiometries based on the config
@@ -396,10 +378,10 @@ class AnimalModel(
         return cls(
             data=data,
             core_components=core_components,
-            static=static,
+            static=model_configuration.static,
             functional_groups=functional_groups,
-            model_constants=model_constants,
-            density_scaling_method=density_scaling_method,
+            model_constants=model_configuration.constants,
+            density_scaling_method=model_configuration.density_scaling_method,
             microbial_c_n_p_ratios=microbial_c_n_p_ratios,
         )
 

--- a/virtual_ecosystem/models/animal/animal_model.py
+++ b/virtual_ecosystem/models/animal/animal_model.py
@@ -57,7 +57,6 @@ from virtual_ecosystem.models.animal.functional_group import (
     import_functional_groups,
 )
 from virtual_ecosystem.models.animal.model_config import (
-    DENSITY_SCALING_METHODS,
     AnimalConfiguration,
     AnimalConstants,
 )
@@ -165,7 +164,6 @@ class AnimalModel(
         data: Data,
         core_components: CoreComponents,
         static: bool = False,
-        density_scaling_method: DENSITY_SCALING_METHODS = "madingley",
         **kwargs: Any,
     ):
         """Animal init function.
@@ -174,15 +172,12 @@ class AnimalModel(
         handled in :fun:`~virtual_ecosystem.animal.animal_model._setup`.
         """
 
-        self.density_scaling_method = density_scaling_method
-        """Which density scaling equations are used, "damuth" or "madingley"."""
-        self.model_constants: AnimalConstants = AnimalConstants(
-            density_scaling_method=self.density_scaling_method
-        )
-        """Animal constants."""
-
         super().__init__(data, core_components, static, **kwargs)  # runs _setup
 
+        self.density_scaling_method
+        """Which density scaling equations are used."""
+        self.model_constants: AnimalConstants
+        """Animal constants."""
         self.communities: dict[int, list[AnimalCohort]]
         """Animal communities with grid cell IDs and lists of AnimalCohorts."""
         self.active_cohorts: dict[uuid.UUID, AnimalCohort] = {}
@@ -381,7 +376,6 @@ class AnimalModel(
             static=model_configuration.static,
             functional_groups=functional_groups,
             model_constants=model_configuration.constants,
-            density_scaling_method=model_configuration.density_scaling_method,
             microbial_c_n_p_ratios=microbial_c_n_p_ratios,
         )
 
@@ -389,6 +383,7 @@ class AnimalModel(
         self,
         functional_groups: list[FunctionalGroup],
         microbial_c_n_p_ratios: dict[str, dict[str, float]],
+        model_constants: AnimalConstants,
         **kwargs: Any,
     ) -> None:
         """Method to setup the animal model specific data variables.
@@ -402,8 +397,18 @@ class AnimalModel(
                 simulation.
             microbial_c_n_p_ratios: Biomass stoichiometry of each microbial functional
                 group.
+            model_constants: An
+                :class:`~virtual_ecosystem.models.animal.model_config.AnimalConstants`
+                instance, providing constants for the model and setting the density
+                scaling method to be used in simulation.
             **kwargs: Further arguments to the setup method.
         """
+
+        self.model_constants = model_constants
+        """Animal constants."""
+        self.density_scaling_method = self.model_constants.density_scaling_method
+        """Which density scaling equations are used, "damuth" or "madingley"."""
+
         days_as_float = self.model_timing.update_interval_quantity.to("days").magnitude
         self.update_interval_in_days = days_as_float
         """Store update interval as a number of days."""

--- a/virtual_ecosystem/models/animal/animal_traits.py
+++ b/virtual_ecosystem/models/animal/animal_traits.py
@@ -3,6 +3,8 @@ animal traits into enumerations for use by the Functional Group class in the
 :mod:`~virtual_ecosystem.models.animal.functional_group` module.
 """  # noqa: D205
 
+from __future__ import annotations
+
 from enum import Enum, Flag, auto
 
 
@@ -55,7 +57,7 @@ class DietType(Flag):
     OMNIVORE = HERBIVORE | CARNIVORE
 
     @classmethod
-    def parse(cls, diet_string: str) -> "DietType":
+    def parse(cls, diet_string: str) -> DietType:
         """Parse a string of underscore-separated diet terms into a DietType flag.
 
         This method takes a lowercase string such as 'fruit_foliage_fish' and converts
@@ -91,7 +93,7 @@ class DietType(Flag):
 
         return flags
 
-    def coarse_category(self) -> "DietType":
+    def coarse_category(self) -> DietType:
         """Classify the detailed diet into a broad trophic category.
 
         This method examines the components of the current DietType flag and returns one
@@ -191,7 +193,7 @@ class VerticalOccupancy(Flag):
     CANOPY = auto()
 
     @classmethod
-    def parse(cls, occupancy: str) -> "VerticalOccupancy":
+    def parse(cls, occupancy: str) -> VerticalOccupancy:
         """Convert a string like 'soil_ground' into a VerticalOccupancy flag.
 
         This method parses a lowercase underscore-separated string into a combined

--- a/virtual_ecosystem/models/animal/functional_group.py
+++ b/virtual_ecosystem/models/animal/functional_group.py
@@ -4,6 +4,7 @@ constants and rate equations used by AnimalCohorts in the
 """  # noqa: D205
 
 from collections.abc import Iterable
+from pathlib import Path
 
 import pandas as pd
 
@@ -125,7 +126,7 @@ class FunctionalGroup:
 
 
 def import_functional_groups(
-    fg_csv_file: str, constants: AnimalConstants
+    fg_csv_file: Path, constants: AnimalConstants
 ) -> list[FunctionalGroup]:
     """The function to import pre-defined functional groups.
 
@@ -150,11 +151,11 @@ def import_functional_groups(
     try:
         fg_data = pd.read_csv(fg_csv_file)
     except FileNotFoundError:
-        msg = "Animal functional group definition file not found: " + fg_csv_file
+        msg = f"Animal functional group definition file not found: {fg_csv_file!s}"
         LOGGER.error(msg)
         raise
     except pd.errors.ParserError:
-        msg = "Cannot parse animal functional group definition file: " + fg_csv_file
+        msg = f"Cannot parse animal functional group definition file: {fg_csv_file!s}"
         LOGGER.error(msg)
         raise
 

--- a/virtual_ecosystem/models/animal/functional_group.py
+++ b/virtual_ecosystem/models/animal/functional_group.py
@@ -20,7 +20,7 @@ from virtual_ecosystem.models.animal.animal_traits import (
     TaxaType,
     VerticalOccupancy,
 )
-from virtual_ecosystem.models.animal.constants import AnimalConsts
+from virtual_ecosystem.models.animal.model_config import AnimalConstants
 
 
 class FunctionalGroup:
@@ -53,7 +53,7 @@ class FunctionalGroup:
         birth_mass: float,
         adult_mass: float,
         density_individuals_m2: float | None = None,
-        constants: AnimalConsts = AnimalConsts(),
+        constants: AnimalConstants = AnimalConstants(),
     ) -> None:
         """The constructor for the FunctionalGroup class.
 
@@ -125,7 +125,7 @@ class FunctionalGroup:
 
 
 def import_functional_groups(
-    fg_csv_file: str, constants: AnimalConsts
+    fg_csv_file: str, constants: AnimalConstants
 ) -> list[FunctionalGroup]:
     """The function to import pre-defined functional groups.
 

--- a/virtual_ecosystem/models/animal/model_config.py
+++ b/virtual_ecosystem/models/animal/model_config.py
@@ -4,9 +4,15 @@ constants" (fitting relationships taken from the literature) required by the bro
 
 """  # noqa: D205, D415
 
+import operator
+from functools import reduce
 from typing import Annotated, Literal
 
-from pydantic import AfterValidator, Field
+from pydantic import (
+    Field,
+    PlainSerializer,
+    PlainValidator,
+)
 
 from virtual_ecosystem.core.configuration import (
     FILEPATH_PLACEHOLDER,
@@ -26,9 +32,7 @@ TEMPERATURE: float = 37.0  # Toy temperature for setting up metabolism [C].
 DENSITY_SCALING_METHODS = Literal["damuth", "madingley"]
 
 
-def deserialise_diet_items(
-    diet_items: dict[str, float | tuple[float, ...]],
-) -> dict[DietType, float | tuple[float, ...]]:
+def deserialise_diet_type_dicts(diet_items: dict[str, float]) -> dict[DietType, float]:
     """Deserialise string diet terms to DietType.
 
     For standard ``Enum`` types, pydantic correctly serialises and deserialise a string
@@ -36,27 +40,38 @@ def deserialise_diet_items(
     these are seriliased and deserialised as with an ``Enum``, then users would need to
     use numeric diet codes in the configuration.
 
-    This shim takes a string from a config, such as "CARNIVORE" or "seeds_fruit", and
-    uses the ``DietType.parse()`` to convert and validate the value.
+    This function takes a string such as "CARNIVORE" or "FRUIT|SEEDS" and returns the
+    appropriate DietType.
     """
 
-    try:
-        return_value = {DietType.parse(k): v for k, v in diet_items.items()}
-    except ValueError:
-        raise
+    return {
+        reduce(operator.or_, [DietType[d] for d in key.split("|")]): value
+        for key, value in diet_items.items()
+    }
 
-    return return_value
+
+def serialise_diet_type_dicts(diet_items: dict[DietType, float]) -> dict[str, float]:
+    """Serialise DietType Flag value to string.
+
+    This shim simply exports the ``DietType._name_`` attribute, which is a string
+    representation of the Flag value.
+    """
+
+    return {key._name_: value for key, value in diet_items.items()}  # type: ignore[misc]
 
 
 DamuthTerms = Annotated[
     dict[DietType, tuple[float, float]],
-    AfterValidator(deserialise_diet_items),
+    None,
+    PlainSerializer(serialise_diet_type_dicts),
+    PlainValidator(deserialise_diet_type_dicts),
 ]
 """Custom data type with post validation for dictionaries of Damuth coefficients."""
 
 DietFloats = Annotated[
     dict[DietType, float],
-    AfterValidator(deserialise_diet_items),
+    PlainSerializer(serialise_diet_type_dicts),
+    PlainValidator(deserialise_diet_type_dicts),
 ]
 """Custom data type with post validation for dictionaries of diet type and floats."""
 

--- a/virtual_ecosystem/models/animal/model_config.py
+++ b/virtual_ecosystem/models/animal/model_config.py
@@ -376,8 +376,6 @@ class AnimalConfiguration(ModelConfigurationRoot):
 
     functional_group_definitions_path: FILEPATH_PLACEHOLDER
     "A file path to a data file of animal functional group definitions"
-    # density_scaling_method: DENSITY_SCALING_METHODS = "madingley"
-    # """Specifies which density scaling equation to use for initialization. Options are
-    # 'damuth' or 'madingley'."""
+
     constants: AnimalConstants = AnimalConstants()
     """The constants class for the animal model."""

--- a/virtual_ecosystem/models/animal/model_config.py
+++ b/virtual_ecosystem/models/animal/model_config.py
@@ -8,7 +8,11 @@ from typing import Annotated, Literal
 
 from pydantic import AfterValidator, Field
 
-from virtual_ecosystem.core.configuration import Configuration, ModelConfigurationRoot
+from virtual_ecosystem.core.configuration import (
+    FILEPATH_PLACEHOLDER,
+    Configuration,
+    ModelConfigurationRoot,
+)
 from virtual_ecosystem.models.animal.animal_traits import (
     DietType,
     MetabolicType,
@@ -18,6 +22,8 @@ from virtual_ecosystem.models.animal.animal_traits import (
 BOLTZMANN_CONSTANT: float = 8.617333262145e-5  # Boltzmann constant [eV/K]
 
 TEMPERATURE: float = 37.0  # Toy temperature for setting up metabolism [C].
+
+DENSITY_SCALING_METHODS = Literal["damuth", "madingley"]
 
 
 def deserialise_diet_items(
@@ -43,13 +49,13 @@ def deserialise_diet_items(
 
 
 DamuthTerms = Annotated[
-    dict[str, tuple[float, ...]],
+    dict[DietType, tuple[float, float]],
     AfterValidator(deserialise_diet_items),
 ]
 """Custom data type with post validation for dictionaries of Damuth coefficients."""
 
 DietFloats = Annotated[
-    dict[str, float],
+    dict[DietType, float],
     AfterValidator(deserialise_diet_items),
 ]
 """Custom data type with post validation for dictionaries of diet type and floats."""
@@ -62,7 +68,8 @@ class AnimalConstants(Configuration):
 
     """
 
-    density_scaling_method: str = "damuth"
+    density_scaling_method: DENSITY_SCALING_METHODS = "damuth"
+    """The density scaling method to use within a simulation."""
 
     def get_population_density_terms(
         self, taxa: TaxaType, diet: DietType
@@ -92,29 +99,31 @@ class AnimalConstants(Configuration):
     damuths_law_terms: dict[TaxaType, DamuthTerms] = Field(
         default_factory=lambda: {
             TaxaType.MAMMAL: {
-                "HERBIVORE": (-0.75, 4.23),
-                "CARNIVORE": (-0.75, 1.00),
-                "OMNIVORE": (-0.75, 3.00),
+                DietType.HERBIVORE: (-0.75, 4.23),
+                DietType.CARNIVORE: (-0.75, 1.00),
+                DietType.OMNIVORE: (-0.75, 3.00),
             },
             TaxaType.BIRD: {
-                "HERBIVORE": (-0.75, 5.00),
-                "CARNIVORE": (-0.75, 2.00),
-                "OMNIVORE": (-0.75, 3.00),
+                DietType.HERBIVORE: (-0.75, 5.00),
+                DietType.CARNIVORE: (-0.75, 2.00),
+                DietType.OMNIVORE: (-0.75, 3.00),
             },
             TaxaType.INVERTEBRATE: {
-                "HERBIVORE": (-0.75, 5.00),
-                "CARNIVORE": (-0.75, 2.00),
-                "OMNIVORE": (-0.75, 3.00),
+                DietType.HERBIVORE: (-0.75, 5.00),
+                DietType.CARNIVORE: (-0.75, 2.00),
+                DietType.OMNIVORE: (-0.75, 3.00),
             },
             TaxaType.AMPHIBIAN: {
-                "HERBIVORE": (-0.75, 5.00),
-                "CARNIVORE": (-0.75, 2.00),
-                "OMNIVORE": (-0.75, 3.00),
+                DietType.HERBIVORE: (-0.75, 5.00),
+                DietType.CARNIVORE: (-0.75, 2.00),
+                DietType.OMNIVORE: (-0.75, 3.00),
             },
         }
     )
+    """Damuth Law terms, structured by taxonomic type and broad diet category."""
 
     madingley_biomass_scaling_terms: tuple[float, float] = (0.6, 300000.0)
+    """Biomass scaling terms from the Madingley model."""
 
     metabolic_rate_terms: dict[MetabolicType, dict[str, tuple[float, float]]] = Field(
         default_factory=lambda: {
@@ -141,19 +150,21 @@ class AnimalConstants(Configuration):
     # TODO: rework these efficiencies to be interaction-specific, not trait based
     conversion_efficiency: DietFloats = Field(
         default_factory=lambda: {
-            "HERBIVORE": 0.1,  # Toy value
-            "CARNIVORE": 0.25,  # Toy value
-            "OMNIVORE": 0.175,  # Toy value
+            DietType.HERBIVORE: 0.1,  # Toy value
+            DietType.CARNIVORE: 0.25,  # Toy value
+            DietType.OMNIVORE: 0.175,  # Toy value
         }
     )
+    """Conversion efficiencies by broad diet categories."""
 
     mechanical_efficiency: DietFloats = Field(
         default_factory=lambda: {
-            "HERBIVORE": 0.9,  # Toy value
-            "CARNIVORE": 0.8,  # Toy value
-            "OMNIVORE": 0.85,  # Toy value
+            DietType.HERBIVORE: 0.9,  # Toy value
+            DietType.CARNIVORE: 0.8,  # Toy value
+            DietType.OMNIVORE: 0.85,  # Toy value
         }
     )
+    """Mechanical efficiencies by broad diet categories."""
 
     prey_mass_scaling_terms: dict[
         MetabolicType, dict[TaxaType, tuple[float, float]]
@@ -169,6 +180,7 @@ class AnimalConstants(Configuration):
             },  # Toy values
         }
     )
+    """Prey mass scaling terms by metabolic type."""
 
     cnp_proportion_terms: dict[TaxaType, dict[str, float]] = Field(
         default_factory=lambda: {
@@ -178,13 +190,16 @@ class AnimalConstants(Configuration):
             TaxaType.AMPHIBIAN: {"carbon": 0.4, "nitrogen": 0.2, "phosphorus": 0.4},
         }
     )
+    """Stoichiometric proportions structured by taxon type."""
 
-    birth_mass_threshold: float = 1.5  # Threshold for reproduction
-    flow_to_reproductive_mass_threshold: float = (
-        1.0  # Threshold of trophic flow to reproductive mass
-    )
-    dispersal_mass_threshold: float = 0.8  # Threshold for dispersal
-    energy_percentile_threshold: float = 0.5  # Threshold for initiating migration
+    birth_mass_threshold: float = 1.5
+    """Mass threshold for reproduction"""
+    flow_to_reproductive_mass_threshold: float = 1.0
+    """Threshold of trophic flow to reproductive mass."""
+    dispersal_mass_threshold: float = 0.8
+    """Mass threshold for dispersal."""
+    energy_percentile_threshold: float = 0.5
+    """Energy threshold for initiating migration."""
 
     # Madingley Foraging Parameters
 
@@ -360,9 +375,10 @@ class AnimalConstants(Configuration):
 class AnimalConfiguration(ModelConfigurationRoot):
     """Root configuration class for the animal model."""
 
-    functional_group_definitions_path: str = ""
+    functional_group_definitions_path: FILEPATH_PLACEHOLDER
     "A file path to a data file of animal functional group definitions"
-    density_scaling_method: Literal["damuth", "madingley"] = "madingley"
+    density_scaling_method: DENSITY_SCALING_METHODS = "madingley"
     """Specifies which density scaling equation to use for initialization. Options are
     'damuth' or 'madingley'."""
     constants: AnimalConstants = AnimalConstants()
+    """The constants class for the animal model."""

--- a/virtual_ecosystem/models/animal/model_config.py
+++ b/virtual_ecosystem/models/animal/model_config.py
@@ -32,7 +32,7 @@ TEMPERATURE: float = 37.0  # Toy temperature for setting up metabolism [C].
 DENSITY_SCALING_METHODS = Literal["damuth", "madingley"]
 
 
-def deserialise_diet_type_dicts(diet_items: dict[str, float]) -> dict[DietType, float]:
+def deserialise_diet_type(diet: str) -> DietType:
     """Deserialise string diet terms to DietType.
 
     For standard ``Enum`` types, pydantic correctly serialises and deserialise a string
@@ -44,36 +44,26 @@ def deserialise_diet_type_dicts(diet_items: dict[str, float]) -> dict[DietType, 
     appropriate DietType.
     """
 
-    return {
-        reduce(operator.or_, [DietType[d] for d in key.split("|")]): value
-        for key, value in diet_items.items()
-    }
+    return reduce(operator.or_, [DietType[d] for d in diet.split("|")])
 
 
-def serialise_diet_type_dicts(diet_items: dict[DietType, float]) -> dict[str, float]:
+def serialise_diet_type(diet: DietType) -> str:
     """Serialise DietType Flag value to string.
 
     This shim simply exports the ``DietType._name_`` attribute, which is a string
     representation of the Flag value.
     """
 
-    return {key._name_: value for key, value in diet_items.items()}  # type: ignore[misc]
+    # The _name_ value _can_ be None, but I don't think will be in this use case.
+    return diet._name_  # type: ignore[return-value]
 
 
-DamuthTerms = Annotated[
-    dict[DietType, tuple[float, float]],
-    None,
-    PlainSerializer(serialise_diet_type_dicts),
-    PlainValidator(deserialise_diet_type_dicts),
+DietTypeSer = Annotated[
+    DietType,
+    PlainSerializer(serialise_diet_type),
+    PlainValidator(deserialise_diet_type),
 ]
-"""Custom data type with post validation for dictionaries of Damuth coefficients."""
-
-DietFloats = Annotated[
-    dict[DietType, float],
-    PlainSerializer(serialise_diet_type_dicts),
-    PlainValidator(deserialise_diet_type_dicts),
-]
-"""Custom data type with post validation for dictionaries of diet type and floats."""
+"""Custom data type to serialise and deserialise DietType Flag values."""
 
 
 class AnimalConstants(Configuration):
@@ -95,23 +85,17 @@ class AnimalConstants(Configuration):
             taxa: The TaxaType of the functional group (used for damuth).
             diet: The DietType of the functional group (used for damuth).
 
-        ..TODO:
-            Need to fix the typing here - the damuths_law_terms dict entries are typed
-            as str, but are autoconverted to DietType on load.
-
         Returns:
             A tuple (exponent, scalar) for the scaling law.
         """
-        if self.density_scaling_method == "damuth":
-            return self.damuths_law_terms[taxa][diet]  # type: ignore[index]
-        elif self.density_scaling_method == "madingley":
-            return self.madingley_biomass_scaling_terms
-        else:
-            raise ValueError(
-                f"Unsupported density scaling method: {self.density_scaling_method}"
-            )
 
-    damuths_law_terms: dict[TaxaType, DamuthTerms] = Field(
+        return (
+            self.damuths_law_terms[taxa][diet]
+            if self.density_scaling_method == "damuth"
+            else self.madingley_biomass_scaling_terms
+        )
+
+    damuths_law_terms: dict[TaxaType, dict[DietTypeSer, tuple[float, float]]] = Field(
         default_factory=lambda: {
             TaxaType.MAMMAL: {
                 DietType.HERBIVORE: (-0.75, 4.23),
@@ -163,7 +147,7 @@ class AnimalConstants(Configuration):
     """Energy densities of different food sources [J/g]"""
 
     # TODO: rework these efficiencies to be interaction-specific, not trait based
-    conversion_efficiency: DietFloats = Field(
+    conversion_efficiency: dict[DietTypeSer, float] = Field(
         default_factory=lambda: {
             DietType.HERBIVORE: 0.1,  # Toy value
             DietType.CARNIVORE: 0.25,  # Toy value
@@ -172,7 +156,7 @@ class AnimalConstants(Configuration):
     )
     """Conversion efficiencies by broad diet categories."""
 
-    mechanical_efficiency: DietFloats = Field(
+    mechanical_efficiency: dict[DietTypeSer, float] = Field(
         default_factory=lambda: {
             DietType.HERBIVORE: 0.9,  # Toy value
             DietType.CARNIVORE: 0.8,  # Toy value
@@ -392,8 +376,8 @@ class AnimalConfiguration(ModelConfigurationRoot):
 
     functional_group_definitions_path: FILEPATH_PLACEHOLDER
     "A file path to a data file of animal functional group definitions"
-    density_scaling_method: DENSITY_SCALING_METHODS = "madingley"
-    """Specifies which density scaling equation to use for initialization. Options are
-    'damuth' or 'madingley'."""
+    # density_scaling_method: DENSITY_SCALING_METHODS = "madingley"
+    # """Specifies which density scaling equation to use for initialization. Options are
+    # 'damuth' or 'madingley'."""
     constants: AnimalConstants = AnimalConstants()
     """The constants class for the animal model."""

--- a/virtual_ecosystem/models/animal/plant_resources.py
+++ b/virtual_ecosystem/models/animal/plant_resources.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from virtual_ecosystem.core.data import Data
 from virtual_ecosystem.models.animal.animal_traits import VerticalOccupancy
-from virtual_ecosystem.models.animal.constants import AnimalConsts
+from virtual_ecosystem.models.animal.model_config import AnimalConstants
 
 # from virtual_ecosystem.models.animal.decay import ExcrementPool
 from virtual_ecosystem.models.animal.protocols import Consumer
@@ -30,7 +30,7 @@ class PlantResources:
         constants: Animal-related constants, including plant energy density.
     """
 
-    def __init__(self, data: Data, cell_id: int, constants: AnimalConsts) -> None:
+    def __init__(self, data: Data, cell_id: int, constants: AnimalConstants) -> None:
         # Store the data and extract the appropriate plant data
         self.data = data
         """A reference to the core data object."""


### PR DESCRIPTION
# Description

Mostly this PR is:

* Moving the animal model and its tests over to using the new Configuration object style.
* Adding a doc page for the new AnimalModel configuration object, which has been updated slightly to better handle some trickier bits - writing DietType mostly.

However, there is also a deeper change in the model `__init__`. The current code looks like this:

https://github.com/ImperialCollegeLondon/virtual_ecosystem/blob/4c9e14bb3f6ff004c7ae00ceca89315b7ddf4907/virtual_ecosystem/models/animal/animal_model.py#L162-L181

The model arguments do not require that users provide a set of model constants. The constants are provided internally - the model `__init__` creates a brand new set of constants with the appropriate density scaling but using all of the default values. So users can configure the density scaling but **cannot configure anything else**.

My solution here is to just use the existing setting inside the constants configuration section to set the method. I've replaced the `density_scaling_method: str = "madingley"` in `__init__` with a required `model_constants` in `_setup`. That can then be passed in using `_from_config`. That also means defining the constants and scaling method in `__init__` but delaying setting them until `_setup`: I think this is closer to how these methods should be defined - only attribute definitions in the `__init__`. With this setup, users can provide a complete configuration and change defaults and it will be respected by the model. At the moment it gets ignored.

Fixes #1113 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
