### PR TITLE
Fixed division by zero warning in `soil.uptake`

### DIFF
--- a/virtual_ecosystem/models/soil/uptake.py
+++ b/virtual_ecosystem/models/soil/uptake.py
@@ -279,14 +279,13 @@ def find_net_nutrient_consumptions_free_living(
     """
 
     # Determine how limiting carbon is (as a proportion). The zero carbon uptake case is
-    # handled by assuming that carbon limitation is total in this case. Divide by zero
-    # warnings are turned off because this is explicitly handled.
-    with np.errstate(divide="ignore", invalid="ignore"):
-        carbon_limitation = np.where(
-            max_uptake_rates.carbon > 0,
-            actual_carbon_gain / (max_uptake_rates.carbon * carbon_use_efficiency),
-            1,
-        )
+    # handled by assuming that carbon limitation is total in this case.
+    carbon_limitation = np.divide(
+        actual_carbon_gain,
+        max_uptake_rates.carbon * carbon_use_efficiency,
+        out=np.ones_like(max_uptake_rates.carbon, dtype=float),
+        where=(max_uptake_rates.carbon > 0),
+    )
 
     # Calculate biomass demands for nitrogen and phosphorus
     nitrogen_demand = (
@@ -328,11 +327,11 @@ def find_net_nutrient_consumptions_free_living(
 
     # For immobilisation of nitrogen, the proportion of ammonium and nitrate taken up
     # follows the proportion of the maximum uptake rates (if either is above zero)
-    ammonium_uptake_proportion = np.where(
-        (max_uptake_rates.ammonium > 0) | (max_uptake_rates.nitrate > 0),
-        max_uptake_rates.ammonium
-        / (max_uptake_rates.ammonium + max_uptake_rates.nitrate),
-        0.0,
+    ammonium_uptake_proportion = np.divide(
+        max_uptake_rates.ammonium,
+        max_uptake_rates.ammonium + max_uptake_rates.nitrate,
+        out=np.zeros_like(max_uptake_rates.ammonium, dtype=float),
+        where=(max_uptake_rates.ammonium > 0) | (max_uptake_rates.nitrate > 0),
     )
 
     # Whether the uptake proportion or the mineralisation proportion is relevant depends
@@ -455,15 +454,12 @@ def find_net_nutrient_consumptions_symbiotic(
 
     # For inorganic nitrogen uptake, the proportion of ammonium and nitrate taken up
     # follows the proportion of the maximum uptake rates (if either is above zero)
-    # I explicitly handle the divide by zero case here, so that error state is ignored
-    # to prevent runtime warnings related to something that I have actually handled.
-    with np.errstate(divide="ignore", invalid="ignore"):
-        ammonium_uptake_proportion = np.where(
-            (max_uptake_rates.ammonium > 0) | (max_uptake_rates.nitrate > 0),
-            max_uptake_rates.ammonium
-            / (max_uptake_rates.ammonium + max_uptake_rates.nitrate),
-            0.0,
-        )
+    ammonium_uptake_proportion = np.divide(
+        max_uptake_rates.ammonium,
+        max_uptake_rates.ammonium + max_uptake_rates.nitrate,
+        out=np.zeros_like(max_uptake_rates.ammonium, dtype=float),
+        where=(max_uptake_rates.ammonium > 0) | (max_uptake_rates.nitrate > 0),
+    )
 
     ammonium_uptake = inorganic_nitrogen_uptake * ammonium_uptake_proportion
     nitrate_uptake = inorganic_nitrogen_uptake * (1 - ammonium_uptake_proportion)


### PR DESCRIPTION
# Description

Mini-PR that stops division by zero warnings in the `soil.uptake` submodule by switching to `np.divide` (with where as an argument) rather than using `np.where`

Fixes #1146

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
