### PR TITLE
Fixing incorrect volume to area conversion in fungal fruiting body production rate calculation

### DIFF
--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -306,7 +306,7 @@ def test_update(mocker, fixture_soil_model, dummy_carbon_data):
 
     # And fungal fruiting body production to test that step
     fruiting_body_production = [2.0235824e-6, 2.6018971e-4, 4.7134783e-4, 3.9772191e-4]
-    production_rate = [1.618865952e-5, 0.00208151768, 0.00377078264, 0.003181775276]
+    production_rate = [1.01179122e-6, 0.000130094855, 0.000235673915, 0.00019886095475]
 
     mock_integrate = mocker.patch.object(fixture_soil_model, "integrate")
 
@@ -684,7 +684,7 @@ def test_convert_fruiting_body_production_to_rate(fixture_soil_model):
         [2.02358244e-6, 0.00026018971, 0.00047134783, 0.0003977219095]
     )
 
-    expected_rate = [1.618865952e-5, 0.00208151768, 0.00377078264, 0.003181775276]
+    expected_rate = [1.01179122e-6, 0.000130094855, 0.000235673915, 0.00019886095475]
 
     actual_rate = fixture_soil_model.convert_fruiting_body_production_to_rate(
         total_production=total_production

--- a/virtual_ecosystem/models/soil/soil_model.py
+++ b/virtual_ecosystem/models/soil/soil_model.py
@@ -557,10 +557,8 @@ class SoilModel(
 
         return {
             "production_of_fungal_fruiting_bodies": total_production
-            / (
-                self.core_constants.max_depth_of_microbial_activity
-                * self.model_timing.update_interval_quantity.to("days").magnitude
-            )
+            * self.core_constants.max_depth_of_microbial_activity
+            / self.model_timing.update_interval_quantity.to("days").magnitude
         }
 
     def calculate_dissolved_nutrient_concentrations(self) -> dict[str, DataArray]:


### PR DESCRIPTION
# Description

Small fix that stops the fungi from spontaneously generating carbon

Fixes #1151

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
