### PR TITLE
1022 get canopy temperatures to converge

### DIFF
--- a/docs/source/virtual_ecosystem/implementation/abiotic_implementation.md
+++ b/docs/source/virtual_ecosystem/implementation/abiotic_implementation.md
@@ -511,7 +511,7 @@ with
 
 $$R = \sqrt{C_s + \frac{C_r LAI}{2}}$$
 
-where $C_{s}$ is the substrate surface drag coefficient, $C_{r}$ is the roughness
+where $C_{s}$ is the substrate surface roughness length, $C_{r}$ is the roughness
 element (vegetation) drag coefficient, $C_{d}$ is the roughness sublayer depth parameter,
 $\kappa$ is the von Karman constant, and $LAI$ is the leaf area index
 ($\mathrm{m\,m^{-1}}$).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -564,6 +564,7 @@ def dummy_climate_data(fixture_core_components):
         "diabatic_correction_momentum_canopy": 1.0,
         "mean_mixing_length": 1.3,
         "aerodynamic_resistance_surface": 12.5,
+        "aerodynamic_resistance_canopy": 12.5,
         "mean_annual_temperature": 20.0,
     }
     for var, val in spatially_constant.items():
@@ -584,9 +585,6 @@ def dummy_climate_data(fixture_core_components):
     # - Vertically structured
     data["wind_speed"] = from_template()
     data["wind_speed"][lyr_str.index_filled_atmosphere] = 0.1
-
-    data["aerodynamic_resistance_canopy"] = from_template()
-    data["aerodynamic_resistance_canopy"][lyr_str.index_filled_canopy] = 12.5
 
     data["atmospheric_pressure"] = from_template()
     data["atmospheric_pressure"][lyr_str.index_filled_atmosphere] = 96.0
@@ -739,12 +737,6 @@ def dummy_climate_data_varying_canopy(fixture_core_components, dummy_climate_dat
         [450.0, 450.0, 450.0, 450],
     ]
     # dummy_climate_data["shortwave_absorption"][13] = np.repeat(0.0, 4)
-
-    dummy_climate_data["aerodynamic_resistance_canopy"][index_filled_canopy] = [
-        [12.5, 12.5, 12.5, np.nan],
-        [12.5, 12.5, np.nan, np.nan],
-        [12.5, np.nan, np.nan, np.nan],
-    ]
 
     dummy_climate_data["vapour_pressure_deficit"][index_filled_atmosphere] = [
         [0.14, 0.14, 0.14, 0.14],

--- a/tests/models/abiotic/test_energy_balance.py
+++ b/tests/models/abiotic/test_energy_balance.py
@@ -314,7 +314,7 @@ def test_solve_canopy_temperature(
         )
 
     messages = [record.getMessage() for record in caplog.records]
-    assert any("did not converge" in msg for msg in messages)
+    assert any("converge" in msg for msg in messages)
 
     assert isinstance(result, np.ndarray)
     assert result.shape == data["canopy_temperature"][canopy_index].shape

--- a/tests/models/abiotic/test_energy_balance.py
+++ b/tests/models/abiotic/test_energy_balance.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 
+from virtual_ecosystem.core.logger import LOGGER
 from virtual_ecosystem.models.abiotic.abiotic_tools import (
     compute_layer_thickness_for_varying_canopy,
 )
@@ -272,7 +273,10 @@ def test_energy_balance_return_fluxes(
 
 
 def test_solve_canopy_temperature(
-    dummy_climate_data_varying_canopy, fixture_core_components, fixture_core_constants
+    dummy_climate_data_varying_canopy,
+    fixture_core_components,
+    fixture_core_constants,
+    caplog,
 ):
     """Test solving canopy temperature with Newton method."""
 
@@ -284,25 +288,33 @@ def test_solve_canopy_temperature(
     canopy_index = fixture_core_components.layer_structure.index_filled_canopy
     evapotranspiration = data["canopy_evaporation"] + data["transpiration"]
 
-    result = solve_canopy_temperature(
-        canopy_temperature_initial=data["canopy_temperature"][canopy_index].to_numpy(),
-        air_temperature=data["air_temperature"][canopy_index].to_numpy(),
-        evapotranspiration=evapotranspiration[canopy_index].to_numpy() / 730,
-        absorbed_radiation_canopy=data["shortwave_absorption"][canopy_index].to_numpy(),
-        specific_heat_air=data["specific_heat_air"][canopy_index].to_numpy(),
-        density_air=data["density_air"][canopy_index].to_numpy(),
-        aerodynamic_resistance=data["aerodynamic_resistance_canopy"].to_numpy(),
-        latent_heat_vapourisation=data["latent_heat_vapourisation"][
-            canopy_index
-        ].to_numpy()
-        * 1000,
-        emissivity_leaf=0.96,
-        stefan_boltzmann_constant=fixture_core_constants.stefan_boltzmann_constant,
-        zero_Celsius=fixture_core_constants.zero_Celsius,
-        seconds_to_hour=fixture_core_constants.seconds_to_hour,
-        return_fluxes=False,
-        maxiter=100,
-    )
+    with caplog.at_level(LOGGER.level):
+        result = solve_canopy_temperature(
+            canopy_temperature_initial=data["canopy_temperature"][
+                canopy_index
+            ].to_numpy(),
+            air_temperature=data["air_temperature"][canopy_index].to_numpy(),
+            evapotranspiration=evapotranspiration[canopy_index].to_numpy() / 730,
+            absorbed_radiation_canopy=data["shortwave_absorption"][
+                canopy_index
+            ].to_numpy(),
+            specific_heat_air=data["specific_heat_air"][canopy_index].to_numpy(),
+            density_air=data["density_air"][canopy_index].to_numpy(),
+            aerodynamic_resistance=data["aerodynamic_resistance_canopy"].to_numpy(),
+            latent_heat_vapourisation=data["latent_heat_vapourisation"][
+                canopy_index
+            ].to_numpy()
+            * 1000,
+            emissivity_leaf=0.96,
+            stefan_boltzmann_constant=fixture_core_constants.stefan_boltzmann_constant,
+            zero_Celsius=fixture_core_constants.zero_Celsius,
+            seconds_to_hour=fixture_core_constants.seconds_to_hour,
+            return_fluxes=False,
+            maxiter=100,
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("did not converge" in msg for msg in messages)
 
     assert isinstance(result, np.ndarray)
     assert result.shape == data["canopy_temperature"][canopy_index].shape

--- a/tests/models/abiotic/test_energy_balance.py
+++ b/tests/models/abiotic/test_energy_balance.py
@@ -108,7 +108,7 @@ def test_calculate_sensible_heat_flux(
         specific_heat_air=data["specific_heat_air"][index].to_numpy(),
         air_temperature=data["air_temperature"][index].to_numpy(),
         surface_temperature=data["canopy_temperature"][index].to_numpy(),
-        aerodynamic_resistance=data["aerodynamic_resistance_canopy"][index].to_numpy(),
+        aerodynamic_resistance=data["aerodynamic_resistance_canopy"].to_numpy(),
     )
 
     # Assert all elements are close
@@ -207,9 +207,7 @@ def test_energy_balance_residual_only(
         absorbed_radiation_canopy=data["shortwave_absorption"][canopy_index].to_numpy(),
         specific_heat_air=data["specific_heat_air"][canopy_index].to_numpy(),
         density_air=data["density_air"][canopy_index].to_numpy(),
-        aerodynamic_resistance=data["aerodynamic_resistance_canopy"][
-            canopy_index
-        ].to_numpy(),
+        aerodynamic_resistance=data["aerodynamic_resistance_canopy"].to_numpy(),
         latent_heat_vapourisation=data["latent_heat_vapourisation"][
             canopy_index
         ].to_numpy()
@@ -248,9 +246,7 @@ def test_energy_balance_return_fluxes(
         absorbed_radiation_canopy=data["shortwave_absorption"][canopy_index].to_numpy(),
         specific_heat_air=data["specific_heat_air"][canopy_index].to_numpy(),
         density_air=data["density_air"][canopy_index].to_numpy(),
-        aerodynamic_resistance=data["aerodynamic_resistance_canopy"][
-            canopy_index
-        ].to_numpy(),
+        aerodynamic_resistance=data["aerodynamic_resistance_canopy"].to_numpy(),
         latent_heat_vapourisation=data["latent_heat_vapourisation"][
             canopy_index
         ].to_numpy()
@@ -295,9 +291,7 @@ def test_solve_canopy_temperature(
         absorbed_radiation_canopy=data["shortwave_absorption"][canopy_index].to_numpy(),
         specific_heat_air=data["specific_heat_air"][canopy_index].to_numpy(),
         density_air=data["density_air"][canopy_index].to_numpy(),
-        aerodynamic_resistance=data["aerodynamic_resistance_canopy"][
-            canopy_index
-        ].to_numpy(),
+        aerodynamic_resistance=data["aerodynamic_resistance_canopy"].to_numpy(),
         latent_heat_vapourisation=data["latent_heat_vapourisation"][
             canopy_index
         ].to_numpy()
@@ -344,9 +338,7 @@ def test_update_air_temperature(
         surface_temperature=data["canopy_temperature"][canopy_index].to_numpy(),
         specific_heat_air=data["specific_heat_air"][canopy_index].to_numpy(),
         density_air=data["density_air"][canopy_index].to_numpy(),
-        aerodynamic_resistance=data["aerodynamic_resistance_canopy"][
-            canopy_index
-        ].to_numpy(),
+        aerodynamic_resistance=data["aerodynamic_resistance_canopy"].to_numpy(),
         mixing_layer_thickness=above_ground_layer_thickness[1:-1],
     )
 

--- a/tests/models/abiotic/test_wind.py
+++ b/tests/models/abiotic/test_wind.py
@@ -31,7 +31,7 @@ def test_calculate_roughness_length_momentum(dummy_climate_data_varying_canopy):
         canopy_height=dummy_climate_data_varying_canopy["layer_heights"][1].to_numpy(),
         leaf_area_index=np.array([np.nan, 0.0, 7, 0.0]),
         zero_plane_displacement=np.array([0.0, 0.0, 27.58673, 0.0]),
-        substrate_surface_drag_coefficient=0.003,
+        substrate_surface_roughness_length=0.003,
         roughness_element_drag_coefficient=0.3,
         roughness_sublayer_depth_parameter=0.193,
         max_ratio_wind_to_friction_velocity=0.3,

--- a/virtual_ecosystem/models/abiotic/energy_balance.py
+++ b/virtual_ecosystem/models/abiotic/energy_balance.py
@@ -458,7 +458,7 @@ def solve_canopy_temperature(
                     ),
                     density_air=np.array([[density_air[i, j]]], dtype=np.float64),
                     aerodynamic_resistance=np.array(
-                        [[aerodynamic_resistance[i, j]]], dtype=np.float64
+                        [[aerodynamic_resistance[i]]], dtype=np.float64
                     ),
                     latent_heat_vapourisation=np.array(
                         [[latent_heat_vapourisation[i, j]]], dtype=np.float64
@@ -497,6 +497,10 @@ def solve_canopy_temperature(
                 )
 
             except RuntimeError:
+                print(
+                    "Warning: Canopy temperature solver did not converge."
+                    "Using last best estimate."
+                )
                 solved_temperature[i, j] = best_estimate[0]  # use last known good value
 
     return solved_temperature

--- a/virtual_ecosystem/models/abiotic/energy_balance.py
+++ b/virtual_ecosystem/models/abiotic/energy_balance.py
@@ -516,10 +516,17 @@ def solve_canopy_temperature(
         }
     )
 
-    LOGGER.info(
-        f"Solver finished: {sum(not c['converged'] for c in convergence_info)} / "
-        f"{nrows * ncols} cells did not converge"
-    )
+    # Log a message based on whether all cells converged or not
+    num_not_converged = sum(not c["converged"] for c in convergence_info)
+    total_cells = nrows * ncols
+
+    if num_not_converged == 0:
+        LOGGER.info(f"Solver finished successfully: all {total_cells} cells converged.")
+    else:
+        LOGGER.warning(
+            f"Solver finished with issues: {num_not_converged} / {total_cells} cells"
+            " did not converge. Best estimates were used for those cells."
+        )
 
     return solved_temperature
 

--- a/virtual_ecosystem/models/abiotic/energy_balance.py
+++ b/virtual_ecosystem/models/abiotic/energy_balance.py
@@ -50,6 +50,7 @@ from scipy.optimize import newton
 from xarray import DataArray
 
 from virtual_ecosystem.core.core_components import LayerStructure
+from virtual_ecosystem.core.logger import LOGGER
 from virtual_ecosystem.models.abiotic import wind
 from virtual_ecosystem.models.abiotic.abiotic_tools import set_unintended_nan_to_zero
 
@@ -432,6 +433,7 @@ def solve_canopy_temperature(
 
     nrows, ncols = canopy_temperature_initial.shape
     solved_temperature = np.empty_like(canopy_temperature_initial, dtype=np.float64)
+    convergence_info = []
 
     # TODO this loop might be a potential performance bottleneck.
     # The function only takes scalar values
@@ -482,9 +484,11 @@ def solve_canopy_temperature(
             x0 = canopy_temperature_initial[i, j]
 
             best_estimate = [x0]  # use a mutable object to track updates
+            iteration_history = []
 
             # Wrapper to extract best estimate if function does not converge
             def tracked_func(x):
+                iteration_history.append(x)
                 best_estimate[0] = x  # update best estimate
                 return residual_func(x)
 
@@ -495,13 +499,27 @@ def solve_canopy_temperature(
                     maxiter=maxiter,
                     tol=0.01,
                 )
+                converged = True
 
             except RuntimeError:
-                print(
-                    "Warning: Canopy temperature solver did not converge."
-                    "Using last best estimate."
-                )
                 solved_temperature[i, j] = best_estimate[0]  # use last known good value
+                converged = False
+
+    convergence_info.append(
+        {
+            "row": i,
+            "col": j,
+            "converged": converged,
+            "final_value": solved_temperature[i, j],
+            "best_estimate": best_estimate[0],
+            "history": iteration_history,
+        }
+    )
+
+    LOGGER.info(
+        f"Solver finished: {sum(not c['converged'] for c in convergence_info)} / "
+        f"{nrows * ncols} cells did not converge"
+    )
 
     return solved_temperature
 

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -148,21 +148,27 @@ def run_microclimate(
     )
 
     # Aerodynamic resistance canopy, [s m-1]
-    aerodynamic_resistance_canopy = wind.calculate_aerodynamic_resistance(
-        wind_heights=data["layer_heights"][
-            layer_structure.index_filled_canopy
-        ].to_numpy(),
-        roughness_length=roughness_length,
-        zero_plane_displacement=zero_plane_displacement,
-        wind_speed=wind_profile[1:-1],
-        von_karman_constant=core_constants.von_karmans_constant,
+    # TODO Revisit when model produces realistic forest structure and/or calibrate
+    # default value.
+    # Very high r_a (>1000 s/m) breaks Newton method, but physically possible when:
+    #    - LAI is small
+    #    - wind speed is very low (u < 0.5 m/s)
+    #    - roughness length is small (z0 < 0.01 m)
+    #
+    # aerodynamic_resistance_canopy = wind.calculate_aerodynamic_resistance(
+    #     wind_heights=canopy_height,
+    #     roughness_length=roughness_length,
+    #     zero_plane_displacement=zero_plane_displacement,
+    #     wind_speed=wind_profile[1],
+    #     von_karman_constant=core_constants.von_karmans_constant,
+    # )
+    aerodynamic_resistance_canopy = np.repeat(
+        abiotic_constants.aerodynamic_resistance_canopy_default, data.grid.n_cells
     )
 
-    aerodynamic_resistance_canopy_out = layer_structure.from_template()
-    aerodynamic_resistance_canopy_out[layer_structure.index_filled_canopy] = (
-        aerodynamic_resistance_canopy
+    output["aerodynamic_resistance_canopy"] = DataArray(
+        aerodynamic_resistance_canopy, dims="cell_id"
     )
-    output["aerodynamic_resistance_canopy"] = aerodynamic_resistance_canopy_out
 
     # Aerodynamic resistance soil, [s m-1]
     aerodynamic_resistance_soil = data["aerodynamic_resistance_surface"].to_numpy()
@@ -177,7 +183,7 @@ def run_microclimate(
 
     #  Ventilation rate above canopy, [s-1]
     ventilation_rate = wind.calculate_ventilation_rate(
-        aerodynamic_resistance=aerodynamic_resistance_canopy[0],
+        aerodynamic_resistance=aerodynamic_resistance_canopy,
         characteristic_height=canopy_height + zero_plane_displacement,
     )
 
@@ -471,12 +477,6 @@ def run_microclimate(
     net_radiation[layer_structure.index_filled_canopy] = net_radiation_canopy
     net_radiation[layer_structure.index_topsoil_scalar] = net_radiation_soil
     output["net_radiation"] = net_radiation
-
-    aero_resistance_canopy_out = layer_structure.from_template()
-    aero_resistance_canopy_out[layer_structure.index_filled_canopy] = (
-        aerodynamic_resistance_canopy
-    )
-    output["aerodynamic_resistance_canopy"] = aero_resistance_canopy_out
 
     latent_heat_vapourisation_out = layer_structure.from_template()
     latent_heat_vapourisation_out[layer_structure.index_filled_atmosphere] = (

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -105,8 +105,8 @@ def run_microclimate(
         canopy_height=canopy_height,
         leaf_area_index=leaf_area_index_sum,
         zero_plane_displacement=zero_plane_displacement,
-        substrate_surface_drag_coefficient=(
-            abiotic_constants.substrate_surface_drag_coefficient
+        substrate_surface_roughness_length=(
+            abiotic_constants.substrate_surface_roughness_length
         ),
         roughness_element_drag_coefficient=(
             abiotic_constants.roughness_element_drag_coefficient

--- a/virtual_ecosystem/models/abiotic/model_config.py
+++ b/virtual_ecosystem/models/abiotic/model_config.py
@@ -157,6 +157,9 @@ class AbioticConstants(AbioticSharedConstants):
     initial_flux_value: float = 0.001
     """Initial non-zero fill value for energy fluxes, [W m-2]."""
 
+    aerodynamic_resistance_canopy_default: float = 12.5
+    """Default aerodynamic resistance of the canopy, [s m-1]."""
+
 
 class AbioticConfiguration(ModelConfigurationRoot):
     """The abiotic model configuration."""

--- a/virtual_ecosystem/models/abiotic/model_config.py
+++ b/virtual_ecosystem/models/abiotic/model_config.py
@@ -53,13 +53,12 @@ class AbioticConstants(AbioticSharedConstants):
     Implementation after :cite:t:`maclean_microclimc_2021`, value is taken from
     :cite:t:`raupach_simplified_1994`."""
 
-    substrate_surface_drag_coefficient: float = 0.003
-    """Substrate-surface drag coefficient, dimensionless.
+    substrate_surface_roughness_length: float = 0.003
+    """Substrate-surface roughness length, m.
 
-    The substrate-surface drag coefficient represents the resistance encountered by an
-    object moving on or through a surface and varies based on the nature of the
-    surface and the object's properties. Here, it affects how wind speed is altered by a
-    surface. Implementation and value from :cite:t:`maclean_microclimc_2021`."""
+    The substrate-surface roughness length is the "baseline roughness" of the ground
+    itself before adding vegetation on top. Implementation and value from
+    :cite:t:`maclean_microclimc_2021`."""
 
     roughness_element_drag_coefficient: float = 0.3
     """Roughness-element drag coefficient, dimensionless.

--- a/virtual_ecosystem/models/abiotic/wind.py
+++ b/virtual_ecosystem/models/abiotic/wind.py
@@ -48,7 +48,7 @@ def calculate_roughness_length_momentum(
     canopy_height: NDArray[np.floating],
     leaf_area_index: NDArray[np.floating],
     zero_plane_displacement: NDArray[np.floating],
-    substrate_surface_drag_coefficient: float,
+    substrate_surface_roughness_length: float,
     roughness_element_drag_coefficient: float,
     roughness_sublayer_depth_parameter: float,
     max_ratio_wind_to_friction_velocity: float,
@@ -68,8 +68,8 @@ def calculate_roughness_length_momentum(
         zero_plane_displacement: Height above the actual ground where the wind speed is
             theoretically reduced to zero due to the obstruction caused by the roughness
             elements (like trees or buildings), [m]
-        substrate_surface_drag_coefficient: Substrate-surface drag coefficient,
-            dimensionless
+        substrate_surface_roughness_length: Substrate-surface roughness length is the
+            baseline roughness of the ground itself before adding vegetation, [m]
         roughness_element_drag_coefficient: Roughness-element drag coefficient
         roughness_sublayer_depth_parameter: Parameter that characterizes the roughness
             sublayer depth, dimensionless
@@ -86,30 +86,25 @@ def calculate_roughness_length_momentum(
 
     # Calculate ratio of wind velocity to friction velocity
     ratio_wind_to_friction_velocity = np.sqrt(
-        substrate_surface_drag_coefficient
+        substrate_surface_roughness_length
         + (roughness_element_drag_coefficient * leaf_area_index) / 2
     )
 
-    # If the ratio of wind velocity to friction velocity is larger than the set maximum,
-    # set the value to set maximum
-    set_maximum_ratio = np.where(
-        ratio_wind_to_friction_velocity > max_ratio_wind_to_friction_velocity,
-        max_ratio_wind_to_friction_velocity,
-        ratio_wind_to_friction_velocity,
+    # Set wind to friction velocity ratio
+    ratio_wind_to_friction_velocity = np.minimum(
+        ratio_wind_to_friction_velocity, max_ratio_wind_to_friction_velocity
     )
 
     # Calculate initial roughness length
     initial_roughness_length = (canopy_height - zero_plane_displacement) * np.exp(
-        -von_karman_constant * (1 / set_maximum_ratio)
+        -von_karman_constant * (1 / ratio_wind_to_friction_velocity)
         - roughness_sublayer_depth_parameter
     )
 
     # If roughness smaller than the substrate surface drag coefficient, set to value to
     # the substrate surface drag coefficient
-    roughness_length = np.where(
-        initial_roughness_length < substrate_surface_drag_coefficient,
-        substrate_surface_drag_coefficient,
-        initial_roughness_length,
+    roughness_length = np.maximum(
+        initial_roughness_length, substrate_surface_roughness_length
     )
 
     # If roughness length in nan, zero or below sero, set to minimum value

--- a/virtual_ecosystem/models/abiotic/wind.py
+++ b/virtual_ecosystem/models/abiotic/wind.py
@@ -37,11 +37,11 @@ def calculate_zero_plane_displacement(
     # Calculate zero displacement height
     scale_displacement = np.sqrt(zero_plane_scaling_parameter * displacement)
     zero_plane_displacement = (
-        (1 - (1 - np.exp(-scale_displacement)) / scale_displacement) * canopy_height,
-    )
+        1 - (1 - np.exp(-scale_displacement)) / scale_displacement
+    ) * canopy_height
 
     # No displacement in absence of vegetation
-    return np.nan_to_num(zero_plane_displacement, nan=0.0).squeeze()
+    return np.nan_to_num(zero_plane_displacement, nan=0.0)
 
 
 def calculate_roughness_length_momentum(


### PR DESCRIPTION
It turns out that the Newton method converges when the input parameters are sensible, as confirmed by new logging message.

The aerodynamic resistance seems to have quite a strong influence and is currently extremely high due to the canopy structure. My tentative solution is to set a fixed resistance for the canopy (to be solved later in calibration - reopened #967) to find out what else is causing the problems (the model runs now much longer until the soil freezes, to be addressed in #1154).

Also renamed a parameter in `wind.py` which was wrong in the reference...

Fixes #1022 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
