### PR TITLE
Change mycorrhizal supply calculation to prevent negative populations

### DIFF
--- a/tests/models/soil/conftest.py
+++ b/tests/models/soil/conftest.py
@@ -71,6 +71,7 @@ def dummy_carbon_data(fixture_core_components):
         "animal_arbuscular_mycorrhiza_consumption": [3.43e-4, 4.29e-4, 6.0e-4, 2.30e-4],
         "decay_of_fungal_fruiting_bodies": [2.2499e-4, 5.8168e-4, 3.2185e-4, 2.5871e-3],
         "new_fungal_fruiting_body_production": [0.0, 0.0, 0.0, 0.0],
+        "mean_annual_temperature": [20.0, 20.0, 20.0, 20.0],
     }
 
     for var_name, var_values in data_values.items():

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -41,6 +41,8 @@ REQUIRED_INIT_VAR_LOG = (
     (DEBUG, "soil model: required var 'soil_p_pool_labile' checked"),
     (DEBUG, "soil model: required var 'pH' checked"),
     (DEBUG, "soil model: required var 'clay_fraction' checked"),
+    (DEBUG, "soil model: required var 'soil_moisture' checked"),
+    (DEBUG, "soil model: required var 'mean_annual_temperature' checked"),
 )
 POST_SETUP_LOG = (
     *REQUIRED_INIT_VAR_LOG,
@@ -76,6 +78,9 @@ def test_soil_model_initialization(
         enzyme_classes=enzyme_classes,
         soil_moisture_saturation=fixture_hydrology_constants.soil_moisture_saturation,
         soil_moisture_residual=fixture_hydrology_constants.soil_moisture_residual,
+        air_entry_potential_inverse=fixture_hydrology_constants.air_entry_potential_inverse,
+        van_genuchten_nonlinearily_parameter=fixture_hydrology_constants.van_genuchten_nonlinearily_parameter,
+        m_to_kpa=fixture_hydrology_constants.m_to_kpa,
     )
 
     # In cases where it passes then checks that the object has the right properties
@@ -162,6 +167,9 @@ def test_soil_model_initialization_bounds_error(
             enzyme_classes=enzyme_classes,
             soil_moisture_saturation=fixture_hydrology_constants.soil_moisture_saturation,
             soil_moisture_residual=fixture_hydrology_constants.soil_moisture_residual,
+            air_entry_potential_inverse=fixture_hydrology_constants.air_entry_potential_inverse,
+            van_genuchten_nonlinearily_parameter=fixture_hydrology_constants.van_genuchten_nonlinearily_parameter,
+            m_to_kpa=fixture_hydrology_constants.m_to_kpa,
         )
 
     # Final check that expected logging entries are produced
@@ -195,6 +203,9 @@ def test_soil_model_all_pools_positive(
         enzyme_classes=enzyme_classes,
         soil_moisture_saturation=fixture_hydrology_constants.soil_moisture_saturation,
         soil_moisture_residual=fixture_hydrology_constants.soil_moisture_residual,
+        air_entry_potential_inverse=fixture_hydrology_constants.air_entry_potential_inverse,
+        van_genuchten_nonlinearily_parameter=fixture_hydrology_constants.van_genuchten_nonlinearily_parameter,
+        m_to_kpa=fixture_hydrology_constants.m_to_kpa,
     )
 
     assert soil_model._all_pools_positive()
@@ -564,6 +575,7 @@ def test_order_independance(
         "animal_ectomycorrhiza_consumption",
         "animal_arbuscular_mycorrhiza_consumption",
         "decay_of_fungal_fruiting_bodies",
+        "mean_annual_temperature",
     ]
     for not_pool in not_pools:
         new_data[not_pool] = dummy_carbon_data[not_pool]
@@ -749,9 +761,9 @@ def test_calculate_dissolved_nutrient_concentrations_negative(fixture_soil_model
         ),
         pytest.param(
             {
-                "ecto_supply_limit_n": [0.0, 0.0004152, 0.0, 0.00160258],
+                "ecto_supply_limit_n": [0.0, 0.0, 0.0, 0.0],
                 "ecto_supply_limit_p": [0.0, 0.0, 0.0, 0.0],
-                "arbuscular_supply_limit_n": [0.0, 0.00046239, 0.0, 0.00384278],
+                "arbuscular_supply_limit_n": [0.0, 0.0, 0.0, 0.0],
                 "arbuscular_supply_limit_p": [0.0, 0.0, 0.0, 0.0],
             },
             True,

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -41,7 +41,7 @@ REQUIRED_INIT_VAR_LOG = (
     (DEBUG, "soil model: required var 'soil_p_pool_labile' checked"),
     (DEBUG, "soil model: required var 'pH' checked"),
     (DEBUG, "soil model: required var 'clay_fraction' checked"),
-    (DEBUG, "soil model: required var 'soil_moisture' checked"),
+    (DEBUG, "soil model: required var 'matric_potential' checked"),
     (DEBUG, "soil model: required var 'mean_annual_temperature' checked"),
 )
 POST_SETUP_LOG = (
@@ -761,9 +761,9 @@ def test_calculate_dissolved_nutrient_concentrations_negative(fixture_soil_model
         ),
         pytest.param(
             {
-                "ecto_supply_limit_n": [0.0, 0.0, 0.0, 0.0],
+                "ecto_supply_limit_n": [0.0, 0.00033416, 0.0, 0.0],
                 "ecto_supply_limit_p": [0.0, 0.0, 0.0, 0.0],
-                "arbuscular_supply_limit_n": [0.0, 0.0, 0.0, 0.0],
+                "arbuscular_supply_limit_n": [0.0, 0.00037213, 0.0, 0.0],
                 "arbuscular_supply_limit_p": [0.0, 0.0, 0.0, 0.0],
             },
             True,

--- a/virtual_ecosystem/models/abiotic_simple/abiotic_simple_model.py
+++ b/virtual_ecosystem/models/abiotic_simple/abiotic_simple_model.py
@@ -160,6 +160,10 @@ class AbioticSimpleModel(
         the reference vapour pressure deficit for all time steps. Both variables are
         added directly to the self.data object.
 
+        TODO - Unlike the abiotic model this init does not populate initial values for
+        the air temperatures. This is something that might need to be reconsidered in
+        future.
+
         Args:
             model_configuration: Configuration object from the abiotic_simple model.
             abiotic_constants: Provides required abiotic constants.

--- a/virtual_ecosystem/models/hydrology/hydrology_model.py
+++ b/virtual_ecosystem/models/hydrology/hydrology_model.py
@@ -99,6 +99,7 @@ class HydrologyModel(
     ),
     vars_populated_by_init=(
         "soil_moisture",
+        "matric_potential",
         "groundwater_storage",
         "aerodynamic_resistance_surface",
         "aerodynamic_resistance_canopy",
@@ -113,7 +114,6 @@ class HydrologyModel(
         "bypass_flow",
         "soil_evaporation",
         "vertical_flow",
-        "matric_potential",
         "subsurface_flow",
         "baseflow",
         "surface_runoff_routed_plus_local",
@@ -292,6 +292,25 @@ class HydrologyModel(
             soil_layer_thickness=self.soil_layer_thickness_mm,
             layer_structure=self.layer_structure,
             initial_soil_moisture=self.initial_soil_moisture,
+        )
+
+        # Make initial guess of the matric potential based on the soil moisture
+        effective_saturation = hydrology_tools.calculate_effective_saturation(
+            soil_moisture=self.data["soil_moisture"][
+                self.layer_structure.index_all_soil
+            ].to_numpy()
+            / self.soil_layer_thickness_mm,
+            soil_moisture_saturation=self.model_constants.soil_moisture_saturation,
+            soil_moisture_residual=self.model_constants.soil_moisture_residual,
+        )
+        matric_potential = below_ground.calculate_matric_potential(
+            effective_saturation=effective_saturation,
+            air_entry_potential_inverse=self.model_constants.air_entry_potential_inverse,
+            van_genuchten_nonlinearily_parameter=self.model_constants.van_genuchten_nonlinearily_parameter,
+        )
+        self.data["matric_potential"] = self.layer_structure.from_template()
+        self.data["matric_potential"][self.layer_structure.index_all_soil] = DataArray(
+            matric_potential * self.model_constants.m_to_kpa, dims=["layers", "cell_id"]
         )
 
         # Create initial groundwater storage variable with two layers, [mm]

--- a/virtual_ecosystem/models/soil/soil_model.py
+++ b/virtual_ecosystem/models/soil/soil_model.py
@@ -31,10 +31,6 @@ from virtual_ecosystem.core.data import Data
 from virtual_ecosystem.core.exceptions import InitialisationError
 from virtual_ecosystem.core.logger import LOGGER
 from virtual_ecosystem.core.model_config import CoreConfiguration, CoreConstants
-from virtual_ecosystem.models.hydrology.below_ground import (
-    calculate_effective_saturation,
-    calculate_matric_potential,
-)
 from virtual_ecosystem.models.hydrology.model_config import (
     HydrologyConfiguration,
 )
@@ -98,7 +94,7 @@ class SoilModel(
         "soil_p_pool_labile",
         "pH",
         "clay_fraction",
-        "soil_moisture",
+        "matric_potential",
         "mean_annual_temperature",
     ),
     vars_populated_by_init=(
@@ -302,9 +298,6 @@ class SoilModel(
             enzyme_classes=enzyme_classes,
             soil_moisture_saturation=hydrology_configuration.constants.soil_moisture_saturation,
             soil_moisture_residual=hydrology_configuration.constants.soil_moisture_residual,
-            air_entry_potential_inverse=hydrology_configuration.constants.air_entry_potential_inverse,
-            van_genuchten_nonlinearily_parameter=hydrology_configuration.constants.van_genuchten_nonlinearily_parameter,
-            m_to_kpa=hydrology_configuration.constants.m_to_kpa,
         )
 
     def _setup(
@@ -314,9 +307,6 @@ class SoilModel(
         enzyme_classes: dict[str, SoilEnzymeClass],
         soil_moisture_saturation: float,
         soil_moisture_residual: float,
-        air_entry_potential_inverse: float,
-        van_genuchten_nonlinearily_parameter: float,
-        m_to_kpa: float,
         **kwargs: Any,
     ) -> None:
         """Function to setup up the soil model."""
@@ -327,12 +317,9 @@ class SoilModel(
         self.microbial_groups = microbial_groups
         self.enzyme_classes = enzyme_classes
 
-        # Store the four required hydrology constants
+        # Store the required hydrology constants
         self.soil_moisture_saturation = soil_moisture_saturation
         self.soil_moisture_residual = soil_moisture_residual
-        self.air_entry_potential_inverse = air_entry_potential_inverse
-        self.van_genuchten_nonlinearily_parameter = van_genuchten_nonlinearily_parameter
-        self.m_to_kpa = m_to_kpa
 
         # Calculate dissolved amounts of each inorganic nutrient
         dissolved_nutrient_pools = self.calculate_dissolved_nutrient_concentrations()
@@ -641,11 +628,6 @@ class SoilModel(
         converted from the per volume units used in the soil model, to the per area
         units used in the plant model.
 
-        TODO - This function currently calculates matric potential based on soil
-        moisture when being used within model initialisation. At some point this should
-        be migrated to the hydrology model init/setup as that is a more natural home for
-        this calculation
-
         TODO - In model initialisation, the annual mean temperature is used as an
         estimate of the soil temperature as soil temperatures are not yet known. This
         issue won't be resolved until we have decided what we are doing about model spin
@@ -662,46 +644,26 @@ class SoilModel(
         """
 
         if not init:
-            # Average soil temperature and water potential over the microbially active
-            # layers, and then use to calculate the environmental factors
-            soil_water_potential = (
-                average_water_potential_over_microbially_active_layers(
-                    water_potentials=self.data["matric_potential"],
+            averaged_soil_temperature = (
+                average_temperature_over_microbially_active_layers(
+                    soil_temperatures=self.data["soil_temperature"],
+                    surface_temperature=self.data["air_temperature"][
+                        self.layer_structure.index_surface_scalar
+                    ].to_numpy(),
                     layer_structure=self.layer_structure,
                 )
-            )
-            soil_temperature = average_temperature_over_microbially_active_layers(
-                soil_temperatures=self.data["soil_temperature"],
-                surface_temperature=self.data["air_temperature"][
-                    self.layer_structure.index_surface_scalar
-                ].to_numpy(),
-                layer_structure=self.layer_structure,
             )
         else:
             # As soil temperature hasn't be calculated yet we assume that it matches the
             # mean annual temperature (a common assumption for deeper soil layers)
-            soil_temperature = self.data["mean_annual_temperature"].to_numpy()
+            averaged_soil_temperature = self.data["mean_annual_temperature"].to_numpy()
 
-            # Matric potential hasn't been found yet, so we calculate it based on soil
-            # effective saturation (and then average across layers)
-            effective_saturation = calculate_effective_saturation(
-                soil_moisture=self.data["soil_moisture"].to_numpy(),
-                soil_moisture_saturation=self.soil_moisture_saturation,
-                soil_moisture_residual=self.soil_moisture_residual,
-            )
-            matric_potential = calculate_matric_potential(
-                effective_saturation=effective_saturation,
-                air_entry_potential_inverse=self.air_entry_potential_inverse,
-                van_genuchten_nonlinearily_parameter=self.van_genuchten_nonlinearily_parameter,
-            )
-            soil_water_potential = (
-                average_water_potential_over_microbially_active_layers(
-                    water_potentials=DataArray(
-                        matric_potential * self.m_to_kpa, dims=["cell_id", "layers"]
-                    ),
-                    layer_structure=self.layer_structure,
-                )
-            )
+        # Average soil temperature and water potential over the microbially active
+        # layers, and then use to calculate the environmental factors
+        soil_water_potential = average_water_potential_over_microbially_active_layers(
+            water_potentials=self.data["matric_potential"],
+            layer_structure=self.layer_structure,
+        )
 
         env_factors = calculate_environmental_effect_factors(
             soil_water_potential=soil_water_potential,
@@ -718,7 +680,7 @@ class SoilModel(
             soil_p_pool_dop=self.data["soil_p_pool_dop"].to_numpy(),
             soil_p_pool_labile=self.data["soil_p_pool_labile"].to_numpy(),
             microbe_pool_size=self.data["soil_c_pool_ectomycorrhiza"].to_numpy(),
-            soil_temp=soil_temperature,
+            soil_temp=averaged_soil_temperature,
             microbial_group=self.microbial_groups["ectomycorrhiza"],
             env_factors=env_factors,
         )
@@ -730,7 +692,7 @@ class SoilModel(
             soil_p_pool_dop=self.data["soil_p_pool_dop"].to_numpy(),
             soil_p_pool_labile=self.data["soil_p_pool_labile"].to_numpy(),
             microbe_pool_size=self.data["soil_c_pool_arbuscular_mycorrhiza"].to_numpy(),
-            soil_temp=soil_temperature,
+            soil_temp=averaged_soil_temperature,
             microbial_group=self.microbial_groups["arbuscular_mycorrhiza"],
             env_factors=env_factors,
         )

--- a/virtual_ecosystem/models/soil/soil_model.py
+++ b/virtual_ecosystem/models/soil/soil_model.py
@@ -31,6 +31,10 @@ from virtual_ecosystem.core.data import Data
 from virtual_ecosystem.core.exceptions import InitialisationError
 from virtual_ecosystem.core.logger import LOGGER
 from virtual_ecosystem.core.model_config import CoreConfiguration, CoreConstants
+from virtual_ecosystem.models.hydrology.below_ground import (
+    calculate_effective_saturation,
+    calculate_matric_potential,
+)
 from virtual_ecosystem.models.hydrology.model_config import (
     HydrologyConfiguration,
 )
@@ -94,6 +98,8 @@ class SoilModel(
         "soil_p_pool_labile",
         "pH",
         "clay_fraction",
+        "soil_moisture",
+        "mean_annual_temperature",
     ),
     vars_populated_by_init=(
         "dissolved_nitrate",
@@ -296,6 +302,9 @@ class SoilModel(
             enzyme_classes=enzyme_classes,
             soil_moisture_saturation=hydrology_configuration.constants.soil_moisture_saturation,
             soil_moisture_residual=hydrology_configuration.constants.soil_moisture_residual,
+            air_entry_potential_inverse=hydrology_configuration.constants.air_entry_potential_inverse,
+            van_genuchten_nonlinearily_parameter=hydrology_configuration.constants.van_genuchten_nonlinearily_parameter,
+            m_to_kpa=hydrology_configuration.constants.m_to_kpa,
         )
 
     def _setup(
@@ -305,6 +314,9 @@ class SoilModel(
         enzyme_classes: dict[str, SoilEnzymeClass],
         soil_moisture_saturation: float,
         soil_moisture_residual: float,
+        air_entry_potential_inverse: float,
+        van_genuchten_nonlinearily_parameter: float,
+        m_to_kpa: float,
         **kwargs: Any,
     ) -> None:
         """Function to setup up the soil model."""
@@ -315,9 +327,12 @@ class SoilModel(
         self.microbial_groups = microbial_groups
         self.enzyme_classes = enzyme_classes
 
-        # Store the two required hydrology constants
+        # Store the four required hydrology constants
         self.soil_moisture_saturation = soil_moisture_saturation
         self.soil_moisture_residual = soil_moisture_residual
+        self.air_entry_potential_inverse = air_entry_potential_inverse
+        self.van_genuchten_nonlinearily_parameter = van_genuchten_nonlinearily_parameter
+        self.m_to_kpa = m_to_kpa
 
         # Calculate dissolved amounts of each inorganic nutrient
         dissolved_nutrient_pools = self.calculate_dissolved_nutrient_concentrations()
@@ -626,13 +641,15 @@ class SoilModel(
         converted from the per volume units used in the soil model, to the per area
         units used in the plant model.
 
-        TODO - These supply limits can only be properly calculated once the soil
-        temperature and matric potential are known. At present these are only found once
-        the abiotic and hydrology models (respectively), are updated. Instead a
-        temperature of 25C and optimal water potential (set in the constants) are used.
-        Down the line we need to decide whether this inaccuracy is acceptable, or
-        whether the stage at which basic abiotic information gets calculated needs to
-        change.
+        TODO - This function currently calculates matric potential based on soil
+        moisture when being used within model initialisation. At some point this should
+        be migrated to the hydrology model init/setup as that is a more natural home for
+        this calculation
+
+        TODO - In model initialisation, the annual mean temperature is used as an
+        estimate of the soil temperature as soil temperatures are not yet known. This
+        issue won't be resolved until we have decided what we are doing about model spin
+        up
 
         Args:
             init: A boolean specifying whether this function is being called as part of
@@ -661,13 +678,29 @@ class SoilModel(
                 layer_structure=self.layer_structure,
             )
         else:
-            # Want to establish the maximum for optimal conditions, so use the water
-            # potential optimum from the constants, and arbitrarily select a soil
-            # temperature of 25C as "optimal"
-            soil_temperature = np.full_like(self.data["pH"].to_numpy(), 25.0)
-            soil_water_potential = np.full_like(
-                self.data["pH"].to_numpy(),
-                self.model_constants.soil_microbe_water_potential_optimum,
+            # As soil temperature hasn't be calculated yet we assume that it matches the
+            # mean annual temperature (a common assumption for deeper soil layers)
+            soil_temperature = self.data["mean_annual_temperature"].to_numpy()
+
+            # Matric potential hasn't been found yet, so we calculate it based on soil
+            # effective saturation (and then average across layers)
+            effective_saturation = calculate_effective_saturation(
+                soil_moisture=self.data["soil_moisture"].to_numpy(),
+                soil_moisture_saturation=self.soil_moisture_saturation,
+                soil_moisture_residual=self.soil_moisture_residual,
+            )
+            matric_potential = calculate_matric_potential(
+                effective_saturation=effective_saturation,
+                air_entry_potential_inverse=self.air_entry_potential_inverse,
+                van_genuchten_nonlinearily_parameter=self.van_genuchten_nonlinearily_parameter,
+            )
+            soil_water_potential = (
+                average_water_potential_over_microbially_active_layers(
+                    water_potentials=DataArray(
+                        matric_potential * self.m_to_kpa, dims=["cell_id", "layers"]
+                    ),
+                    layer_structure=self.layer_structure,
+                )
             )
 
         env_factors = calculate_environmental_effect_factors(


### PR DESCRIPTION

# Description

Negative mycorrhizal populations were occurring after the initial time step because the calculation of the maximum amount of nutrient that they can supply to the plant was using guesses for temperature and matric potential. This resulted in mycorrhizal fungi promising far more nutrient than they could provide (even from their existing biomass). I have partially addressed this overpromising by using mean annual temperature as a guess for the soil temperature (which is a fairly common assumption) and by calculating initial values for matric potential based on the initial values for soil moisture.

This partly addresses #835, but does not fully resolve it, as there is still no initial value for soil temperatures, and the initial value of matric potential could be significantly off. This is arguably an issue that won't be completely fixed until we have decided an approach to model spin up.

@vgro, one thing we should decide is whether the calculations make sense in their current location, or are better moved to the hydrology model init? (happy to do the work to move them if so)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
