### PR TITLE
removed understorey vegetation from leaf area index sum

### DIFF
--- a/virtual_ecosystem/models/abiotic_simple/microclimate_simple.py
+++ b/virtual_ecosystem/models/abiotic_simple/microclimate_simple.py
@@ -101,6 +101,9 @@ def run_simple_microclimate(
     output = {}
 
     # Sum leaf area index over all canopy layers, [m m-1]
+    # TODO This step excludes the understorey vegetation, assuming that the relationship
+    # between LAI and the variables is purely based on the vegetation above the 1.5m
+    # reference height.
     leaf_area_index_sum = data["leaf_area_index"][
         layer_structure.index_filled_canopy
     ].sum(dim="layers")

--- a/virtual_ecosystem/models/abiotic_simple/microclimate_simple.py
+++ b/virtual_ecosystem/models/abiotic_simple/microclimate_simple.py
@@ -101,7 +101,9 @@ def run_simple_microclimate(
     output = {}
 
     # Sum leaf area index over all canopy layers, [m m-1]
-    leaf_area_index_sum = data["leaf_area_index"].sum(dim="layers")
+    leaf_area_index_sum = data["leaf_area_index"][
+        layer_structure.index_filled_canopy
+    ].sum(dim="layers")
 
     # Interpolate atmospheric profiles
     for var in [

--- a/virtual_ecosystem/models/abiotic_simple/microclimate_simple.py
+++ b/virtual_ecosystem/models/abiotic_simple/microclimate_simple.py
@@ -101,9 +101,9 @@ def run_simple_microclimate(
     output = {}
 
     # Sum leaf area index over all canopy layers, [m m-1]
-    # TODO This step excludes the understorey vegetation, assuming that the relationship
-    # between LAI and the variables is purely based on the vegetation above the 1.5m
-    # reference height.
+    # This step excludes the understorey vegetation, assuming that the relationship
+    # between LAI and the variables is purely based on the vegetation above the
+    # measurement height of 1m :cite:p:`hardwick_relationship_2015`.
     leaf_area_index_sum = data["leaf_area_index"][
         layer_structure.index_filled_canopy
     ].sum(dim="layers")


### PR DESCRIPTION
The abiotic simple model is based on observations of temperatures at 1.5 m below a canopy. At the moment the model sums the LAI over all layers, including the understorey layer which has a very high LAI. That causes the soil to be freezing. Although the understorey vegetation takes some light from hitting the soil, the LAI is currently high and the cooling unrealistic.

I propose removing the understorey vegetation from the summing step. This does not solve the issue of a canopy being lower than 1.5m, but it gives a correct representation of the initial assumptions.

Fixes #1169 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

