### PR TITLE
Small fixes to prevent negative microbial populations from propagating further errors

### DIFF
--- a/tests/models/soil/test_pools.py
+++ b/tests/models/soil/test_pools.py
@@ -544,6 +544,30 @@ def test_calculate_maintenance_biomass_synthesis(
     assert np.allclose(actual_loss, expected_loss)
 
 
+def test_calculate_maintenance_biomass_synthesis_negative(
+    dummy_carbon_data, averaged_soil_temp, functional_groups
+):
+    """Check maintenance biomass synthesis handles negative populations correctly."""
+    from virtual_ecosystem.models.soil.pools import (
+        calculate_maintenance_biomass_synthesis,
+    )
+
+    # Replace two values with negative biomasses to check that negatives are handled
+    microbe_pool_size = dummy_carbon_data["soil_c_pool_bacteria"]
+    microbe_pool_size[1] = -0.456
+    microbe_pool_size[3] = -1.33e-3
+
+    expected_loss = [0.04254605, 0.0, 0.08862048, 0.0]
+
+    actual_loss = calculate_maintenance_biomass_synthesis(
+        microbe_pool_size=microbe_pool_size,
+        soil_temp=averaged_soil_temp,
+        microbial_group=functional_groups["bacteria"],
+    )
+
+    assert np.allclose(actual_loss, expected_loss)
+
+
 @pytest.mark.parametrize(
     "turnover,expected_decay",
     [

--- a/virtual_ecosystem/data_variables.toml
+++ b/virtual_ecosystem/data_variables.toml
@@ -1276,28 +1276,28 @@ variable_type = "float"
 axis = ["spatial"]
 description = "Limit on rate at which ectomycorrhizal fungi will supply nitrogen to their plant partners"
 name = "ecto_supply_limit_n"
-unit = "kg N m^-2"
+unit = "kg N m^-2 day^-1"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Limit on rate at which ectomycorrhizal fungi will supply phosphorus to their plant partners"
 name = "ecto_supply_limit_p"
-unit = "kg P m^-2"
+unit = "kg P m^-2 day^-1"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Limit on rate at which arbuscular mycorrhizal fungi will supply nitrogen to their plant partners"
 name = "arbuscular_supply_limit_n"
-unit = "kg N m^-2"
+unit = "kg N m^-2 day^-1"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Limit on rate at which arbuscular mycorrhizal fungi will supply phosphorus to their plant partners"
 name = "arbuscular_supply_limit_p"
-unit = "kg P m^-2"
+unit = "kg P m^-2 day^-1"
 variable_type = "float"
 
 [[variable]]

--- a/virtual_ecosystem/models/animal/decay.py
+++ b/virtual_ecosystem/models/animal/decay.py
@@ -565,7 +565,13 @@ class SoilPool:
                 for bacterial biomass [unitless]
         """
 
-        carbon_stock = data["soil_c_pool_bacteria"].sel(cell_id=self.cell_id).item()
+        carbon_stock = (
+            data["soil_c_pool_bacteria"]
+            .sel(cell_id=self.cell_id)
+            .where(lambda x: x >= 0)
+            .fillna(0)
+            .item()
+        )
 
         # Convert stock (kg m^-3) into mass by multiplying by grid square area and by
         # soil active depth
@@ -602,7 +608,11 @@ class SoilPool:
         """
 
         saprotrophic_stock = (
-            data["soil_c_pool_saprotrophic_fungi"].sel(cell_id=self.cell_id).item()
+            data["soil_c_pool_saprotrophic_fungi"]
+            .sel(cell_id=self.cell_id)
+            .where(lambda x: x >= 0)
+            .fillna(0)
+            .item()
         )
         arbuscular_mycorrhizal_stock = (
             data["soil_c_pool_arbuscular_mycorrhiza"]

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -1371,7 +1371,11 @@ def calculate_maintenance_biomass_synthesis(
         reference_temperature=microbial_group.reference_temperature,
     )
 
-    return microbial_group.turnover_rate * temp_factor * microbe_pool_size
+    return np.where(
+        microbe_pool_size >= 0.0,
+        microbial_group.turnover_rate * temp_factor * microbe_pool_size,
+        0.0,
+    )
 
 
 def calculate_enzyme_turnover(


### PR DESCRIPTION
# Description

Two changes here.

1) Negative microbial populations now no longer lose a negative amount of biomass to maintenance. Instead the biomass loss rate is zero
2) The animal available microbial consumption pools now treat any negative microbial pool as zero (previously this only happened for the two mycorrhizal pools)

These fixes are needed not just for the mycorrhizal problems (which a better long term solution for is described in #1197), but also because animal consumption will be potentially able to drive microbial pools negative. 

Fixes #1198

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
