### PR TITLE
initialised all variables in setup

### DIFF
--- a/docs/source/virtual_ecosystem/implementation/abiotic_simple_implementation.md
+++ b/docs/source/virtual_ecosystem/implementation/abiotic_simple_implementation.md
@@ -135,7 +135,7 @@ tags: [remove-input]
 display_markdown(
     generate_variable_table(
         "AbioticSimpleModel",
-        ["vars_populated_by_init", "vars_populated_by_first_update"],
+        ["vars_populated_by_init"],
     ),
     raw=True,
 )

--- a/docs/source/virtual_ecosystem/implementation/abiotic_simple_implementation.md
+++ b/docs/source/virtual_ecosystem/implementation/abiotic_simple_implementation.md
@@ -135,7 +135,7 @@ tags: [remove-input]
 display_markdown(
     generate_variable_table(
         "AbioticSimpleModel",
-        ["vars_populated_by_init"],
+        ["vars_populated_by_init", "vars_populated_by_first_update"],
     ),
     raw=True,
 )

--- a/docs/source/virtual_ecosystem/implementation/var_generator.py
+++ b/docs/source/virtual_ecosystem/implementation/var_generator.py
@@ -143,12 +143,22 @@ def generate_variable_table(model_name: str, var_attributes: list[str]) -> str:
         if vattr not in vattr_headings:
             raise ValueError("Unknown variable attribute")
 
+        # Get the tuple of variables for this attribute and then check there are
+        # actually any variables to report for this attribute.
+        vars_for_table = getattr(model, vattr)
+        if len(vars_for_table) == 0:
+            return_value += (
+                f"\n**{vattr_headings[vattr]}**\n\nThe {model_name} model does "
+                f"not include any variables in the `{vattr}` attribute."
+            )
+            break
+
         # Get the variables formatted as list table rows
         listing = "\n".join(
             [
                 f"* - `{v.name}`\n  - {v.description}\n  - {v.unit}"
                 for k, v in variables.KNOWN_VARIABLES.items()
-                if k in getattr(model, vattr)
+                if k in vars_for_table
             ]
         )
 

--- a/tests/models/abiotic_simple/test_abiotic_simple_model.py
+++ b/tests/models/abiotic_simple/test_abiotic_simple_model.py
@@ -76,7 +76,6 @@ def test_abiotic_simple_model_initialization(
 
     # Final check that expected logging entries are produced
     log_check(caplog, expected_log_entries)
-    print(caplog.text)
 
 
 @pytest.mark.parametrize(

--- a/tests/models/abiotic_simple/test_abiotic_simple_model.py
+++ b/tests/models/abiotic_simple/test_abiotic_simple_model.py
@@ -15,10 +15,16 @@ from tests.conftest import log_check, patch_run_setup, patch_run_update
 MODEL_VAR_CHECK_LOG = [
     (DEBUG, "abiotic_simple model: required var 'air_temperature_ref' checked"),
     (DEBUG, "abiotic_simple model: required var 'relative_humidity_ref' checked"),
-    (INFO, "Replacing data array for 'soil_temperature'"),
-    (INFO, "Replacing data array for 'net_radiation'"),
     (INFO, "Replacing data array for 'vapour_pressure_deficit_ref'"),
     (INFO, "Replacing data array for 'vapour_pressure_ref'"),
+    (INFO, "Replacing data array for 'air_temperature'"),
+    (INFO, "Replacing data array for 'relative_humidity'"),
+    (INFO, "Replacing data array for 'vapour_pressure_deficit'"),
+    (INFO, "Replacing data array for 'wind_speed'"),
+    (INFO, "Replacing data array for 'atmospheric_pressure'"),
+    (INFO, "Adding data array for 'atmospheric_co2'"),
+    (INFO, "Replacing data array for 'soil_temperature'"),
+    (INFO, "Replacing data array for 'net_radiation'"),
 ]
 
 
@@ -70,6 +76,7 @@ def test_abiotic_simple_model_initialization(
 
     # Final check that expected logging entries are produced
     log_check(caplog, expected_log_entries)
+    print(caplog.text)
 
 
 @pytest.mark.parametrize(
@@ -187,6 +194,10 @@ def test_setup(
         )
 
     exp_soil_temp = lyr_strct.from_template()
+    exp_soil_temp[lyr_strct.index_all_soil] = [
+        [20.712458, 21.317566, 21.922674, 22.527783],
+        [20.0, 20.0, 20.0, 20.0],
+    ]
     xr.testing.assert_allclose(model.data["soil_temperature"], exp_soil_temp)
 
     xr.testing.assert_allclose(

--- a/virtual_ecosystem/models/abiotic_simple/abiotic_simple_model.py
+++ b/virtual_ecosystem/models/abiotic_simple/abiotic_simple_model.py
@@ -71,7 +71,7 @@ class AbioticSimpleModel(
         "atmospheric_co2",
         "wind_speed",
     ),
-    vars_populated_by_first_update=(),
+    vars_populated_by_first_update=tuple(),
 ):
     """A class describing the abiotic simple model.
 

--- a/virtual_ecosystem/models/abiotic_simple/abiotic_simple_model.py
+++ b/virtual_ecosystem/models/abiotic_simple/abiotic_simple_model.py
@@ -64,8 +64,6 @@ class AbioticSimpleModel(
         "vapour_pressure_ref",
         "vapour_pressure_deficit_ref",
         "net_radiation",
-    ),
-    vars_populated_by_first_update=(
         "air_temperature",
         "relative_humidity",
         "vapour_pressure_deficit",
@@ -73,6 +71,7 @@ class AbioticSimpleModel(
         "atmospheric_co2",
         "wind_speed",
     ),
+    vars_populated_by_first_update=(),
 ):
     """A class describing the abiotic simple model.
 
@@ -136,18 +135,6 @@ class AbioticSimpleModel(
         self.bounds = model_configuration.bounds
         self.pyrealm_core_constants = pyrealm_core_constants
 
-        # create soil temperature array
-        self.data["soil_temperature"] = self.layer_structure.from_template()
-
-        # create net radiation array
-        self.data["net_radiation"] = self.layer_structure.from_template()
-        self.data["net_radiation"][self.layer_structure.index_flux_layers] = (
-            self.model_constants.initial_net_radiation
-        )
-        self.data["net_radiation"][self.layer_structure.index_surface_scalar] = (
-            self.model_constants.initial_net_radiation
-        )
-
         # calculate vapour pressure deficit at reference height for all time steps
         vapour_pressure_and_deficit = calculate_vapour_pressure_deficit(
             temperature=self.data["air_temperature_ref"],
@@ -160,6 +147,18 @@ class AbioticSimpleModel(
         self.data["vapour_pressure_ref"] = vapour_pressure_and_deficit[
             "vapour_pressure"
         ]
+
+        # This section performs a series of calculations to initialise atmospheric
+        # variables in the abiotic simple model which are then added to the data object.
+        output_variables = run_simple_microclimate(
+            data=self.data,
+            layer_structure=self.layer_structure,
+            time_index=0,
+            constants=self.model_constants,
+            core_constants=self.core_constants,
+            bounds=self.bounds,
+        )
+        self.data.add_from_dict(output_dict=output_variables)
 
     @classmethod
     def from_config(


### PR DESCRIPTION
The `abiotic_simple` model populated a lot of variables in the first update so we had to initialise some empty ones for other models to work, mostly soil model. Now all availability after setup.

Fixes #1175 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
