### PR TITLE
1243 sort out abiotic constants for calibration

### DIFF
--- a/tests/models/abiotic/test_abiotic_model.py
+++ b/tests/models/abiotic/test_abiotic_model.py
@@ -149,7 +149,7 @@ def test_abiotic_model_initialization_no_data(
             (
                 "[core]\n[core.grid]\ncell_nx = 2\ncell_ny = 2\n"
                 "[core.timing]\nupdate_interval = '12 hours'\n"
-                "[abiotic.constants]\ndrag_coefficient = 0.05\n"
+                "[abiotic.constants]\nzero_plane_scaling_parameter = 0.05\n"
             ),
             does_not_raise(),
             (

--- a/virtual_ecosystem/core/model_config.py
+++ b/virtual_ecosystem/core/model_config.py
@@ -152,6 +152,15 @@ class CoreConstants(Configuration):
     This represents the amount of heat energy required to raise the temperature 
     of one cubic meter of air by 1 Kelvin."""
 
+    initial_aerodynamic_resistance_canopy: float = 12.1
+    """Initial aerodynamic resistance of the canopy, [s m-1].
+    
+    This parameter is an initial estimate of the resistance to the transfer of momentum,
+    heat, and water vapour between the leaf surface and the atmosphere. The value is
+    based on Australian evergreen forest, taken from :cite:t:`su_aerodynamic_2021`;
+    note that this assumes a dense canopy.
+    """
+
 
 class GridConfiguration(Configuration):
     """Grid configuration.

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -166,7 +166,7 @@ def run_microclimate(
     #     von_karman_constant=core_constants.von_karmans_constant,
     # )
     aerodynamic_resistance_canopy = np.repeat(
-        abiotic_constants.aerodynamic_resistance_canopy_default, data.grid.n_cells
+        core_constants.initial_aerodynamic_resistance_canopy, data.grid.n_cells
     )
 
     # Aerodynamic resistance soil, [s m-1]

--- a/virtual_ecosystem/models/abiotic/model_config.py
+++ b/virtual_ecosystem/models/abiotic/model_config.py
@@ -139,9 +139,6 @@ class AbioticConstants(AbioticSharedConstants):
     initial_flux_value: float = 0.001
     """Initial non-zero fill value for energy fluxes, [W m-2]."""
 
-    aerodynamic_resistance_canopy_default: float = 12.5
-    """Default aerodynamic resistance of the canopy, [s m-1]."""
-
     coefficient_aerodynamic_resistance_understorey: float = 33.0
     """Coefficient for aerodynamic resistance of the understorey, [s m-1].
     

--- a/virtual_ecosystem/models/abiotic/model_config.py
+++ b/virtual_ecosystem/models/abiotic/model_config.py
@@ -88,15 +88,6 @@ class AbioticConstants(AbioticSharedConstants):
     transfer from the atmosphere to the surface. Implementation and value from
     :cite:t:`maclean_microclimc_2021`."""
 
-    drag_coefficient: float = 0.2
-    """Drag coefficient, dimensionless.
-
-    The drag coefficient is a dimensionless quantity that characterizes the drag or
-    resistance experienced by an object moving through a fluid (here the atmosphere) and
-    is defined as the ratio of the drag force on the object to the dynamic pressure of
-    the fluid flow and the reference area of the object.
-    Implementation and value from :cite:t:`maclean_microclimc_2021`."""
-
     min_windspeed_below_canopy: float = 0.1
     """Minimum wind speed below the canopy or in absence of vegetation, [m s-1]."""
 
@@ -106,14 +97,6 @@ class AbioticConstants(AbioticSharedConstants):
     The minimum roughness length represents the lowest height at which the surface
     roughness significantly affects the wind flow over a particular terrain or
     surface. Implementation and value from :cite:t:`maclean_microclimc_2021`."""
-
-    light_extinction_coefficient: float = 0.01
-    """Light extinction coefficient for canopy, unitless.
-    
-    The light extinction coefficient for a canopy quantifies how quickly light
-    diminishes as it passes through vegetation, reflecting the canopy's ability to
-    absorb or scatter incoming radiation. This value is only used in the model setup and
-    later derived in the plant model."""
 
     soil_thermal_conductivity: float = 1.206
     """Soil thermal conductivity, [W m-1 K-1].

--- a/virtual_ecosystem/models/abiotic_simple/model_config.py
+++ b/virtual_ecosystem/models/abiotic_simple/model_config.py
@@ -33,7 +33,7 @@ class AbioticSimpleConstants(AbioticSharedConstants):
     initial_net_radiation: float = 10.0
     """Initial value for net radiation per layer, W m-2.
     
-    TODO This is currently set to an arbitrary value."""
+    This is currently set to an arbitrary value, only used in test."""
 
 
 class AbioticSimpleBounds(Configuration):

--- a/virtual_ecosystem/models/hydrology/hydrology_tools.py
+++ b/virtual_ecosystem/models/hydrology/hydrology_tools.py
@@ -51,7 +51,7 @@ def initialise_atmosphere_for_hydrology(
             "aerodynamic_resistance_canopy",
             layer_structure.index_filled_canopy,
             layer_structure.index_surface_scalar,
-            model_constants.initial_aerodynamic_resistance_canopy,
+            core_constants.initial_aerodynamic_resistance_canopy,
         ),
         (
             "stomatal_conductance",

--- a/virtual_ecosystem/models/hydrology/model_config.py
+++ b/virtual_ecosystem/models/hydrology/model_config.py
@@ -46,17 +46,6 @@ class HydrologyConstants(Configuration):
     :cite:t:`gupta_global_2022`.
     """
 
-    hydraulic_gradient: float = 1.31
-    """The hydraulic gradient, [m].
-
-    The hydraulic gradient is a measure of the change in hydraulic head
-    (pressure) per unit of distance in a particular direction within a fluid or porous
-    medium, such as soil or an aquifer. It represents the driving force behind the
-    movement of water and indicates the direction in which water will flow. Value for
-    subtropical regions, taken from :cite:t:`reichardt_hydraulic_1993`; depends on the
-    soil type, permeability, slope, and water table depth.
-    """
-
     van_genuchten_nonlinearily_parameter: float = 1.598
     """Nonlinearity parameter n (dimensionless) in Mualem-van Genuchten model.
 
@@ -65,13 +54,6 @@ class HydrologyConstants(Configuration):
     across tropical regions 
     is taken from :cite:t:`hodnett_marked_2002`.
     """
-
-    stream_flow_capacity: float = 5000.0
-    """Stream flow capacity, [mm per day].
-
-    This parameter represents the maximum capacity of an average stream in the model.
-    At the moment, this is set as an arbitrary value; we are working on getting a best
-    estimate."""
 
     intercept_parameters: tuple[float, float, float] = (0.935, 0.498, 0.00575)
     """Interception parameters, unitless.
@@ -101,14 +83,6 @@ class HydrologyConstants(Configuration):
     directly to groundwater via preferential bypass flow. A value of
     0 means all surface water goes directly to groundwater, a value of 1 gives a linear
     relation between soil moisture and bypass flow."""
-
-    air_entry_water_potential: float = -3.648
-    """Water potential at which soil pores begin to aerate, [kPa].
-
-    The constant is used to estimate soil water potential from soil moisture. As this
-    estimation is a stopgap this constant probably shouldn't become a core constant. The
-    value is the average across soil types found in :cite:t:`tao_simplified_2021`.
-    """
 
     extinction_coefficient_global_radiation: float = 0.74
     """Extinction coefficient for global radiation, [unitless].
@@ -160,27 +134,11 @@ class HydrologyConstants(Configuration):
     note that this assumes a dense canopy.
     """
 
-    initial_aerodynamic_resistance_canopy: float = 12.1
-    """Initial aerodynamic resistance of the canopy, [s m-1].
-    
-    This parameter is an initial estimate of the resistance to the transfer of momentum,
-    heat, and water vapour between the leaf surface and the atmosphere. The value is
-    based on Australian evergreen forest, taken from :cite:t:`su_aerodynamic_2021`;
-    note that this assumes a dense canopy.
-    """
-
     drag_coefficient_evaporation: float = 0.2
     """Drag coefficient for evaporation, dimensionless.
     
     Represents the efficiency of turbulent transport of water vapour from a surface to
     the atmosphere."""
-
-    intercept_residence_time: float = 86400.0
-    """Intecept residence time, [s].
-    
-    The amount of time that water sits on the leaves before it evaporates or falls to
-    the ground. We currently assume that at the end of each day, all water has either
-    evaporated or fallen to the ground."""
 
     initial_stomatal_conductance: float = 1000.0
     """Initial stomatal conductance, [mmol m-2 s-1].


### PR DESCRIPTION
This PR removed unused `abiotic` and `hydrology` constants.

Fixes #1243
