### PR TITLE
Write variable metadata to netcdf files

### DIFF
--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -13,6 +13,14 @@ from tests.conftest import log_check
 from virtual_ecosystem.core.exceptions import ConfigurationError
 
 
+@pytest.fixture(autouse=False, scope="module")
+def populate_known_variables():
+    """Make sure that KNOWN_VARIABLES is populated."""
+    from virtual_ecosystem.core.variables import register_all_variables
+
+    register_all_variables()
+
+
 @pytest.mark.parametrize(
     argnames=["use_grid", "exp_err", "expected_log"],
     argvalues=[
@@ -698,9 +706,9 @@ def test_on_core_axis(
 @pytest.mark.parametrize(
     argnames=["folder", "file_name", "raises", "save_specific", "exp_log"],
     argvalues=[
-        (None, "initial.nc", does_not_raise(), False, ()),
-        (None, "initial.nc", does_not_raise(), True, ()),
-        (
+        pytest.param(None, "initial.nc", does_not_raise(), False, (), id="fine_all"),
+        pytest.param(None, "initial.nc", does_not_raise(), True, (), id="fine_subset"),
+        pytest.param(
             "bad_folder",
             "initial.nc",
             pytest.raises(ConfigurationError),
@@ -711,8 +719,9 @@ def test_on_core_axis(
                     "The user specified output directory (bad_folder) doesn't exist!",
                 ),
             ),
+            id="bad_folder",
         ),
-        (
+        pytest.param(
             "pyproject.toml",
             "initial.nc",
             pytest.raises(ConfigurationError),
@@ -724,8 +733,9 @@ def test_on_core_axis(
                     "directory!",
                 ),
             ),
+            id="not folder",
         ),
-        (
+        pytest.param(
             None,
             "already_exists.nc",
             pytest.raises(ConfigurationError),
@@ -736,10 +746,12 @@ def test_on_core_axis(
                     "A file in the user specified output folder (",
                 ),
             ),
+            id="folder exists",
         ),
     ],
 )
 def test_save_to_netcdf(
+    populate_known_variables,
     shared_datadir,
     caplog,
     fixture_core_components,

--- a/virtual_ecosystem/core/data.py
+++ b/virtual_ecosystem/core/data.py
@@ -385,6 +385,9 @@ class Data:
                 variables are saved.
         """
 
+        # Local import to avoid circular import issue
+        from virtual_ecosystem.core.variables import KNOWN_VARIABLES
+
         # Check that the folder to save to exists and that there isn't already a file
         # saved there
         check_outfile(output_file_path)
@@ -395,6 +398,13 @@ class Data:
             out = self.data[variables_to_save]
         else:
             out = self.data
+
+        # Add variable_metadata from variables database
+        for var in out.data_vars:
+            variable = KNOWN_VARIABLES[str(var)]
+            out[var].attrs.update(
+                {"unit": variable.unit, "description": variable.description}
+            )
 
         # Add the timestamps to the output
         out["timestamp"] = DataArray(timing.update_datestamps, dims="time_index")
@@ -424,6 +434,9 @@ class Data:
             ConfigurationError: If the file to save to can't be found
         """
 
+        # Local import to avoid circular import issue
+        from virtual_ecosystem.core.variables import KNOWN_VARIABLES
+
         # Check that the folder to save to exists and that there isn't already a file
         # saved there
         check_outfile(output_file_path)
@@ -434,6 +447,13 @@ class Data:
             .expand_dims({"time_index": 1})
             .assign_coords(time_index=[time_index])
         )
+
+        # Add variable_metadata from variables database
+        for var in time_slice.data_vars:
+            variable = KNOWN_VARIABLES[str(var)]
+            time_slice[var].attrs.update(
+                {"unit": variable.unit, "description": variable.description}
+            )
 
         # Add the timestamp
         time_slice["timestamp"] = DataArray([timestamp], dims="time_index")

--- a/virtual_ecosystem/core/data.py
+++ b/virtual_ecosystem/core/data.py
@@ -401,10 +401,11 @@ class Data:
 
         # Add variable_metadata from variables database
         for var in out.data_vars:
-            variable = KNOWN_VARIABLES[str(var)]
-            out[var].attrs.update(
-                {"unit": variable.unit, "description": variable.description}
-            )
+            if not out[var].attrs:
+                variable = KNOWN_VARIABLES[str(var)]
+                out[var].attrs.update(
+                    {"unit": variable.unit, "description": variable.description}
+                )
 
         # Add the timestamps to the output
         out["timestamp"] = DataArray(timing.update_datestamps, dims="time_index")
@@ -448,12 +449,13 @@ class Data:
             .assign_coords(time_index=[time_index])
         )
 
-        # Add variable_metadata from variables database
+        # Update any missing variable_metadata from variables database
         for var in time_slice.data_vars:
-            variable = KNOWN_VARIABLES[str(var)]
-            time_slice[var].attrs.update(
-                {"unit": variable.unit, "description": variable.description}
-            )
+            if not time_slice[var].attrs:
+                variable = KNOWN_VARIABLES[str(var)]
+                time_slice[var].attrs.update(
+                    {"unit": variable.unit, "description": variable.description}
+                )
 
         # Add the timestamp
         time_slice["timestamp"] = DataArray([timestamp], dims="time_index")

--- a/virtual_ecosystem/data_variables.toml
+++ b/virtual_ecosystem/data_variables.toml
@@ -1383,3 +1383,10 @@ description = "Average C, N, and P masses of each seed in a PFT"
 name = "fallen_seeds_cnp"
 unit = "kg"
 variable_type = "float"
+
+[[variable]]
+axis = ["spatial"]
+description = "NEEDS DESCRIPTION"
+name = "root_turnover_c_p_ratio"
+unit = "NEEDS UNITS"
+variable_type = "float"


### PR DESCRIPTION
# Description

This PR:

* Adds a loop into the two NetCDF output files that adds the `Variable.unit` and `Variable.description` attributes from `ve.core.variables.KNOWN_VARIABLES` to each of the variables in the output data. 
* We only need to add these on write to file (and not as variables are created), so it's much easier just to tag it on at the last moment. 
* Annoyingly there is a circular import issue, so the functions have internal imports of `KNOWN_VARIABLES`. I don't like that but for now it'll stand.

Fixes #1293

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
