### PR TITLE
Fix weird blue backgrounds for figures in new docs style

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -47,3 +47,10 @@ h5.card-header {
 div.btn-group>button.btn {
     opacity: 1.0;
 }
+
+/* Override the pydata-sphinx-theme default bright blue background in anchors */
+
+img.bg-primary,
+a.bg-primary {
+    background-color: white !important;
+}


### PR DESCRIPTION
# Description

This PR changes the CSS for the new docs style to eliminate the weird blue backgrounds that were cropping up in @vgro's theory sections.

The [relevant figures](https://virtual-ecosystem.readthedocs.io/en/1326-weird-blue-backgrounds-for-figures-in-new-docs-style/virtual_ecosystem/theory/abiotic_theory.html) now have normal backgrounds

Fixes #1326

