### PR TITLE
Write subcanopy biomasses to data during  PlantMode.__init__

### DIFF
--- a/tests/models/plants/test_subcanopy.py
+++ b/tests/models/plants/test_subcanopy.py
@@ -179,6 +179,7 @@ def test_subcanopy_vegetation_dynamics(
         model_constants=fixture_plants_constants,
         layer_index=fixture_core_components.layer_structure.index_surface_scalar,
         model_timing=fixture_core_components.model_timing,
+        data_object_template=cnp_template,
     )
 
     # Test initialisation sets the biomasses
@@ -194,7 +195,6 @@ def test_subcanopy_vegetation_dynamics(
         lue=np.ones(4),
         iwue=np.ones(4),
         swd=np.ones(4),
-        data_object_template=cnp_template,
     )
 
     # Assert that biomasses are either equal to zero or greater.

--- a/virtual_ecosystem/core/variables.py
+++ b/virtual_ecosystem/core/variables.py
@@ -444,8 +444,8 @@ def _collect_vars_populated_by_first_update(
                     else (v.vars_populated_by_first_update[0], "first update")
                 )
                 raise ValueError(
-                    f"Variable {var} initialised by {model.model_name} already "
-                    f"initialised during {init_stage} by {init_model}."
+                    f"Variable {var} initialised at first update by {model.model_name} "
+                    f"already initialised during {init_stage} by {init_model}."
                 )
 
             runtime_variables[var] = known_variables[var]

--- a/virtual_ecosystem/models/plants/plants_model.py
+++ b/virtual_ecosystem/models/plants/plants_model.py
@@ -62,6 +62,10 @@ class PlantsModel(
         "layer_leaf_mass",  # NOTE - placeholder resource for herbivory
         "leaf_area_index",  # NOTE - LAI is integrated into the full layer roles
         "shortwave_absorption",
+        "subcanopy_seedbank_litter_cnp",
+        "subcanopy_vegetation_litter_cnp",
+        "subcanopy_vegetation_cnp",
+        "subcanopy_seedbank_cnp",
     ),
     vars_required_for_update=(
         "air_temperature",
@@ -135,10 +139,6 @@ class PlantsModel(
         "fallen_fruit_cnp",
         "fallen_seeds_per_fruit",
         "fallen_seeds_cnp",
-        "subcanopy_seedbank_litter_cnp",
-        "subcanopy_vegetation_litter_cnp",
-        "subcanopy_vegetation_cnp",
-        "subcanopy_seedbank_cnp",
         "fallen_non_propagule_c_mass",
         "plant_ammonium_uptake",
         "plant_nitrate_uptake",
@@ -463,6 +463,7 @@ class PlantsModel(
             model_constants=self.model_constants,
             layer_index=self.layer_structure.index_surface_scalar,
             model_timing=self.model_timing,
+            data_object_template=self.data_object_templates["cnp"],
         )
 
         # Get the canopy top shortwave downwelling radiation for the first time slice
@@ -664,7 +665,6 @@ class PlantsModel(
             lue=self.pmodel.lue[self.layer_structure.index_surface_scalar, :],
             iwue=self.pmodel.iwue[self.layer_structure.index_surface_scalar, :],
             swd=self.canopy_top_radiation,
-            data_object_template=self.data_object_templates["cnp"],
         )
 
         # Run the community data exporter

--- a/virtual_ecosystem/models/plants/subcanopy.py
+++ b/virtual_ecosystem/models/plants/subcanopy.py
@@ -228,6 +228,7 @@ class Subcanopy:
         model_constants: The PlantModel constants for the simulation
         layer_index: The layer index of the surface layer in the vertical layer axis.
         model_timing: The core ModelTiming instance for the simulation.
+        data_object_template: A template for creating CNP element arrays.
     """
 
     elements: tuple[str, ...] = ("n", "p")
@@ -240,6 +241,7 @@ class Subcanopy:
         model_constants: PlantsConstants,
         layer_index: int,
         model_timing: ModelTiming,
+        data_object_template: DataArray,
     ) -> None:
         # Init attributes
         self.data: Data = data
@@ -247,9 +249,11 @@ class Subcanopy:
         self.model_constants: PlantsConstants = model_constants
         self.model_timing: ModelTiming = model_timing
         self.layer_index: int = layer_index
+        self.data_object_template: DataArray = data_object_template
 
-        # TODO: currently initialising from constants using ideal ratios but could load
-        #       nutrient masses from init data.
+        # TODO: Currently initialising from constants using ideal ratios but should load
+        #       nutrient masses from init data. See:
+        #       https://github.com/ImperialCollegeLondon/virtual_ecosystem/issues/1334
 
         # Stochiometry of vegetation and seedbank
         self.vegetation_biomass: SubcanopyBiomass = SubcanopyBiomass.from_constants(
@@ -266,6 +270,40 @@ class Subcanopy:
             constants=self.model_constants,
         )
 
+        # Write the initial values to data. This currently:
+        #
+        # * Assumes no initial litter from either pool
+        # * Duplicates code used in the update method (calculate_dynamics)
+        # * Uses a meaningless "ideal" ratio for litter
+        #
+        # But - both of those should be fixed in a more general refactor of this module
+        # to use the CNP array structure. That will likely change a lot of this code, so
+        # not currently adding a SubcanopyBiomass.to_data() method etc etc.
+        empty_litter = np.zeros_like(self.seedbank_biomass.carbon_mass)
+        initial_litter = SubcanopyBiomass(
+            carbon_mass=empty_litter.copy(),
+            nutrients={
+                "n": Nutrient(name="n", ideal_ratio=0, masses=empty_litter.copy()),
+                "p": Nutrient(name="p", ideal_ratio=0, masses=empty_litter.copy()),
+            },
+        )
+
+        # Write biomasses to Data
+        biomasses: dict[str, SubcanopyBiomass] = {
+            "subcanopy_vegetation": self.vegetation_biomass,
+            "subcanopy_seedbank": self.seedbank_biomass,
+            "subcanopy_vegetation_litter": initial_litter,
+            "subcanopy_seedbank_litter": initial_litter,
+        }
+
+        for var, biomass in biomasses.items():
+            biomass_array = self.data_object_template.copy()
+            biomass_array.loc[:, "C"] = biomass.carbon_mass
+            for elem in self.elements:
+                biomass_array.loc[:, elem.upper()] = biomass.nutrients[elem].masses
+
+            self.data[f"{var}_cnp"] = biomass_array
+
         # Type other attributes not populated at __init__
         self.lai: NDArray[np.floating]
         self.light_transmission: NDArray[np.floating]
@@ -276,7 +314,6 @@ class Subcanopy:
         lue: NDArray[np.floating],
         iwue: NDArray[np.floating],
         swd: NDArray[np.floating],
-        data_object_template: DataArray,
     ) -> None:
         r"""Estimate the dynamics of subcanopy vegetation.
 
@@ -440,14 +477,14 @@ class Subcanopy:
 
         # Write biomasses to Data
         biomasses: dict[str, SubcanopyBiomass] = {
-            "subcanopy_vegetation": self.seedbank_biomass,
+            "subcanopy_vegetation": self.vegetation_biomass,
             "subcanopy_seedbank": self.seedbank_biomass,
             "subcanopy_vegetation_litter": vegetation_turnover,
             "subcanopy_seedbank_litter": seedbank_turnover,
         }
 
         for var, biomass in biomasses.items():
-            self.data[f"{var}_cnp"] = data_object_template.copy()
+            self.data[f"{var}_cnp"] = self.data_object_template.copy()
 
             self.data[f"{var}_cnp"].loc[:, "C"] = biomass.carbon_mass
 


### PR DESCRIPTION
# Description

This PR:

* Updates the `Subcanopy.__init__` method to include writing the subcanopy pool CNP arrays to data. This is so that these arrays are available during `AnimalModel.__init__` for the setup of ArrayResources (#1318).
* Fixes a misleading error message from the variables module.
* Fixes a bug in the Subcanopy - the seedbank biomass was replacing the vegetation biomass.

Fixes #1333 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
