### PR TITLE
1344 animal   change stoichiometry naming to align with plants and soils

### DIFF
--- a/tests/models/animals/conftest.py
+++ b/tests/models/animals/conftest.py
@@ -698,8 +698,8 @@ def excrement_pool_instance():
     from virtual_ecosystem.models.animal.decay import ExcrementPool
 
     return ExcrementPool(
-        scavengeable_cnp=CNP(carbon=500.0, nitrogen=100.0, phosphorus=50.0),
-        decomposed_cnp=CNP(carbon=0.0, nitrogen=0.0, phosphorus=0.0),
+        scavengeable_cnp=CNP(C=500.0, N=100.0, P=50.0),
+        decomposed_cnp=CNP(C=0.0, N=0.0, P=0.0),
     )
 
 
@@ -712,8 +712,8 @@ def excrement_pools_by_cell_instance():
     return {
         1: [
             ExcrementPool(
-                scavengeable_cnp=CNP(carbon=500.0, nitrogen=100.0, phosphorus=50.0),
-                decomposed_cnp=CNP(carbon=0.0, nitrogen=0.0, phosphorus=0.0),
+                scavengeable_cnp=CNP(C=500.0, N=100.0, P=50.0),
+                decomposed_cnp=CNP(C=0.0, N=0.0, P=0.0),
             )
         ]
     }
@@ -772,8 +772,8 @@ def carcass_pool_instance():
     from virtual_ecosystem.models.animal.decay import CarcassPool
 
     return CarcassPool(
-        scavengeable_cnp=CNP(carbon=500.0, nitrogen=100.0, phosphorus=50.0),
-        decomposed_cnp=CNP(carbon=0.0, nitrogen=0.0, phosphorus=0.0),
+        scavengeable_cnp=CNP(C=500.0, N=100.0, P=50.0),
+        decomposed_cnp=CNP(C=0.0, N=0.0, P=0.0),
     )
 
 
@@ -786,8 +786,8 @@ def carcass_pools_by_cell_instance():
     return {
         cell_id: [
             CarcassPool(
-                scavengeable_cnp=CNP(carbon=500.0, nitrogen=100.0, phosphorus=50.0),
-                decomposed_cnp=CNP(carbon=0.0, nitrogen=0.0, phosphorus=0.0),
+                scavengeable_cnp=CNP(C=500.0, N=100.0, P=50.0),
+                decomposed_cnp=CNP(C=0.0, N=0.0, P=0.0),
             )
         ]
         for cell_id in range(0, 9)  # Creates carcass pools for cells 0 to 8
@@ -958,10 +958,10 @@ def microbial_cnp_ratios() -> dict[str, dict[str, float]]:
     """
 
     return {
-        "bacteria": {"nitrogen": 5.0, "phosphorus": 30.0},
-        "saprotrophic_fungi": {"nitrogen": 10.0, "phosphorus": 80.0},
-        "arbuscular_mycorrhiza": {"nitrogen": 12.0, "phosphorus": 90.0},
-        "ectomycorrhiza": {"nitrogen": 8.0, "phosphorus": 70.0},
+        "bacteria": {"N": 5.0, "P": 30.0},
+        "saprotrophic_fungi": {"N": 10.0, "P": 80.0},
+        "arbuscular_mycorrhiza": {"N": 12.0, "P": 90.0},
+        "ectomycorrhiza": {"N": 8.0, "P": 70.0},
     }
 
 

--- a/tests/models/animals/test_animal_cohorts.py
+++ b/tests/models/animals/test_animal_cohorts.py
@@ -207,21 +207,19 @@ class TestAnimalCohort:
                 cohort_instance.metabolize(temperature, dt)
         else:
             cohort_instance.metabolize(temperature, dt)
-            assert isclose(
-                cohort_instance.mass_cnp.carbon, expected_final_mass, rtol=1e-9
-            )
+            assert isclose(cohort_instance.mass_cnp.C, expected_final_mass, rtol=1e-9)
 
     @pytest.mark.parametrize(
         "cohort_type, excreta_mass, num_pools",
         [
-            ("herbivore", {"carbon": 100.0, "nitrogen": 10.0, "phosphorus": 1.0}, 1),
-            ("herbivore", {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0}, 1),
-            ("ectotherm", {"carbon": 50.0, "nitrogen": 5.0, "phosphorus": 0.5}, 1),
-            ("ectotherm", {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0}, 1),
-            ("herbivore", {"carbon": 100.0, "nitrogen": 10.0, "phosphorus": 1.0}, 3),
-            ("herbivore", {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0}, 3),
-            ("ectotherm", {"carbon": 50.0, "nitrogen": 5.0, "phosphorus": 0.5}, 3),
-            ("ectotherm", {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0}, 3),
+            ("herbivore", {"C": 100.0, "N": 10.0, "P": 1.0}, 1),
+            ("herbivore", {"C": 0.0, "N": 0.0, "P": 0.0}, 1),
+            ("ectotherm", {"C": 50.0, "N": 5.0, "P": 0.5}, 1),
+            ("ectotherm", {"C": 0.0, "N": 0.0, "P": 0.0}, 1),
+            ("herbivore", {"C": 100.0, "N": 10.0, "P": 1.0}, 3),
+            ("herbivore", {"C": 0.0, "N": 0.0, "P": 0.0}, 3),
+            ("ectotherm", {"C": 50.0, "N": 5.0, "P": 0.5}, 3),
+            ("ectotherm", {"C": 0.0, "N": 0.0, "P": 0.0}, 3),
         ],
     )
     def test_excrete(
@@ -290,15 +288,15 @@ class TestAnimalCohort:
     @pytest.mark.parametrize(
         "cohort_type, excreta_mass",
         [
-            ("herbivore", {"carbon": 100.0, "nitrogen": 0.0, "phosphorus": 0.0}),
+            ("herbivore", {"C": 100.0, "N": 0.0, "P": 0.0}),
             (
                 "herbivore",
-                {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0},
+                {"C": 0.0, "N": 0.0, "P": 0.0},
             ),  # Zero excreta
-            ("ectotherm", {"carbon": 50.0, "nitrogen": 0.0, "phosphorus": 0.0}),
+            ("ectotherm", {"C": 50.0, "N": 0.0, "P": 0.0}),
             (
                 "ectotherm",
-                {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0},
+                {"C": 0.0, "N": 0.0, "P": 0.0},
             ),  # Zero excreta
         ],
     )
@@ -320,7 +318,7 @@ class TestAnimalCohort:
 
         # Calculate the expected carbon waste based on the cohort's constants
         expected_carbon_waste = (
-            excreta_mass["carbon"] * cohort_instance.constants.carbon_excreta_proportion
+            excreta_mass["C"] * cohort_instance.constants.carbon_excreta_proportion
         )
 
         # Call the respire method
@@ -332,14 +330,14 @@ class TestAnimalCohort:
     @pytest.mark.parametrize(
         "cohort_type, mass_consumed, num_pools",
         [
-            ("herbivore", {"carbon": 100.0, "nitrogen": 10.0, "phosphorus": 1.0}, 1),
-            ("herbivore", {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0}, 1),
-            ("ectotherm", {"carbon": 50.0, "nitrogen": 5.0, "phosphorus": 0.5}, 1),
-            ("ectotherm", {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0}, 1),
-            ("herbivore", {"carbon": 100.0, "nitrogen": 10.0, "phosphorus": 1.0}, 3),
-            ("herbivore", {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0}, 3),
-            ("ectotherm", {"carbon": 50.0, "nitrogen": 5.0, "phosphorus": 0.5}, 3),
-            ("ectotherm", {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0}, 3),
+            ("herbivore", {"C": 100.0, "N": 10.0, "P": 1.0}, 1),
+            ("herbivore", {"C": 0.0, "N": 0.0, "P": 0.0}, 1),
+            ("ectotherm", {"C": 50.0, "N": 5.0, "P": 0.5}, 1),
+            ("ectotherm", {"C": 0.0, "N": 0.0, "P": 0.0}, 1),
+            ("herbivore", {"C": 100.0, "N": 10.0, "P": 1.0}, 3),
+            ("herbivore", {"C": 0.0, "N": 0.0, "P": 0.0}, 3),
+            ("ectotherm", {"C": 50.0, "N": 5.0, "P": 0.5}, 3),
+            ("ectotherm", {"C": 0.0, "N": 0.0, "P": 0.0}, 3),
         ],
     )
     def test_defecate(
@@ -480,17 +478,15 @@ class TestAnimalCohort:
         else:
             # Positive deaths -> carcass pool should receive total mass lost
             expected_mass_lost = {
-                "carbon": herbivore_cohort_instance.mass_cnp.carbon * number_of_deaths,
-                "nitrogen": herbivore_cohort_instance.mass_cnp.nitrogen
-                * number_of_deaths,
-                "phosphorus": herbivore_cohort_instance.mass_cnp.phosphorus
-                * number_of_deaths,
+                "C": herbivore_cohort_instance.mass_cnp.C * number_of_deaths,
+                "N": herbivore_cohort_instance.mass_cnp.N * number_of_deaths,
+                "P": herbivore_cohort_instance.mass_cnp.P * number_of_deaths,
             }
 
             mock_update_carcass_pool.assert_called_once_with(
-                expected_mass_lost["carbon"],
-                expected_mass_lost["nitrogen"],
-                expected_mass_lost["phosphorus"],
+                expected_mass_lost["C"],
+                expected_mass_lost["N"],
+                expected_mass_lost["P"],
                 [],
             )
 
@@ -498,43 +494,43 @@ class TestAnimalCohort:
         "carcass_mass, num_pools, decay_fraction, should_raise",
         [
             (
-                {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0},
+                {"C": 0.0, "N": 0.0, "P": 0.0},
                 1,
                 0.5,
                 False,
             ),  # zero_mass
             (
-                {"carbon": 1000.0, "nitrogen": 500.0, "phosphorus": 250.0},
+                {"C": 1000.0, "N": 500.0, "P": 250.0},
                 1,
                 0.5,
                 False,
             ),  # single_pool_distribution
             (
-                {"carbon": 1000.0, "nitrogen": 500.0, "phosphorus": 250.0},
+                {"C": 1000.0, "N": 500.0, "P": 250.0},
                 2,
                 0.5,
                 False,
             ),  # multiple_pools_distribution
             (
-                {"carbon": 1000.0, "nitrogen": 500.0, "phosphorus": 250.0},
+                {"C": 1000.0, "N": 500.0, "P": 250.0},
                 1,
                 1.0,
                 False,
             ),  # high_decay_fraction
             (
-                {"carbon": 1000.0, "nitrogen": 500.0, "phosphorus": 250.0},
+                {"C": 1000.0, "N": 500.0, "P": 250.0},
                 1,
                 0.0,
                 False,
             ),  # low_decay_fraction
             (
-                {"carbon": 1000.0, "nitrogen": 500.0, "phosphorus": 250.0},
+                {"C": 1000.0, "N": 500.0, "P": 250.0},
                 0,
                 0.5,
                 True,
             ),  # no_pools_provided
             (
-                {"carbon": -100.0, "nitrogen": 500.0, "phosphorus": 250.0},
+                {"C": -100.0, "N": 500.0, "P": 250.0},
                 1,
                 0.5,
                 True,
@@ -564,8 +560,8 @@ class TestAnimalCohort:
 
         carcass_pools = [
             CarcassPool(
-                scavengeable_cnp=CNP(carbon=500.0, nitrogen=100.0, phosphorus=50.0),
-                decomposed_cnp=CNP(carbon=0.0, nitrogen=0.0, phosphorus=0.0),
+                scavengeable_cnp=CNP(C=500.0, N=100.0, P=50.0),
+                decomposed_cnp=CNP(C=0.0, N=0.0, P=0.0),
             )
             for _ in range(num_pools)
         ]
@@ -587,17 +583,17 @@ class TestAnimalCohort:
         if should_raise:
             with pytest.raises(ValueError):
                 herbivore_cohort_instance.update_carcass_pool(
-                    carcass_mass["carbon"],
-                    carcass_mass["nitrogen"],
-                    carcass_mass["phosphorus"],
+                    carcass_mass["C"],
+                    carcass_mass["N"],
+                    carcass_mass["P"],
                     carcass_pools,
                 )
             return
 
         herbivore_cohort_instance.update_carcass_pool(
-            carcass_mass["carbon"],
-            carcass_mass["nitrogen"],
-            carcass_mass["phosphorus"],
+            carcass_mass["C"],
+            carcass_mass["N"],
+            carcass_mass["P"],
             carcass_pools,
         )
 
@@ -658,27 +654,24 @@ class TestAnimalCohort:
 
         # Ensure mass_current correctly reflects individual mass
         herbivore_cohort_instance.mass_cnp = CNP(
-            carbon=individual_mass
-            * herbivore_cohort_instance.cnp_proportions["carbon"],
-            nitrogen=individual_mass
-            * herbivore_cohort_instance.cnp_proportions["nitrogen"],
-            phosphorus=individual_mass
-            * herbivore_cohort_instance.cnp_proportions["phosphorus"],
+            C=individual_mass * herbivore_cohort_instance.cnp_proportions["C"],
+            N=individual_mass * herbivore_cohort_instance.cnp_proportions["N"],
+            P=individual_mass * herbivore_cohort_instance.cnp_proportions["P"],
         )
 
         # Track initial total carcass pool mass for each nutrient
         initial_carcass_mass_c = sum(
-            pool.scavengeable_cnp["carbon"]
+            pool.scavengeable_cnp["C"]
             for pools in carcass_pools_by_cell_instance.values()
             for pool in pools
         )
         initial_carcass_mass_n = sum(
-            pool.scavengeable_cnp["nitrogen"]
+            pool.scavengeable_cnp["N"]
             for pools in carcass_pools_by_cell_instance.values()
             for pool in pools
         )
         initial_carcass_mass_p = sum(
-            pool.scavengeable_cnp["phosphorus"]
+            pool.scavengeable_cnp["P"]
             for pools in carcass_pools_by_cell_instance.values()
             for pool in pools
         )
@@ -692,9 +685,9 @@ class TestAnimalCohort:
         decay_fraction_carcasses = herbivore_cohort_instance.decay_fraction_carcasses
 
         # **Get C, N, P proportions for the prey species (mammal)**
-        c_proportion = herbivore_cohort_instance.cnp_proportions["carbon"]
-        n_proportion = herbivore_cohort_instance.cnp_proportions["nitrogen"]
-        p_proportion = herbivore_cohort_instance.cnp_proportions["phosphorus"]
+        c_proportion = herbivore_cohort_instance.cnp_proportions["C"]
+        n_proportion = herbivore_cohort_instance.cnp_proportions["N"]
+        p_proportion = herbivore_cohort_instance.cnp_proportions["P"]
 
         # **Mock `find_intersecting_carcass_pools` return only relevant carcass pools**
         predator_cells = predator_cohort_instance.territory
@@ -773,17 +766,17 @@ class TestAnimalCohort:
 
         # Track final total carcass pool mass for each nutrient
         final_carcass_mass_c = sum(
-            pool.scavengeable_cnp["carbon"]
+            pool.scavengeable_cnp["C"]
             for pools in carcass_pools_by_cell_instance.values()
             for pool in pools
         )
         final_carcass_mass_n = sum(
-            pool.scavengeable_cnp["nitrogen"]
+            pool.scavengeable_cnp["N"]
             for pools in carcass_pools_by_cell_instance.values()
             for pool in pools
         )
         final_carcass_mass_p = sum(
-            pool.scavengeable_cnp["phosphorus"]
+            pool.scavengeable_cnp["P"]
             for pools in carcass_pools_by_cell_instance.values()
             for pool in pools
         )
@@ -812,33 +805,33 @@ class TestAnimalCohort:
         [
             # Normal cases
             (
-                {"carbon": 100.0, "nitrogen": 10.0, "phosphorus": 1.0},
-                {"carbon": 20.0, "nitrogen": 2.0, "phosphorus": 0.2},
+                {"C": 100.0, "N": 10.0, "P": 1.0},
+                {"C": 20.0, "N": 2.0, "P": 0.2},
             ),
             (
-                {"carbon": 50.0, "nitrogen": 5.0, "phosphorus": 0.5},
-                {"carbon": 10.0, "nitrogen": 1.0, "phosphorus": 0.1},
+                {"C": 50.0, "N": 5.0, "P": 0.5},
+                {"C": 10.0, "N": 1.0, "P": 0.1},
             ),
             # Edge cases
             (
-                {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0},
-                {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0},
+                {"C": 0.0, "N": 0.0, "P": 0.0},
+                {"C": 0.0, "N": 0.0, "P": 0.0},
             ),  # Zero consumption
             (
-                {"carbon": 1e9, "nitrogen": 1e9, "phosphorus": 1e9},
-                {"carbon": 2e8, "nitrogen": 2e8, "phosphorus": 2e8},
+                {"C": 1e9, "N": 1e9, "P": 1e9},
+                {"C": 2e8, "N": 2e8, "P": 2e8},
             ),  # Extremely high consumption
             (
-                {"carbon": 0.0000001, "nitrogen": 0.0000001, "phosphorus": 0.0000001},
+                {"C": 0.0000001, "N": 0.0000001, "P": 0.0000001},
                 {
-                    "carbon": 0.00000002,
-                    "nitrogen": 0.00000002,
-                    "phosphorus": 0.00000002,
+                    "C": 0.00000002,
+                    "N": 0.00000002,
+                    "P": 0.00000002,
                 },
             ),  # Floating point precision
             (
-                {"carbon": 1e-6, "nitrogen": 1e-6, "phosphorus": 1e-6},
-                {"carbon": 2e-7, "nitrogen": 2e-7, "phosphorus": 2e-7},
+                {"C": 1e-6, "N": 1e-6, "P": 1e-6},
+                {"C": 2e-7, "N": 2e-7, "P": 2e-7},
             ),  # Minimum nonzero consumption
         ],
     )
@@ -876,39 +869,39 @@ class TestAnimalCohort:
         [
             # Missing required keys
             (
-                {"carbon": 100.0, "nitrogen": 10.0},
+                {"C": 100.0, "N": 10.0},
                 ["mock_pool"],
                 "mass_consumed must contain all required keys",
             ),
             (
-                {"carbon": 100.0, "phosphorus": 1.0},
+                {"C": 100.0, "P": 1.0},
                 ["mock_pool"],
                 "mass_consumed must contain all required keys",
             ),
             (
-                {"nitrogen": 10.0, "phosphorus": 1.0},
+                {"N": 10.0, "P": 1.0},
                 ["mock_pool"],
                 "mass_consumed must contain all required keys",
             ),
             # Negative values
             (
-                {"carbon": -100.0, "nitrogen": 10.0, "phosphorus": 1.0},
+                {"C": -100.0, "N": 10.0, "P": 1.0},
                 ["mock_pool"],
                 "Values in mass_consumed must be non-negative",
             ),
             (
-                {"carbon": 100.0, "nitrogen": -10.0, "phosphorus": 1.0},
+                {"C": 100.0, "N": -10.0, "P": 1.0},
                 ["mock_pool"],
                 "Values in mass_consumed must be non-negative",
             ),
             (
-                {"carbon": 100.0, "nitrogen": 10.0, "phosphorus": -1.0},
+                {"C": 100.0, "N": 10.0, "P": -1.0},
                 ["mock_pool"],
                 "Values in mass_consumed must be non-negative",
             ),
             # No excrement pools
             (
-                {"carbon": 100.0, "nitrogen": 10.0, "phosphorus": 1.0},
+                {"C": 100.0, "N": 10.0, "P": 1.0},
                 [],
                 "At least one excrement pool must be provided.",
             ),
@@ -956,11 +949,9 @@ class TestAnimalCohort:
         from virtual_ecosystem.models.animal.cnp import CNP
 
         # Mock `mass_current` and `reproductive_mass` properties
-        herbivore_cohort_instance.mass_cnp = CNP(
-            carbon=mass_current, nitrogen=0.0, phosphorus=0.0
-        )
+        herbivore_cohort_instance.mass_cnp = CNP(C=mass_current, N=0.0, P=0.0)
         herbivore_cohort_instance.reproductive_mass_cnp = CNP(
-            carbon=reproductive_mass, nitrogen=0.0, phosphorus=0.0
+            C=reproductive_mass, N=0.0, P=0.0
         )
 
         # Mock `adult_mass`
@@ -1515,9 +1506,9 @@ class TestAnimalCohort:
                 {1: [{"mock": True}]},
                 False,
                 None,
-                {"carbon": 10.0, "nitrogen": 2.0, "phosphorus": 1.0},
-                {"carbon": 8.0, "nitrogen": 1.5, "phosphorus": 0.8},
-                {"carbon": 8.0, "nitrogen": 1.5, "phosphorus": 0.8},
+                {"C": 10.0, "N": 2.0, "P": 1.0},
+                {"C": 8.0, "N": 1.5, "P": 0.8},
+                {"C": 8.0, "N": 1.5, "P": 0.8},
             ),
             # Normal case: Two prey cohorts, sum their values
             (
@@ -1525,9 +1516,9 @@ class TestAnimalCohort:
                 {1: [{"mock": True}]},
                 False,
                 None,
-                {"carbon": 5.0, "nitrogen": 1.0, "phosphorus": 0.5},
-                {"carbon": 4.0, "nitrogen": 0.8, "phosphorus": 0.4},
-                {"carbon": 8.0, "nitrogen": 1.6, "phosphorus": 0.8},
+                {"C": 5.0, "N": 1.0, "P": 0.5},
+                {"C": 4.0, "N": 0.8, "P": 0.4},
+                {"C": 8.0, "N": 1.6, "P": 0.8},
             ),
             # No prey (should return zero mass)
             (
@@ -1537,7 +1528,7 @@ class TestAnimalCohort:
                 None,
                 None,
                 None,
-                {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0},
+                {"C": 0.0, "N": 0.0, "P": 0.0},
             ),
             # animal_list is None
             (
@@ -1566,7 +1557,7 @@ class TestAnimalCohort:
                 True,
                 "calculate_consumed_mass_predation.*returned None",
                 None,
-                {"carbon": 8.0, "nitrogen": 1.5, "phosphorus": 0.8},
+                {"C": 8.0, "N": 1.5, "P": 0.8},
                 None,
             ),
             # get_eaten returns None
@@ -1575,7 +1566,7 @@ class TestAnimalCohort:
                 {1: [{"mock": True}]},
                 True,
                 "get_eaten.*returned None",
-                {"carbon": 10.0, "nitrogen": 2.0, "phosphorus": 1.0},
+                {"C": 10.0, "N": 2.0, "P": 1.0},
                 None,
                 None,
             ),
@@ -1703,28 +1694,28 @@ class TestAnimalCohort:
         "gain, litter, expect_waste_call, expect_error, test_id",
         [
             (
-                {"carbon": 10.0, "nitrogen": 5.0, "phosphorus": 2.0},
-                {"carbon": 3.0, "nitrogen": 1.0, "phosphorus": 0.5},
+                {"C": 10.0, "N": 5.0, "P": 2.0},
+                {"C": 3.0, "N": 1.0, "P": 0.5},
                 2,
                 None,
                 "standard",
             ),
             (
-                {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0},
-                {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0},
+                {"C": 0.0, "N": 0.0, "P": 0.0},
+                {"C": 0.0, "N": 0.0, "P": 0.0},
                 2,
                 None,
                 "no_gain",
             ),
             (
-                {"carbon": 4.0, "nitrogen": 2.0, "phosphorus": 1.0},
-                {"carbon": 1.0, "nitrogen": 0.5, "phosphorus": 0.25},
+                {"C": 4.0, "N": 2.0, "P": 1.0},
+                {"C": 1.0, "N": 0.5, "P": 0.25},
                 0,
                 KeyError,
                 "no_waste_pool",
             ),
             (
-                {"carbon": 5.0, "nitrogen": 2.5, "phosphorus": 1.0},
+                {"C": 5.0, "N": 2.5, "P": 1.0},
                 {},
                 0,
                 None,
@@ -1787,9 +1778,9 @@ class TestAnimalCohort:
             )
 
             expected = {
-                "carbon": gain["carbon"] * 0.5 * 2,
-                "nitrogen": gain["nitrogen"] * 0.5 * 2,
-                "phosphorus": gain["phosphorus"] * 0.5 * 2,
+                "C": gain["C"] * 0.5 * 2,
+                "N": gain["N"] * 0.5 * 2,
+                "P": gain["P"] * 0.5 * 2,
             }
 
             assert result == expected
@@ -1809,7 +1800,7 @@ class TestAnimalCohort:
         mock_forage = mocker.patch.object(
             cohort,
             "forage_resource_list",
-            return_value={"carbon": 1, "nitrogen": 2, "phosphorus": 3},
+            return_value={"C": 1, "N": 2, "P": 3},
         )
 
         result = cohort.delta_mass_herbivory(
@@ -1825,7 +1816,7 @@ class TestAnimalCohort:
             herbivory_waste_pools=waste_pools,
             resource_kind="plant_resource",
         )
-        assert result == {"carbon": 1, "nitrogen": 2, "phosphorus": 3}
+        assert result == {"C": 1, "N": 2, "P": 3}
 
     def test_delta_mass_detritivory_calls_forage_resource_list(
         self, herbivore_cohort_instance, mocker
@@ -1837,7 +1828,7 @@ class TestAnimalCohort:
         mock_forage = mocker.patch.object(
             cohort,
             "forage_resource_list",
-            return_value={"carbon": 1, "nitrogen": 2, "phosphorus": 3},
+            return_value={"C": 1, "N": 2, "P": 3},
         )
 
         result = cohort.delta_mass_detritivory(pools, adjusted_dt=7.5)
@@ -1848,7 +1839,7 @@ class TestAnimalCohort:
             calculate_consumed_mass=cohort._consumed_resource_mass,
             resource_kind="litter_pool",
         )
-        assert result == {"carbon": 1, "nitrogen": 2, "phosphorus": 3}
+        assert result == {"C": 1, "N": 2, "P": 3}
 
     def test_delta_mass_carcass_scavenging_calls_forage_resource_list(
         self, herbivore_cohort_instance, mocker
@@ -1860,7 +1851,7 @@ class TestAnimalCohort:
         mock_forage = mocker.patch.object(
             cohort,
             "forage_resource_list",
-            return_value={"carbon": 1.0, "nitrogen": 2.0, "phosphorus": 3.0},
+            return_value={"C": 1.0, "N": 2.0, "P": 3.0},
         )
 
         result = cohort.delta_mass_carcass_scavenging(
@@ -1875,7 +1866,7 @@ class TestAnimalCohort:
             resource_kind="carcass_pool",
         )
 
-        assert result == {"carbon": 1.0, "nitrogen": 2.0, "phosphorus": 3.0}
+        assert result == {"C": 1.0, "N": 2.0, "P": 3.0}
 
     def test_delta_mass_excrement_scavenging_calls_forage_resource_list(
         self, herbivore_cohort_instance, mocker
@@ -1887,7 +1878,7 @@ class TestAnimalCohort:
         mock_forage = mocker.patch.object(
             cohort,
             "forage_resource_list",
-            return_value={"carbon": 4.0, "nitrogen": 1.0, "phosphorus": 0.5},
+            return_value={"C": 4.0, "N": 1.0, "P": 0.5},
         )
 
         result = cohort.delta_mass_excrement_scavenging(
@@ -1902,7 +1893,7 @@ class TestAnimalCohort:
             resource_kind="excrement_pool",
         )
 
-        assert result == {"carbon": 4.0, "nitrogen": 1.0, "phosphorus": 0.5}
+        assert result == {"C": 4.0, "N": 1.0, "P": 0.5}
 
     def test_delta_mass_fruiting_fungivory_calls_forage_resource_list(
         self, herbivore_cohort_instance, mocker
@@ -1915,7 +1906,7 @@ class TestAnimalCohort:
         mock_forage = mocker.patch.object(
             cohort,
             "forage_resource_list",
-            return_value={"carbon": 1, "nitrogen": 2, "phosphorus": 3},
+            return_value={"C": 1, "N": 2, "P": 3},
         )
 
         result = cohort.delta_mass_fruiting_fungivory(
@@ -1931,7 +1922,7 @@ class TestAnimalCohort:
             herbivory_waste_pools=waste_pools,
             resource_kind="fungal_fruit_pool",
         )
-        assert result == {"carbon": 1, "nitrogen": 2, "phosphorus": 3}
+        assert result == {"C": 1, "N": 2, "P": 3}
 
     def test_delta_mass_soil_fungivory_calls_forage_resource_list(
         self, herbivore_cohort_instance, mocker
@@ -1943,7 +1934,7 @@ class TestAnimalCohort:
         mock_forage = mocker.patch.object(
             cohort,
             "forage_resource_list",
-            return_value={"carbon": 4, "nitrogen": 5, "phosphorus": 6},
+            return_value={"C": 4, "N": 5, "P": 6},
         )
 
         result = cohort.delta_mass_soil_fungivory(
@@ -1958,7 +1949,7 @@ class TestAnimalCohort:
             herbivory_waste_pools=None,
             resource_kind="soil_fungi_pool",
         )
-        assert result == {"carbon": 4, "nitrogen": 5, "phosphorus": 6}
+        assert result == {"C": 4, "N": 5, "P": 6}
 
     def test_delta_mass_pomivory_calls_forage_resource_list(
         self, herbivore_cohort_instance, mocker
@@ -1970,7 +1961,7 @@ class TestAnimalCohort:
         mock_forage = mocker.patch.object(
             cohort,
             "forage_resource_list",
-            return_value={"carbon": 7, "nitrogen": 8, "phosphorus": 9},
+            return_value={"C": 7, "N": 8, "P": 9},
         )
 
         result = cohort.delta_mass_pomivory(
@@ -1985,7 +1976,7 @@ class TestAnimalCohort:
             herbivory_waste_pools=None,  #
             resource_kind="pom_pool",
         )
-        assert result == {"carbon": 7, "nitrogen": 8, "phosphorus": 9}
+        assert result == {"C": 7, "N": 8, "P": 9}
 
     def test_delta_mass_bacteriophagy_calls_forage_resource_list(
         self, herbivore_cohort_instance, mocker
@@ -1997,7 +1988,7 @@ class TestAnimalCohort:
         mock_forage = mocker.patch.object(
             cohort,
             "forage_resource_list",
-            return_value={"carbon": 10, "nitrogen": 11, "phosphorus": 12},
+            return_value={"C": 10, "N": 11, "P": 12},
         )
 
         result = cohort.delta_mass_bacteriophagy(
@@ -2012,7 +2003,7 @@ class TestAnimalCohort:
             herbivory_waste_pools=None,
             resource_kind="bacteria_pool",
         )
-        assert result == {"carbon": 10, "nitrogen": 11, "phosphorus": 12}
+        assert result == {"C": 10, "N": 11, "P": 12}
 
     @pytest.mark.parametrize(
         "cohort_instance, diet_string, plant_list, animal_list, fungal_fruit_list,"
@@ -2028,7 +2019,7 @@ class TestAnimalCohort:
                 [],
                 [],
                 [],
-                {"carbon": 60.0, "nitrogen": 30.0, "phosphorus": 10.0},
+                {"C": 60.0, "N": 30.0, "P": 10.0},
                 "delta_mass_herbivory",
             ),
             (
@@ -2040,7 +2031,7 @@ class TestAnimalCohort:
                 [],
                 [],
                 [],
-                {"carbon": 120.0, "nitrogen": 60.0, "phosphorus": 20.0},
+                {"C": 120.0, "N": 60.0, "P": 20.0},
                 "delta_mass_predation",
             ),
             (
@@ -2052,7 +2043,7 @@ class TestAnimalCohort:
                 [],
                 [],
                 [],
-                {"carbon": 25.0, "nitrogen": 5.0, "phosphorus": 2.5},
+                {"C": 25.0, "N": 5.0, "P": 2.5},
                 "delta_mass_fruiting_fungivory",
             ),
         ],
@@ -2166,7 +2157,7 @@ class TestAnimalCohort:
         cohort.functional_group.diet = DietType.parse("detritus_fungi_pom_bacteria")
 
         # Patch delta-mass methods to observe calls and avoid side effects.
-        expected = {"carbon": 1.0, "nitrogen": 0.5, "phosphorus": 0.1}
+        expected = {"C": 1.0, "N": 0.5, "P": 0.1}
         m_det = mocker.patch.object(
             cohort, "delta_mass_detritivory", return_value=expected
         )
@@ -3434,7 +3425,7 @@ class TestAnimalCohort:
         assert len(result) == expected
 
     @pytest.mark.parametrize(
-        "carbon, nitrogen, phosphorus, initial_largest_mass, expected_largest_mass",
+        "C, N, P, initial_largest_mass, expected_largest_mass",
         [
             # Grows, still under adult mass
             (6.0, 1.0, 0.5, 5.0, 7.5),
@@ -3447,18 +3438,18 @@ class TestAnimalCohort:
     def test_update_largest_mass(
         self,
         herbivore_cohort_instance,
-        carbon,
-        nitrogen,
-        phosphorus,
+        C,
+        N,
+        P,
         initial_largest_mass,
         expected_largest_mass,
     ):
         """Test update_largest_mass."""
 
         # Set up current mass via mass_cnp
-        herbivore_cohort_instance.mass_cnp.carbon = carbon
-        herbivore_cohort_instance.mass_cnp.nitrogen = nitrogen
-        herbivore_cohort_instance.mass_cnp.phosphorus = phosphorus
+        herbivore_cohort_instance.mass_cnp.C = C
+        herbivore_cohort_instance.mass_cnp.N = N
+        herbivore_cohort_instance.mass_cnp.P = P
 
         # Set initial largest_mass_achieved
         herbivore_cohort_instance.largest_mass_achieved = initial_largest_mass

--- a/tests/models/animals/test_animal_model.py
+++ b/tests/models/animals/test_animal_model.py
@@ -476,8 +476,8 @@ class TestAnimalModel:
                     expected_p = expected_carbon / c_p_ratio.values[cell_id]
 
                     assert np.isclose(pool.mass_current, expected_carbon)
-                    assert np.isclose(pool.mass_cnp.nitrogen, expected_n)
-                    assert np.isclose(pool.mass_cnp.phosphorus, expected_p)
+                    assert np.isclose(pool.mass_cnp.N, expected_n)
+                    assert np.isclose(pool.mass_cnp.P, expected_p)
 
     def test_populate_soil_pools(self, animal_model_instance):
         """Test that populating of the soil resource pools works as expected."""
@@ -508,10 +508,10 @@ class TestAnimalModel:
                     pool.mass_current, expected_carbon[pool_name][cell_id]
                 )
                 assert np.isclose(
-                    pool.mass_cnp.nitrogen, expected_nitrogen[pool_name][cell_id]
+                    pool.mass_cnp.N, expected_nitrogen[pool_name][cell_id]
                 )
                 assert np.isclose(
-                    pool.mass_cnp.phosphorus,
+                    pool.mass_cnp.P,
                     expected_phosphorus[pool_name][cell_id],
                 )
 
@@ -526,8 +526,8 @@ class TestAnimalModel:
 
         for cell_id, pool in fungal_fruiting_bodies.items():
             assert np.isclose(pool.mass_current, expected_carbon[cell_id])
-            assert np.isclose(pool.mass_cnp.nitrogen, expected_nitrogen[cell_id])
-            assert np.isclose(pool.mass_cnp.phosphorus, expected_phosphorus[cell_id])
+            assert np.isclose(pool.mass_cnp.N, expected_nitrogen[cell_id])
+            assert np.isclose(pool.mass_cnp.P, expected_phosphorus[cell_id])
 
     def test_populate_soil_pools_negative(self, animal_model_instance):
         """Test that trying to populate a negative soil pool causes an error."""
@@ -799,11 +799,11 @@ class TestAnimalModel:
             for cell_id in model.fungal_fruiting_bodies
         ]
         actual_new_nitrogen_mass = [
-            model.fungal_fruiting_bodies[cell_id].mass_cnp["nitrogen"]
+            model.fungal_fruiting_bodies[cell_id].mass_cnp["N"]
             for cell_id in model.fungal_fruiting_bodies
         ]
         actual_new_phosphorus_mass = [
-            model.fungal_fruiting_bodies[cell_id].mass_cnp["phosphorus"]
+            model.fungal_fruiting_bodies[cell_id].mass_cnp["P"]
             for cell_id in model.fungal_fruiting_bodies
         ]
 
@@ -1362,20 +1362,20 @@ class TestAnimalModel:
         # Set up mock cohort with dynamic mass and age values
         cohort = herbivore_cohort_instance
         cohort.age = age
-        cohort.mass_cnp.carbon = (
+        cohort.mass_cnp.C = (
             cohort.functional_group.adult_mass
             * mass_ratio
-            * cohort.cnp_proportions["carbon"]
+            * cohort.cnp_proportions["C"]
         )
-        cohort.mass_cnp.nitrogen = (
+        cohort.mass_cnp.N = (
             cohort.functional_group.adult_mass
             * mass_ratio
-            * cohort.cnp_proportions["nitrogen"]
+            * cohort.cnp_proportions["N"]
         )
-        cohort.mass_cnp.phosphorus = (
+        cohort.mass_cnp.P = (
             cohort.functional_group.adult_mass
             * mass_ratio
-            * cohort.cnp_proportions["phosphorus"]
+            * cohort.cnp_proportions["P"]
         )
 
         cohort_id = cohort.id
@@ -1550,9 +1550,9 @@ class TestAnimalModel:
 
         # Set return values for helpers
         mock_calculate_mass.return_value = {
-            "carbon": 1.0,
-            "nitrogen": 0.1,
-            "phosphorus": 0.05,
+            "C": 1.0,
+            "N": 0.1,
+            "P": 0.05,
         }
         mock_calculate_count.return_value = offspring_count
 
@@ -1581,15 +1581,15 @@ class TestAnimalModel:
         [
             # Case 1: No semelparous loss (iteroparous species)
             (
-                {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0},
-                {"carbon": 0.5, "nitrogen": 0.1, "phosphorus": 0.05},
-                {"carbon": 0.5, "nitrogen": 0.1, "phosphorus": 0.05},
+                {"C": 0.0, "N": 0.0, "P": 0.0},
+                {"C": 0.5, "N": 0.1, "P": 0.05},
+                {"C": 0.5, "N": 0.1, "P": 0.05},
             ),
             # Case 2: Semelparous species with mass loss contribution
             (
-                {"carbon": 0.2, "nitrogen": 0.05, "phosphorus": 0.01},
-                {"carbon": 0.5, "nitrogen": 0.1, "phosphorus": 0.05},
-                {"carbon": 0.7, "nitrogen": 0.15, "phosphorus": 0.06},
+                {"C": 0.2, "N": 0.05, "P": 0.01},
+                {"C": 0.5, "N": 0.1, "P": 0.05},
+                {"C": 0.7, "N": 0.15, "P": 0.06},
             ),
         ],
     )
@@ -1623,48 +1623,48 @@ class TestAnimalModel:
         )
 
         # Check result using pytest.approx for floats
-        assert result["carbon"] == pytest.approx(expected_total_mass["carbon"])
-        assert result["nitrogen"] == pytest.approx(expected_total_mass["nitrogen"])
-        assert result["phosphorus"] == pytest.approx(expected_total_mass["phosphorus"])
+        assert result["C"] == pytest.approx(expected_total_mass["C"])
+        assert result["N"] == pytest.approx(expected_total_mass["N"])
+        assert result["P"] == pytest.approx(expected_total_mass["P"])
 
     @pytest.mark.parametrize(
         "birth_mass_cnp, reproductive_mass, individuals, expected_offspring",
         [
             # Case 1: Exactly 1 offspring per parent
             (
-                {"carbon": 0.5, "nitrogen": 0.1, "phosphorus": 0.05},
-                {"carbon": 0.5, "nitrogen": 0.1, "phosphorus": 0.05},
+                {"C": 0.5, "N": 0.1, "P": 0.05},
+                {"C": 0.5, "N": 0.1, "P": 0.05},
                 1,
                 1,
             ),
             # Case 2: Exactly 2 offspring per parent
             (
-                {"carbon": 0.5, "nitrogen": 0.1, "phosphorus": 0.05},
-                {"carbon": 1.0, "nitrogen": 0.2, "phosphorus": 0.1},
+                {"C": 0.5, "N": 0.1, "P": 0.05},
+                {"C": 1.0, "N": 0.2, "P": 0.1},
                 1,
                 2,
             ),
             # Case 3: Not enough for any offspring
             (
-                {"carbon": 0.5, "nitrogen": 0.1, "phosphorus": 0.05},
-                {"carbon": 0.2, "nitrogen": 0.05, "phosphorus": 0.02},
+                {"C": 0.5, "N": 0.1, "P": 0.05},
+                {"C": 0.2, "N": 0.05, "P": 0.02},
                 1,
                 0,
             ),
             # Case 4: Multiple parents, each able to make 2 offspring
             (
-                {"carbon": 0.5, "nitrogen": 0.1, "phosphorus": 0.05},
-                {"carbon": 1.0, "nitrogen": 0.2, "phosphorus": 0.1},
+                {"C": 0.5, "N": 0.1, "P": 0.05},
+                {"C": 1.0, "N": 0.2, "P": 0.1},
                 2,
                 4,
             ),
             # Limiting nutrient - phosphorus
             (
-                {"carbon": 0.5, "nitrogen": 0.1, "phosphorus": 0.05},
+                {"C": 0.5, "N": 0.1, "P": 0.05},
                 {
-                    "carbon": 10.0,
-                    "nitrogen": 10.0,
-                    "phosphorus": 0.1,
+                    "C": 10.0,
+                    "N": 10.0,
+                    "P": 0.1,
                 },  # 1 parent, P limits to 2 offspring
                 1,
                 2,
@@ -1690,9 +1690,9 @@ class TestAnimalModel:
             animal_model_instance,
             "calculate_birth_mass_cnp",
             return_value=(
-                birth_mass_cnp["carbon"],
-                birth_mass_cnp["nitrogen"],
-                birth_mass_cnp["phosphorus"],
+                birth_mass_cnp["C"],
+                birth_mass_cnp["N"],
+                birth_mass_cnp["P"],
             ),
         )
 
@@ -1711,37 +1711,37 @@ class TestAnimalModel:
             # Iteroparous parent - reproductive mass reduces but parent survives
             (
                 "iteroparous",
-                {"carbon": 2.0, "nitrogen": 0.5, "phosphorus": 0.2},
+                {"C": 2.0, "N": 0.5, "P": 0.2},
                 2,
                 (0.5, 0.1, 0.05),  # Per offspring birth mass C, N, P
-                {"carbon": 1.0, "nitrogen": 0.3, "phosphorus": 0.1},
+                {"C": 1.0, "N": 0.3, "P": 0.1},
                 False,
             ),
             # Semelparous parent - reproductive mass reduces and parent dies
             (
                 "semelparous",
-                {"carbon": 2.0, "nitrogen": 0.5, "phosphorus": 0.2},
+                {"C": 2.0, "N": 0.5, "P": 0.2},
                 2,
                 (0.5, 0.1, 0.05),
-                {"carbon": 1.0, "nitrogen": 0.3, "phosphorus": 0.1},
+                {"C": 1.0, "N": 0.3, "P": 0.1},
                 True,
             ),
             # More offspring than available reproductive mass - cap at available mass
             (
                 "iteroparous",
-                {"carbon": 0.5, "nitrogen": 0.2, "phosphorus": 0.1},
+                {"C": 0.5, "N": 0.2, "P": 0.1},
                 5,
                 (0.5, 0.1, 0.05),
-                {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0},
+                {"C": 0.0, "N": 0.0, "P": 0.0},
                 False,
             ),
             # No offspring at all - nothing should change
             (
                 "iteroparous",
-                {"carbon": 2.0, "nitrogen": 0.5, "phosphorus": 0.2},
+                {"C": 2.0, "N": 0.5, "P": 0.2},
                 0,
                 (0.5, 0.1, 0.05),  # Doesn't matter since 0 offspring
-                {"carbon": 2.0, "nitrogen": 0.5, "phosphorus": 0.2},
+                {"C": 2.0, "N": 0.5, "P": 0.2},
                 False,
             ),
         ],
@@ -1785,16 +1785,14 @@ class TestAnimalModel:
         )
 
         # Check that the reproductive mass was correctly updated (with float tolerance)
-        assert herbivore_cohort_instance.reproductive_mass_cnp.carbon == pytest.approx(
-            expected_remaining_mass["carbon"]
+        assert herbivore_cohort_instance.reproductive_mass_cnp.C == pytest.approx(
+            expected_remaining_mass["C"]
         )
-        assert (
-            herbivore_cohort_instance.reproductive_mass_cnp.nitrogen
-            == pytest.approx(expected_remaining_mass["nitrogen"])
+        assert herbivore_cohort_instance.reproductive_mass_cnp.N == pytest.approx(
+            expected_remaining_mass["N"]
         )
-        assert (
-            herbivore_cohort_instance.reproductive_mass_cnp.phosphorus
-            == pytest.approx(expected_remaining_mass["phosphorus"])
+        assert herbivore_cohort_instance.reproductive_mass_cnp.P == pytest.approx(
+            expected_remaining_mass["P"]
         )
 
         # Check if semelparous death was correctly triggered or skipped
@@ -1810,12 +1808,10 @@ class TestAnimalModel:
         from virtual_ecosystem.models.animal.cnp import CNP
 
         # Set initial CNP mass (arbitrary non-zero starting mass)
-        herbivore_cohort_instance.mass_cnp = CNP(
-            carbon=5.0, nitrogen=1.0, phosphorus=0.5
-        )
+        herbivore_cohort_instance.mass_cnp = CNP(C=5.0, N=1.0, P=0.5)
 
         # Mock the loss from calculate_semelparous_mass_loss
-        semelparous_loss = {"carbon": 2.0, "nitrogen": 0.5, "phosphorus": 0.2}
+        semelparous_loss = {"C": 2.0, "N": 0.5, "P": 0.2}
         mocker.patch.object(
             animal_model_instance,
             "calculate_semelparous_mass_loss",
@@ -1831,9 +1827,9 @@ class TestAnimalModel:
         animal_model_instance.handle_semelparous_parent_death(herbivore_cohort_instance)
 
         # Check mass was reduced correctly
-        assert herbivore_cohort_instance.mass_cnp.carbon == pytest.approx(3.0)
-        assert herbivore_cohort_instance.mass_cnp.nitrogen == pytest.approx(0.5)
-        assert herbivore_cohort_instance.mass_cnp.phosphorus == pytest.approx(0.3)
+        assert herbivore_cohort_instance.mass_cnp.C == pytest.approx(3.0)
+        assert herbivore_cohort_instance.mass_cnp.N == pytest.approx(0.5)
+        assert herbivore_cohort_instance.mass_cnp.P == pytest.approx(0.3)
 
         # Check parent marked as dead
         assert herbivore_cohort_instance.is_alive is False
@@ -1847,14 +1843,14 @@ class TestAnimalModel:
             # Case 1: Semelparous species with 50% loss applied
             (
                 "semelparous",
-                {"carbon": 10.0, "nitrogen": 2.0, "phosphorus": 1.0},
-                {"carbon": 5.0, "nitrogen": 1.0, "phosphorus": 0.5},
+                {"C": 10.0, "N": 2.0, "P": 1.0},
+                {"C": 5.0, "N": 1.0, "P": 0.5},
             ),
             # Case 2: Iteroparous species (no loss applied)
             (
                 "iteroparous",
-                {"carbon": 10.0, "nitrogen": 2.0, "phosphorus": 1.0},
-                {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0},
+                {"C": 10.0, "N": 2.0, "P": 1.0},
+                {"C": 0.0, "N": 0.0, "P": 0.0},
             ),
         ],
     )
@@ -1879,9 +1875,9 @@ class TestAnimalModel:
         )
 
         # Check result matches expected loss (with float tolerance)
-        assert result["carbon"] == pytest.approx(expected_loss["carbon"])
-        assert result["nitrogen"] == pytest.approx(expected_loss["nitrogen"])
-        assert result["phosphorus"] == pytest.approx(expected_loss["phosphorus"])
+        assert result["C"] == pytest.approx(expected_loss["C"])
+        assert result["N"] == pytest.approx(expected_loss["N"])
+        assert result["P"] == pytest.approx(expected_loss["P"])
 
     @pytest.mark.parametrize(
         "birth_mass, cnp_proportions, expected_birth_cnp",
@@ -1889,19 +1885,19 @@ class TestAnimalModel:
             # Standard balanced case
             (
                 1.0,
-                {"carbon": 0.5, "nitrogen": 0.3, "phosphorus": 0.2},
+                {"C": 0.5, "N": 0.3, "P": 0.2},
                 (0.5, 0.3, 0.2),
             ),
             # Larger birth mass
             (
                 10.0,
-                {"carbon": 0.5, "nitrogen": 0.3, "phosphorus": 0.2},
+                {"C": 0.5, "N": 0.3, "P": 0.2},
                 (5.0, 3.0, 2.0),
             ),
             # Zero birth mass (should return all zeros)
             (
                 0.0,
-                {"carbon": 0.5, "nitrogen": 0.3, "phosphorus": 0.2},
+                {"C": 0.5, "N": 0.3, "P": 0.2},
                 (0.0, 0.0, 0.0),
             ),
         ],

--- a/tests/models/animals/test_cnp.py
+++ b/tests/models/animals/test_cnp.py
@@ -9,29 +9,29 @@ class TestCNP:
     """Test the CNP dataclass."""
 
     @pytest.mark.parametrize(
-        "carbon, nitrogen, phosphorus, expected_total",
+        "C, N, P, expected_total",
         [
             (10.0, 5.0, 2.0, 17.0),
             (0.0, 0.0, 0.0, 0.0),
             (1.2, 0.8, 0.5, 2.5),
         ],
     )
-    def test_total(self, carbon, nitrogen, phosphorus, expected_total):
+    def test_total(self, C, N, P, expected_total):
         """Test total mass calculation."""
-        cnp = CNP(carbon, nitrogen, phosphorus)
+        cnp = CNP(C, N, P)
         assert cnp.total == pytest.approx(expected_total)
 
     @pytest.mark.parametrize(
-        "carbon, nitrogen, phosphorus, key, expected_value",
+        "C, N, P, key, expected_value",
         [
-            (10.0, 5.0, 2.0, "carbon", 10.0),
-            (10.0, 5.0, 2.0, "nitrogen", 5.0),
-            (10.0, 5.0, 2.0, "phosphorus", 2.0),
+            (10.0, 5.0, 2.0, "C", 10.0),
+            (10.0, 5.0, 2.0, "N", 5.0),
+            (10.0, 5.0, 2.0, "P", 2.0),
         ],
     )
-    def test_getitem(self, carbon, nitrogen, phosphorus, key, expected_value):
+    def test_getitem(self, C, N, P, key, expected_value):
         """Test dictionary-style access."""
-        cnp = CNP(carbon, nitrogen, phosphorus)
+        cnp = CNP(C, N, P)
         assert cnp[key] == pytest.approx(expected_value)
 
     def test_getitem_invalid_key(self):
@@ -46,45 +46,45 @@ class TestCNP:
             # Successful additions
             (
                 (10.0, 5.0, 2.0),
-                {"carbon": 3.0, "nitrogen": 2.0, "phosphorus": 1.0},
+                {"C": 3.0, "N": 2.0, "P": 1.0},
                 (13.0, 7.0, 3.0),
                 False,
             ),  # Regular addition
             # Successful subtractions
             (
                 (10.0, 5.0, 2.0),
-                {"carbon": -3.0, "nitrogen": -2.0, "phosphorus": -1.0},
+                {"C": -3.0, "N": -2.0, "P": -1.0},
                 (7.0, 3.0, 1.0),
                 False,
             ),  # Regular subtraction
             (
                 (2.0, 2.0, 2.0),
-                {"carbon": -1.0, "nitrogen": -1.0, "phosphorus": -1.0},
+                {"C": -1.0, "N": -1.0, "P": -1.0},
                 (1.0, 1.0, 1.0),
                 False,
             ),  # No negative totals
             # Error cases (negative totals)
             (
                 (1.0, 1.0, 1.0),
-                {"carbon": -2.0, "nitrogen": 0.0, "phosphorus": 0.0},
+                {"C": -2.0, "N": 0.0, "P": 0.0},
                 None,
                 True,
-            ),  # Carbon negative
+            ),  # C negative
             (
                 (1.0, 1.0, 1.0),
-                {"carbon": 0.0, "nitrogen": -2.0, "phosphorus": 0.0},
+                {"C": 0.0, "N": -2.0, "P": 0.0},
                 None,
                 True,
             ),  # Nitrogen negative
             (
                 (1.0, 1.0, 1.0),
-                {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": -2.0},
+                {"C": 0.0, "N": 0.0, "P": -2.0},
                 None,
                 True,
             ),  # Phosphorus negative
             (
                 (0.0, 0.0, 0.0),
-                {"carbon": -0.1, "nitrogen": -0.1, "phosphorus": -0.1},
+                {"C": -0.1, "N": -0.1, "P": -0.1},
                 None,
                 True,
             ),  # All negative from zero
@@ -99,19 +99,17 @@ class TestCNP:
                 cnp.update(**update_values)
         else:
             cnp.update(**update_values)
-            assert cnp.carbon == pytest.approx(expected[0]), "Carbon mass mismatch"
-            assert cnp.nitrogen == pytest.approx(expected[1]), "Nitrogen mass mismatch"
-            assert cnp.phosphorus == pytest.approx(expected[2]), (
-                "Phosphorus mass mismatch"
-            )
+            assert cnp.C == pytest.approx(expected[0]), "Carbon mass mismatch"
+            assert cnp.N == pytest.approx(expected[1]), "Nitrogen mass mismatch"
+            assert cnp.P == pytest.approx(expected[2]), "Phosphorus mass mismatch"
 
     def test_from_dict(self):
         """Test creating CNP instance from a dictionary."""
-        data = {"carbon": 10.0, "nitrogen": 5.0, "phosphorus": 2.0}
+        data = {"C": 10.0, "N": 5.0, "P": 2.0}
         cnp = CNP.from_dict(data)
-        assert cnp.carbon == pytest.approx(10.0)
-        assert cnp.nitrogen == pytest.approx(5.0)
-        assert cnp.phosphorus == pytest.approx(2.0)
+        assert cnp.C == pytest.approx(10.0)
+        assert cnp.N == pytest.approx(5.0)
+        assert cnp.P == pytest.approx(2.0)
 
     def test_get_ratios(self):
         """Test calculation of C:N and C:P ratios."""
@@ -133,17 +131,17 @@ class TestCNP:
         proportions = cnp.get_proportions()
         total_mass = 17.0
 
-        assert proportions["carbon"] == pytest.approx(10.0 / total_mass)
-        assert proportions["nitrogen"] == pytest.approx(5.0 / total_mass)
-        assert proportions["phosphorus"] == pytest.approx(2.0 / total_mass)
+        assert proportions["C"] == pytest.approx(10.0 / total_mass)
+        assert proportions["N"] == pytest.approx(5.0 / total_mass)
+        assert proportions["P"] == pytest.approx(2.0 / total_mass)
 
     def test_get_proportions_zero_handling(self):
         """Test proportion calculation when total mass is zero."""
         cnp = CNP(0.0, 0.0, 0.0)
         proportions = cnp.get_proportions()
-        assert proportions["carbon"] == 0.0
-        assert proportions["nitrogen"] == 0.0
-        assert proportions["phosphorus"] == 0.0
+        assert proportions["C"] == 0.0
+        assert proportions["N"] == 0.0
+        assert proportions["P"] == 0.0
 
 
 def test_find_microbial_stoichiometries(fixture_configuration):
@@ -151,10 +149,10 @@ def test_find_microbial_stoichiometries(fixture_configuration):
     from virtual_ecosystem.models.animal.cnp import find_microbial_stoichiometries
 
     expected_ratios = {
-        "bacteria": {"nitrogen": 5.2, "phosphorus": 16.0},
-        "saprotrophic_fungi": {"nitrogen": 6.5, "phosphorus": 40.0},
-        "arbuscular_mycorrhiza": {"nitrogen": 18.0, "phosphorus": 120.0},
-        "ectomycorrhiza": {"nitrogen": 18.0, "phosphorus": 120.0},
+        "bacteria": {"N": 5.2, "P": 16.0},
+        "saprotrophic_fungi": {"N": 6.5, "P": 40.0},
+        "arbuscular_mycorrhiza": {"N": 18.0, "P": 120.0},
+        "ectomycorrhiza": {"N": 18.0, "P": 120.0},
     }
 
     actual_ratios = find_microbial_stoichiometries(config=fixture_configuration)

--- a/tests/models/animals/test_decay.py
+++ b/tests/models/animals/test_decay.py
@@ -17,20 +17,16 @@ class TestCarcassPool:
         from virtual_ecosystem.models.animal.decay import CarcassPool
 
         carcasses = CarcassPool(
-            scavengeable_cnp=CNP(
-                carbon=1.0007e-2, nitrogen=0.000133333332, phosphorus=1.33333332e-6
-            ),
-            decomposed_cnp=CNP(
-                carbon=2.5e-5, nitrogen=3.3333333e-6, phosphorus=3.3333333e-8
-            ),
+            scavengeable_cnp=CNP(C=1.0007e-2, N=0.000133333332, P=1.33333332e-6),
+            decomposed_cnp=CNP(C=2.5e-5, N=3.3333333e-6, P=3.3333333e-8),
         )
 
-        assert pytest.approx(carcasses.scavengeable_cnp.carbon) == 1.0007e-2
-        assert pytest.approx(carcasses.decomposed_cnp.carbon) == 2.5e-5
-        assert pytest.approx(carcasses.scavengeable_cnp.nitrogen) == 0.000133333332
-        assert pytest.approx(carcasses.decomposed_cnp.nitrogen) == 3.3333333e-6
-        assert pytest.approx(carcasses.scavengeable_cnp.phosphorus) == 1.33333332e-6
-        assert pytest.approx(carcasses.decomposed_cnp.phosphorus) == 3.3333333e-8
+        assert pytest.approx(carcasses.scavengeable_cnp.C) == 1.0007e-2
+        assert pytest.approx(carcasses.decomposed_cnp.C) == 2.5e-5
+        assert pytest.approx(carcasses.scavengeable_cnp.N) == 0.000133333332
+        assert pytest.approx(carcasses.decomposed_cnp.N) == 3.3333333e-6
+        assert pytest.approx(carcasses.scavengeable_cnp.P) == 1.33333332e-6
+        assert pytest.approx(carcasses.decomposed_cnp.P) == 3.3333333e-8
 
     def test_decomposed_nutrient_per_area(self):
         """Test conversion of decomposed carcass nutrient content to per area basis."""
@@ -38,21 +34,18 @@ class TestCarcassPool:
         from virtual_ecosystem.models.animal.decay import CarcassPool
 
         carcasses = CarcassPool(
-            decomposed_cnp=CNP(
-                carbon=2.5e-5, nitrogen=3.3333333e-6, phosphorus=3.3333333e-8
-            )
+            decomposed_cnp=CNP(C=2.5e-5, N=3.3333333e-6, P=3.3333333e-8)
         )
 
         assert (
-            pytest.approx(carcasses.decomposed_nutrient_per_area("carbon", 10000))
-            == 2.5e-9
+            pytest.approx(carcasses.decomposed_nutrient_per_area("C", 10000)) == 2.5e-9
         )
         assert (
-            pytest.approx(carcasses.decomposed_nutrient_per_area("nitrogen", 10000))
+            pytest.approx(carcasses.decomposed_nutrient_per_area("N", 10000))
             == 3.3333333e-10
         )
         assert (
-            pytest.approx(carcasses.decomposed_nutrient_per_area("phosphorus", 10000))
+            pytest.approx(carcasses.decomposed_nutrient_per_area("P", 10000))
             == 3.3333333e-12
         )
 
@@ -60,8 +53,7 @@ class TestCarcassPool:
             carcasses.decomposed_nutrient_per_area("molybdenum", 10000)
 
     @pytest.mark.parametrize(
-        "carbon, nitrogen, phosphorus, expected_c, expected_n, expected_p,"
-        "raises_exception",
+        "C, N, P, expected_c, expected_n, expected_p,raises_exception",
         [
             (5.0, 1.0, 0.5, 5.0, 1.0, 0.5, False),  # Normal case
             (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, False),  # Zero mass
@@ -70,9 +62,9 @@ class TestCarcassPool:
     )
     def test_add_carcass(
         self,
-        carbon,
-        nitrogen,
-        phosphorus,
+        C,
+        N,
+        P,
         expected_c,
         expected_n,
         expected_p,
@@ -85,12 +77,12 @@ class TestCarcassPool:
 
         if raises_exception:
             with pytest.raises(ValueError):
-                carcasses.add_carcass(carbon, nitrogen, phosphorus)
+                carcasses.add_carcass(C, N, P)
         else:
-            carcasses.add_carcass(carbon, nitrogen, phosphorus)
-            assert carcasses.scavengeable_cnp.carbon == pytest.approx(expected_c)
-            assert carcasses.scavengeable_cnp.nitrogen == pytest.approx(expected_n)
-            assert carcasses.scavengeable_cnp.phosphorus == pytest.approx(expected_p)
+            carcasses.add_carcass(C, N, P)
+            assert carcasses.scavengeable_cnp.C == pytest.approx(expected_c)
+            assert carcasses.scavengeable_cnp.N == pytest.approx(expected_n)
+            assert carcasses.scavengeable_cnp.P == pytest.approx(expected_p)
 
         def test_reset(self):
             """Test resetting of the carcass pool."""
@@ -98,16 +90,16 @@ class TestCarcassPool:
 
             carcasses = CarcassPool(
                 decomposed_cnp={
-                    "carbon": 2.5e-5,
-                    "nitrogen": 3.3333333e-6,
-                    "phosphorus": 3.3333333e-8,
+                    "C": 2.5e-5,
+                    "N": 3.3333333e-6,
+                    "P": 3.3333333e-8,
                 }
             )
             carcasses.reset()
 
-            assert carcasses.decomposed_cnp["carbon"] == 0.0
-            assert carcasses.decomposed_cnp["nitrogen"] == 0.0
-            assert carcasses.decomposed_cnp["phosphorus"] == 0.0
+            assert carcasses.decomposed_cnp["C"] == 0.0
+            assert carcasses.decomposed_cnp["N"] == 0.0
+            assert carcasses.decomposed_cnp["P"] == 0.0
 
 
 class TestExcrementPool:
@@ -120,22 +112,19 @@ class TestExcrementPool:
         from virtual_ecosystem.models.animal.decay import ExcrementPool
 
         excrement = ExcrementPool(
-            scavengeable_cnp=CNP(carbon=7.77e-5, nitrogen=1e-5, phosphorus=1e-7),
-            decomposed_cnp=CNP(
-                carbon=2.5e-5, nitrogen=3.3333333e-6, phosphorus=3.3333333e-8
-            ),
+            scavengeable_cnp=CNP(C=7.77e-5, N=1e-5, P=1e-7),
+            decomposed_cnp=CNP(C=2.5e-5, N=3.3333333e-6, P=3.3333333e-8),
         )
 
-        assert pytest.approx(excrement.scavengeable_cnp.carbon) == 7.77e-5
-        assert pytest.approx(excrement.decomposed_cnp.carbon) == 2.5e-5
-        assert pytest.approx(excrement.scavengeable_cnp.nitrogen) == 1e-5
-        assert pytest.approx(excrement.decomposed_cnp.nitrogen) == 3.3333333e-6
-        assert pytest.approx(excrement.scavengeable_cnp.phosphorus) == 1e-7
-        assert pytest.approx(excrement.decomposed_cnp.phosphorus) == 3.3333333e-8
+        assert pytest.approx(excrement.scavengeable_cnp.C) == 7.77e-5
+        assert pytest.approx(excrement.decomposed_cnp.C) == 2.5e-5
+        assert pytest.approx(excrement.scavengeable_cnp.N) == 1e-5
+        assert pytest.approx(excrement.decomposed_cnp.N) == 3.3333333e-6
+        assert pytest.approx(excrement.scavengeable_cnp.P) == 1e-7
+        assert pytest.approx(excrement.decomposed_cnp.P) == 3.3333333e-8
 
     @pytest.mark.parametrize(
-        "carbon, nitrogen, phosphorus, expected_c, expected_n, expected_p,"
-        "raises_exception",
+        "C, N, P, expected_c, expected_n, expected_p,raises_exception",
         [
             (5.0, 1.0, 0.5, 5.0, 1.0, 0.5, False),  # Normal case
             (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, False),  # Zero mass
@@ -144,9 +133,9 @@ class TestExcrementPool:
     )
     def test_add_excrement(
         self,
-        carbon,
-        nitrogen,
-        phosphorus,
+        C,
+        N,
+        P,
         expected_c,
         expected_n,
         expected_p,
@@ -159,12 +148,12 @@ class TestExcrementPool:
 
         if raises_exception:
             with pytest.raises(ValueError):
-                excrement.add_excrement(carbon, nitrogen, phosphorus)
+                excrement.add_excrement(C, N, P)
         else:
-            excrement.add_excrement(carbon, nitrogen, phosphorus)
-            assert excrement.scavengeable_cnp.carbon == pytest.approx(expected_c)
-            assert excrement.scavengeable_cnp.nitrogen == pytest.approx(expected_n)
-            assert excrement.scavengeable_cnp.phosphorus == pytest.approx(expected_p)
+            excrement.add_excrement(C, N, P)
+            assert excrement.scavengeable_cnp.C == pytest.approx(expected_c)
+            assert excrement.scavengeable_cnp.N == pytest.approx(expected_n)
+            assert excrement.scavengeable_cnp.P == pytest.approx(expected_p)
 
     def test_reset(self):
         """Test resetting of the excrement pool."""
@@ -173,17 +162,15 @@ class TestExcrementPool:
         from virtual_ecosystem.models.animal.decay import ExcrementPool
 
         excrement = ExcrementPool(
-            decomposed_cnp=CNP(
-                carbon=2.5e-5, nitrogen=3.3333333e-6, phosphorus=3.3333333e-8
-            )
+            decomposed_cnp=CNP(C=2.5e-5, N=3.3333333e-6, P=3.3333333e-8)
         )
 
         # Call reset (should set all values to 0.0)
         excrement.reset()
 
-        assert excrement.decomposed_cnp.carbon == 0.0
-        assert excrement.decomposed_cnp.nitrogen == 0.0
-        assert excrement.decomposed_cnp.phosphorus == 0.0
+        assert excrement.decomposed_cnp.C == 0.0
+        assert excrement.decomposed_cnp.N == 0.0
+        assert excrement.decomposed_cnp.P == 0.0
 
 
 @pytest.mark.parametrize(
@@ -243,9 +230,9 @@ class TestFungalFruitPool:
         n_mass = c_mass / 10.0
         p_mass = c_mass / 75.0
 
-        assert np.isclose(litter_pool.mass_cnp.carbon, c_mass)
-        assert np.isclose(litter_pool.mass_cnp.nitrogen, n_mass)
-        assert np.isclose(litter_pool.mass_cnp.phosphorus, p_mass)
+        assert np.isclose(litter_pool.mass_cnp.C, c_mass)
+        assert np.isclose(litter_pool.mass_cnp.N, n_mass)
+        assert np.isclose(litter_pool.mass_cnp.P, p_mass)
 
     def test_mass_current(self, mocker):
         """Test the mass_current property of FungalFruitPool."""
@@ -254,7 +241,7 @@ class TestFungalFruitPool:
 
         # Create a mock FungalFruitPool with a single CNP object
         soil_pool = mocker.Mock()
-        soil_pool.mass_cnp = CNP(carbon=12.34, nitrogen=1.0, phosphorus=0.5)
+        soil_pool.mass_cnp = CNP(C=12.34, N=1.0, P=0.5)
 
         # Access the property via descriptor protocol
         result = FungalFruitPool.mass_current.__get__(soil_pool)
@@ -295,9 +282,9 @@ class TestFungalFruitPool:
 
         nutrient_proportions = cell_cnp.get_proportions()
         expected_nutrients = {
-            "carbon": actual_consumed_mass * nutrient_proportions["carbon"],
-            "nitrogen": actual_consumed_mass * nutrient_proportions["nitrogen"],
-            "phosphorus": actual_consumed_mass * nutrient_proportions["phosphorus"],
+            "C": actual_consumed_mass * nutrient_proportions["C"],
+            "N": actual_consumed_mass * nutrient_proportions["N"],
+            "P": actual_consumed_mass * nutrient_proportions["P"],
         }
 
         for key in expected_nutrients:
@@ -328,9 +315,9 @@ class TestFungalFruitPool:
             time_period=30.0,
         )
         assert np.isclose(total_decay, 51.036906692032936)
-        assert np.isclose(fungal_fruit.mass_cnp["carbon"], 98.96309330796706)
-        assert np.isclose(fungal_fruit.mass_cnp["nitrogen"], 9.896309330796706)
-        assert np.isclose(fungal_fruit.mass_cnp["phosphorus"], 1.3195079107728942)
+        assert np.isclose(fungal_fruit.mass_cnp["C"], 98.96309330796706)
+        assert np.isclose(fungal_fruit.mass_cnp["N"], 9.896309330796706)
+        assert np.isclose(fungal_fruit.mass_cnp["P"], 1.3195079107728942)
 
 
 class TestLitterPool:
@@ -370,9 +357,9 @@ class TestLitterPool:
         n_mass = c_mass / c_n_ratio[cell_id]
         p_mass = c_mass / c_p_ratio[cell_id]
 
-        assert np.isclose(litter_pool.mass_cnp.carbon, c_mass)
-        assert np.isclose(litter_pool.mass_cnp.nitrogen, n_mass)
-        assert np.isclose(litter_pool.mass_cnp.phosphorus, p_mass)
+        assert np.isclose(litter_pool.mass_cnp.C, c_mass)
+        assert np.isclose(litter_pool.mass_cnp.N, n_mass)
+        assert np.isclose(litter_pool.mass_cnp.P, p_mass)
 
     def test_mass_current(self, mocker):
         """Test the mass_current property of LitterPool."""
@@ -381,7 +368,7 @@ class TestLitterPool:
 
         # Create a mock LitterPool with a single CNP object
         litter_pool = mocker.Mock()
-        litter_pool.mass_cnp = CNP(carbon=12.34, nitrogen=1.0, phosphorus=0.5)
+        litter_pool.mass_cnp = CNP(C=12.34, N=1.0, P=0.5)
 
         # Access the property via descriptor protocol
         result = LitterPool.mass_current.__get__(litter_pool)
@@ -433,9 +420,9 @@ class TestLitterPool:
 
         nutrient_proportions = cell_cnp.get_proportions()
         expected_nutrients = {
-            "carbon": actual_consumed_mass * nutrient_proportions["carbon"],
-            "nitrogen": actual_consumed_mass * nutrient_proportions["nitrogen"],
-            "phosphorus": actual_consumed_mass * nutrient_proportions["phosphorus"],
+            "C": actual_consumed_mass * nutrient_proportions["C"],
+            "N": actual_consumed_mass * nutrient_proportions["N"],
+            "P": actual_consumed_mass * nutrient_proportions["P"],
         }
 
         for key in expected_nutrients:
@@ -453,17 +440,17 @@ class TestSoilPool:
         argvalues=[
             (
                 "pom",
-                {"carbon": 17.5, "nitrogen": 0.0714285, "phosphorus": 0.00285714},
+                {"C": 17.5, "N": 0.0714285, "P": 0.00285714},
                 does_not_raise(),
             ),
             (
                 "bacteria",
-                {"carbon": 282.5, "nitrogen": 54.326923, "phosphorus": 17.65625},
+                {"C": 282.5, "N": 54.326923, "P": 17.65625},
                 does_not_raise(),
             ),
             (
                 "fungi",
-                {"carbon": 258.25, "nitrogen": 19.7777778, "phosphorus": 3.07291667},
+                {"C": 258.25, "N": 19.7777778, "P": 3.07291667},
                 does_not_raise(),
             ),
             ("lmwc", {}, pytest.raises(ValueError)),
@@ -493,11 +480,9 @@ class TestSoilPool:
                 c_n_p_ratios=microbial_c_n_p_ratios,
             )
 
-            assert np.isclose(litter_pool.mass_cnp.carbon, expected_mass["carbon"])
-            assert np.isclose(litter_pool.mass_cnp.nitrogen, expected_mass["nitrogen"])
-            assert np.isclose(
-                litter_pool.mass_cnp.phosphorus, expected_mass["phosphorus"]
-            )
+            assert np.isclose(litter_pool.mass_cnp.C, expected_mass["C"])
+            assert np.isclose(litter_pool.mass_cnp.N, expected_mass["N"])
+            assert np.isclose(litter_pool.mass_cnp.P, expected_mass["P"])
 
     def test_mass_current(self, mocker):
         """Test the mass_current property of SoilPool."""
@@ -506,7 +491,7 @@ class TestSoilPool:
 
         # Create a mock SoilPool with a single CNP object
         soil_pool = mocker.Mock()
-        soil_pool.mass_cnp = CNP(carbon=12.34, nitrogen=1.0, phosphorus=0.5)
+        soil_pool.mass_cnp = CNP(C=12.34, N=1.0, P=0.5)
 
         # Access the property via descriptor protocol
         result = SoilPool.mass_current.__get__(soil_pool)
@@ -555,9 +540,9 @@ class TestSoilPool:
 
         nutrient_proportions = cell_cnp.get_proportions()
         expected_nutrients = {
-            "carbon": actual_consumed_mass * nutrient_proportions["carbon"],
-            "nitrogen": actual_consumed_mass * nutrient_proportions["nitrogen"],
-            "phosphorus": actual_consumed_mass * nutrient_proportions["phosphorus"],
+            "C": actual_consumed_mass * nutrient_proportions["C"],
+            "N": actual_consumed_mass * nutrient_proportions["N"],
+            "P": actual_consumed_mass * nutrient_proportions["P"],
         }
 
         for key in expected_nutrients:

--- a/tests/models/animals/test_exporter.py
+++ b/tests/models/animals/test_exporter.py
@@ -553,8 +553,8 @@ class TestAnimalCohortDataExporter:
         fg.diet = "foliage"
         fg.reproductive_environment = "terrestrial"
 
-        mass_cnp = mocker.Mock(carbon=1.0, nitrogen=2.0, phosphorus=3.0)
-        repro_cnp = mocker.Mock(carbon=0.1, nitrogen=0.2, phosphorus=0.3)
+        mass_cnp = mocker.Mock(C=1.0, N=2.0, P=3.0)
+        repro_cnp = mocker.Mock(C=0.1, N=0.2, P=0.3)
 
         cohort = mocker.Mock()
         cohort.id = "abc"
@@ -603,8 +603,8 @@ class TestAnimalCohortDataExporter:
         cohort.territory = [1, 2]
 
         cohort.trophic_record = {
-            ("cohort", "prey-1"): {"carbon": 1.0, "nitrogen": 2.0, "phosphorus": 3.0},
-            ("carcass_pool", "60"): {"carbon": 4.0, "nitrogen": 5.0, "phosphorus": 6.0},
+            ("cohort", "prey-1"): {"C": 1.0, "N": 2.0, "P": 3.0},
+            ("carcass_pool", "60"): {"C": 4.0, "N": 5.0, "P": 6.0},
         }
         territory_by_id = {"prey-1": [9]}
 
@@ -624,13 +624,13 @@ class TestAnimalCohortDataExporter:
         assert cohort_row["consumer_cohort_id"] == "pred"
         assert cohort_row["prey_territory"] == [9]
         assert cohort_row["resource_cell_id"] is None
-        assert cohort_row["carbon"] == 1.0
+        assert cohort_row["C"] == 1.0
 
         pool_row = next(r for r in rows if r["resource_kind"] == "carcass_pool")
         assert pool_row["resource_id"] == "60"
         assert pool_row["resource_cell_id"] == 60
         assert pool_row["prey_territory"] is None
-        assert pool_row["phosphorus"] == 6.0
+        assert pool_row["P"] == 6.0
 
     def test_dump_cohorts_writes_file_and_flips_cohort_state(self, tmp_path, mocker):
         """Test _dump_cohorts writes cohort CSV and flips cohort write state.
@@ -656,10 +656,8 @@ class TestAnimalCohortDataExporter:
         cohort.functional_group = mocker.Mock(
             name="X", development_type="d", diet="e", reproductive_environment="r"
         )
-        cohort.mass_cnp = mocker.Mock(carbon=1.0, nitrogen=1.0, phosphorus=1.0)
-        cohort.reproductive_mass_cnp = mocker.Mock(
-            carbon=0.0, nitrogen=0.0, phosphorus=0.0
-        )
+        cohort.mass_cnp = mocker.Mock(C=1.0, N=1.0, P=1.0)
+        cohort.reproductive_mass_cnp = mocker.Mock(C=0.0, N=0.0, P=0.0)
         cohort.age = 0
         cohort.individuals = 1
         cohort.is_alive = True
@@ -713,9 +711,7 @@ class TestAnimalCohortDataExporter:
         cohort = mocker.Mock()
         cohort.id = "c1"
         cohort.territory = [10]
-        cohort.trophic_record = {
-            ("carcass_pool", "60"): {"carbon": 1.0, "nitrogen": 2.0, "phosphorus": 3.0}
-        }
+        cohort.trophic_record = {("carcass_pool", "60"): {"C": 1.0, "N": 2.0, "P": 3.0}}
 
         assert exporter._trophic_output_mode == "w"
         assert exporter._write_trophic_header is True
@@ -739,9 +735,9 @@ class TestAnimalCohortDataExporter:
             "resource_kind",
             "resource_id",
             "resource_cell_id",
-            "carbon",
-            "nitrogen",
-            "phosphorus",
+            "C",
+            "N",
+            "P",
         }
 
         assert exporter._trophic_output_mode == "a"

--- a/tests/models/animals/test_functional_group.py
+++ b/tests/models/animals/test_functional_group.py
@@ -33,7 +33,7 @@ class TestFunctionalGroup:
                 -0.75,
                 4.23,
                 0.1,
-                {"carbon": 0.5, "nitrogen": 0.3, "phosphorus": 0.2},
+                {"C": 0.5, "N": 0.3, "P": 0.2},
             ),
             (
                 "carnivorous_bird",
@@ -53,7 +53,7 @@ class TestFunctionalGroup:
                 -0.75,
                 2.00,
                 0.25,
-                {"carbon": 0.4, "nitrogen": 0.3, "phosphorus": 0.3},
+                {"C": 0.4, "N": 0.3, "P": 0.3},
             ),
             (
                 "herbivorous_insect_iteroparous",
@@ -73,7 +73,7 @@ class TestFunctionalGroup:
                 -0.75,
                 5.00,
                 0.1,
-                {"carbon": 0.4, "nitrogen": 0.2, "phosphorus": 0.4},
+                {"C": 0.4, "N": 0.2, "P": 0.4},
             ),
         ],
     )

--- a/virtual_ecosystem/models/animal/animal_cohorts.py
+++ b/virtual_ecosystem/models/animal/animal_cohorts.py
@@ -109,15 +109,15 @@ class AnimalCohort:
             raise ValueError("CNP proportions must sum to 1.")
 
         self.mass_cnp = CNP(
-            carbon=mass * self.cnp_proportions["carbon"],
-            nitrogen=mass * self.cnp_proportions["nitrogen"],
-            phosphorus=mass * self.cnp_proportions["phosphorus"],
+            C=mass * self.cnp_proportions["C"],
+            N=mass * self.cnp_proportions["N"],
+            P=mass * self.cnp_proportions["P"],
         )
         """The mass of C, N, and P in the cohort, from total mass and proportions."""
 
         self.reproductive_mass_cnp = CNP(0.0, 0.0, 0.0)
         """The reproductive mass of each stoichiometric element found in the animal
-          cohort, {"carbon": value, "nitrogen": value, "phosphorus": value}."""
+          cohort, {"C": value, "N": value, "P": value}."""
         self.largest_mass_achieved: float = mass
         """The largest body-mass ever achieved by this cohort [kg]."""
         self.diet_category_count: int = (
@@ -128,7 +128,7 @@ class AnimalCohort:
         """A record of the mass transfer from resource to consumer during the
         timestep. tuple["kind", "id"] where kind is a str resource category and
         id is a uuid or a cell_id. 
-        Value example: {"carbon": 1.2, "nitrogen": 0.08, "phosphorus": 0.01}"""
+        Value example: {"C": 1.2, "N": 0.08, "P": 0.01}"""
 
     @property
     def mass_current(self) -> float:
@@ -225,24 +225,24 @@ class AnimalCohort:
         if delta.total == 0.0:
             return
 
-        if delta.carbon < 0.0 or delta.nitrogen < 0.0 or delta.phosphorus < 0.0:
+        if delta.C < 0.0 or delta.N < 0.0 or delta.P < 0.0:
             raise ValueError(
                 "Trophic transfer masses must be non-negative. "
-                f"Received carbon={delta.carbon}, nitrogen={delta.nitrogen}, "
-                f"phosphorus={delta.phosphorus}."
+                f"Received carbon={delta.C}, N={delta.N}, "
+                f"P={delta.P}."
             )
 
         if resource_key not in self.trophic_record:
             self.trophic_record[resource_key] = {
-                "carbon": 0.0,
-                "nitrogen": 0.0,
-                "phosphorus": 0.0,
+                "C": 0.0,
+                "N": 0.0,
+                "P": 0.0,
             }
 
         entry = self.trophic_record[resource_key]
-        entry["carbon"] += delta.carbon
-        entry["nitrogen"] += delta.nitrogen
-        entry["phosphorus"] += delta.phosphorus
+        entry["C"] += delta.C
+        entry["N"] += delta.N
+        entry["P"] += delta.P
 
     def grow(self, resource_intake: dict[str, float]) -> dict[str, float]:
         """Handles growth based on resource intake, enforcing stoichiometry.
@@ -266,23 +266,21 @@ class AnimalCohort:
         max_growth = min(potential_growth.values())
 
         # Calculate the mass of each element used for growth
-        used_carbon = max_growth * self.cnp_proportions["carbon"]
-        used_nitrogen = max_growth * self.cnp_proportions["nitrogen"]
-        used_phosphorus = max_growth * self.cnp_proportions["phosphorus"]
+        used_carbon = max_growth * self.cnp_proportions["C"]
+        used_nitrogen = max_growth * self.cnp_proportions["N"]
+        used_phosphorus = max_growth * self.cnp_proportions["P"]
 
         # Update the mass_cnp object using the new add method
-        self.mass_cnp.update(
-            carbon=used_carbon, nitrogen=used_nitrogen, phosphorus=used_phosphorus
-        )
+        self.mass_cnp.update(C=used_carbon, N=used_nitrogen, P=used_phosphorus)
 
         # Subtract the used mass from the resource intake to get waste
-        resource_intake["carbon"] -= used_carbon
-        resource_intake["nitrogen"] -= used_nitrogen
-        resource_intake["phosphorus"] -= used_phosphorus
+        resource_intake["C"] -= used_carbon
+        resource_intake["N"] -= used_nitrogen
+        resource_intake["P"] -= used_phosphorus
 
         # Numerical safety: clamp tiny negatives to zero, but catch real bugs.
         eps = 1e-12
-        for element in ("carbon", "nitrogen", "phosphorus"):
+        for element in ("C", "N", "P"):
             value = resource_intake[element]
             if value < 0.0:
                 if value > -eps:
@@ -314,7 +312,7 @@ class AnimalCohort:
         if dt < timedelta64(0, "D"):
             raise ValueError("dt cannot be negative.")
 
-        if self.mass_cnp.carbon < 0:
+        if self.mass_cnp.C < 0:
             raise ValueError("Carbon mass (C) cannot be negative.")
 
         # Calculate potential carbon metabolized (kg/day * number of days)
@@ -328,18 +326,16 @@ class AnimalCohort:
         ) * float(dt / timedelta64(1, "D"))
 
         # Ensure metabolized carbon does not exceed available carbon
-        actual_carbon_metabolized = min(
-            self.mass_cnp.carbon, potential_carbon_metabolized
-        )
+        actual_carbon_metabolized = min(self.mass_cnp.C, potential_carbon_metabolized)
 
         # Subtract metabolized carbon directly from mass_cnp
-        self.mass_cnp.update(carbon=-actual_carbon_metabolized)
+        self.mass_cnp.update(C=-actual_carbon_metabolized)
 
         # Return the total metabolized carbon mass for the entire cohort
         return {
-            "carbon": actual_carbon_metabolized * self.individuals,
-            "nitrogen": 0.0,
-            "phosphorus": 0.0,
+            "C": actual_carbon_metabolized * self.individuals,
+            "N": 0.0,
+            "P": 0.0,
         }
 
     def excrete(
@@ -354,7 +350,7 @@ class AnimalCohort:
         Raises:
             ValueError: For invalid keys or negative values in excreta_mass.
         """
-        required_keys = {"carbon", "nitrogen", "phosphorus"}
+        required_keys = {"C", "N", "P"}
         if not required_keys.issubset(excreta_mass.keys()):
             raise ValueError(
                 f"excreta_mass must contain all required keys {required_keys}."
@@ -381,14 +377,14 @@ class AnimalCohort:
 
             # Fixed method calls to pass individual values
             excrement_pool.scavengeable_cnp.update(
-                carbon=scavengeable_mass["carbon"],
-                nitrogen=scavengeable_mass["nitrogen"],
-                phosphorus=scavengeable_mass["phosphorus"],
+                C=scavengeable_mass["C"],
+                N=scavengeable_mass["N"],
+                P=scavengeable_mass["P"],
             )
             excrement_pool.decomposed_cnp.update(
-                carbon=decomposed_mass["carbon"],
-                nitrogen=decomposed_mass["nitrogen"],
-                phosphorus=decomposed_mass["phosphorus"],
+                C=decomposed_mass["C"],
+                N=decomposed_mass["N"],
+                P=decomposed_mass["P"],
             )
 
     def respire(self, excreta_mass: dict[str, float]) -> float:
@@ -402,23 +398,21 @@ class AnimalCohort:
 
         Args:
             excreta_mass: A dictionary representing the mass of each nutrient excreted
-                by the cohort: {"carbon": value, "nitrogen": value,
-                "phosphorus": value}.
+                by the cohort: {"C": value, "N": value,
+                "P": value}.
 
         Returns:
             A float representing the total carbon mass respired to the atmosphere.
         """
 
         # Validate the input dictionary
-        if "carbon" not in excreta_mass:
+        if "C" not in excreta_mass:
             raise ValueError("excreta_mass must contain the key 'C' for carbon.")
-        if excreta_mass["carbon"] < 0:
+        if excreta_mass["C"] < 0:
             raise ValueError("Carbon mass in excreta_mass cannot be negative.")
 
         # Calculate the carbonaceous waste for respiration
-        respired_mass = (
-            excreta_mass["carbon"] * self.constants.carbon_excreta_proportion
-        )
+        respired_mass = excreta_mass["C"] * self.constants.carbon_excreta_proportion
 
         return respired_mass
 
@@ -436,7 +430,7 @@ class AnimalCohort:
             ValueError: If `mass_consumed` is missing required keys or contains negative
               values.
         """
-        required_keys = {"carbon", "nitrogen", "phosphorus"}
+        required_keys = {"C", "N", "P"}
         if not required_keys.issubset(mass_consumed.keys()):
             raise ValueError(
                 f"mass_consumed must contain all required keys {required_keys}."
@@ -528,9 +522,9 @@ class AnimalCohort:
             )
 
         # Calculate total mass lost per element
-        carbon_lost = self.mass_cnp.carbon * number_of_deaths
-        nitrogen_lost = self.mass_cnp.nitrogen * number_of_deaths
-        phosphorus_lost = self.mass_cnp.phosphorus * number_of_deaths
+        carbon_lost = self.mass_cnp.C * number_of_deaths
+        nitrogen_lost = self.mass_cnp.N * number_of_deaths
+        phosphorus_lost = self.mass_cnp.P * number_of_deaths
 
         # Reduce the cohort size
         self.individuals -= number_of_deaths
@@ -542,9 +536,9 @@ class AnimalCohort:
 
     def update_carcass_pool(
         self,
-        carbon: float,
-        nitrogen: float,
-        phosphorus: float,
+        C: float,
+        N: float,
+        P: float,
         carcass_pools: list[CarcassPool],
     ) -> None:
         """Updates the carcass pools after deaths.
@@ -553,18 +547,18 @@ class AnimalCohort:
         decomposed fractions.
 
         Args:
-            carbon (float): The total carbon mass to be distributed.
-            nitrogen (float): The total nitrogen mass to be distributed.
-            phosphorus (float): The total phosphorus mass to be distributed.
+            C (float): The total carbon mass to be distributed.
+            N (float): The total nitrogen mass to be distributed.
+            P (float): The total phosphorus mass to be distributed.
             carcass_pools (list[CarcassPool]): The carcass pools receiving the biomass.
 
         Raises:
             ValueError: If any input mass is negative or no carcass pools are provided.
         """
-        if carbon < 0 or nitrogen < 0 or phosphorus < 0:
+        if C < 0 or N < 0 or P < 0:
             raise ValueError(
                 f"Carcass mass values must be non-negative. Provided: "
-                f"carbon={carbon}, nitrogen={nitrogen}, phosphorus={phosphorus}"
+                f"carbon={C}, N={N}, P={P}"
             )
 
         number_carcass_pools = len(carcass_pools)
@@ -572,23 +566,23 @@ class AnimalCohort:
             raise ValueError("No carcass pools provided for waste distribution.")
 
         # Distribute mass across pools
-        carbon_per_pool = carbon / number_carcass_pools
-        nitrogen_per_pool = nitrogen / number_carcass_pools
-        phosphorus_per_pool = phosphorus / number_carcass_pools
+        carbon_per_pool = C / number_carcass_pools
+        nitrogen_per_pool = N / number_carcass_pools
+        phosphorus_per_pool = P / number_carcass_pools
 
         scavengeable_factor = 1 - self.decay_fraction_carcasses
         decomposed_factor = self.decay_fraction_carcasses
 
         for carcass_pool in carcass_pools:
             carcass_pool.scavengeable_cnp.update(
-                carbon=carbon_per_pool * scavengeable_factor,
-                nitrogen=nitrogen_per_pool * scavengeable_factor,
-                phosphorus=phosphorus_per_pool * scavengeable_factor,
+                C=carbon_per_pool * scavengeable_factor,
+                N=nitrogen_per_pool * scavengeable_factor,
+                P=phosphorus_per_pool * scavengeable_factor,
             )
             carcass_pool.decomposed_cnp.update(
-                carbon=carbon_per_pool * decomposed_factor,
-                nitrogen=nitrogen_per_pool * decomposed_factor,
-                phosphorus=phosphorus_per_pool * decomposed_factor,
+                C=carbon_per_pool * decomposed_factor,
+                N=nitrogen_per_pool * decomposed_factor,
+                P=phosphorus_per_pool * decomposed_factor,
             )
 
     def get_eaten(
@@ -637,23 +631,19 @@ class AnimalCohort:
 
         # Convert consumed mass to stoichiometric proportions
         consumed_carbon = (
-            self.mass_cnp.carbon / individual_mass
+            self.mass_cnp.C / individual_mass
         ) * consumed_mass_after_efficiency
         consumed_nitrogen = (
-            self.mass_cnp.nitrogen / individual_mass
+            self.mass_cnp.N / individual_mass
         ) * consumed_mass_after_efficiency
         consumed_phosphorus = (
-            self.mass_cnp.phosphorus / individual_mass
+            self.mass_cnp.P / individual_mass
         ) * consumed_mass_after_efficiency
 
         # Convert carcass mass to stoichiometric proportions
-        carcass_carbon = (self.mass_cnp.carbon / individual_mass) * carcass_mass_total
-        carcass_nitrogen = (
-            self.mass_cnp.nitrogen / individual_mass
-        ) * carcass_mass_total
-        carcass_phosphorus = (
-            self.mass_cnp.phosphorus / individual_mass
-        ) * carcass_mass_total
+        carcass_carbon = (self.mass_cnp.C / individual_mass) * carcass_mass_total
+        carcass_nitrogen = (self.mass_cnp.N / individual_mass) * carcass_mass_total
+        carcass_phosphorus = (self.mass_cnp.P / individual_mass) * carcass_mass_total
 
         # Remove individuals from the prey cohort
         self.individuals -= actual_individuals_killed
@@ -676,9 +666,9 @@ class AnimalCohort:
         )
 
         return {
-            "carbon": consumed_carbon,
-            "nitrogen": consumed_nitrogen,
-            "phosphorus": consumed_phosphorus,
+            "C": consumed_carbon,
+            "N": consumed_nitrogen,
+            "P": consumed_phosphorus,
         }
 
     def calculate_alpha(self) -> float:
@@ -972,7 +962,7 @@ class AnimalCohort:
 
         Returns:
             A dictionary representing the total change in mass (C, N, P) experienced by
-            the predator: {"carbon": value, "nitrogen": value, "phosphorus": value}.
+            the predator: {"C": value, "N": value, "P": value}.
 
         Raises:
             ValueError: If `animal_list` or `carcass_pools` is None.
@@ -988,10 +978,10 @@ class AnimalCohort:
 
         # If no prey are available, return zero change
         if not animal_list:
-            return {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0}
+            return {"C": 0.0, "N": 0.0, "P": 0.0}
 
         # Initialize the total consumed mass as a stoichiometric dictionary
-        total_consumed_mass = {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0}
+        total_consumed_mass = {"C": 0.0, "N": 0.0, "P": 0.0}
 
         for prey_cohort in animal_list:
             # Calculate the mass to be consumed from this cohort
@@ -1069,7 +1059,7 @@ class AnimalCohort:
         Returns:
             Stoichiometric gain from foraging (kg of C, N, P).
         """
-        total_gain = {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0}
+        total_gain = {"C": 0.0, "N": 0.0, "P": 0.0}
 
         for resource in resources:
             requested = calculate_consumed_mass(resources, resource, adjusted_dt)
@@ -1333,7 +1323,7 @@ class AnimalCohort:
             / self.diet_category_count
         )
 
-        total_gain = {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0}
+        total_gain = {"C": 0.0, "N": 0.0, "P": 0.0}
 
         # live plant herbivory
         if plant_list:
@@ -1462,8 +1452,8 @@ class AnimalCohort:
 
         Args:
             mass_consumed: A dictionary representing the mass of each nutrient consumed
-                by this consumer: {"carbon": value, "nitrogen": value,
-                "phosphorus": value}.
+                by this consumer: {"C": value, "N": value,
+                "P": value}.
             excrement_pools: The ExcrementPool objects in the cohort's territory in
                 which waste is deposited.
 
@@ -1475,7 +1465,7 @@ class AnimalCohort:
             return
 
         # Validate mass_consumed input
-        required_keys = {"carbon", "nitrogen", "phosphorus"}
+        required_keys = {"C", "N", "P"}
         if not required_keys.issubset(mass_consumed.keys()):
             raise ValueError(
                 f"mass_consumed must contain all required keys {required_keys}. "

--- a/virtual_ecosystem/models/animal/animal_cohorts.py
+++ b/virtual_ecosystem/models/animal/animal_cohorts.py
@@ -558,7 +558,7 @@ class AnimalCohort:
         if C < 0 or N < 0 or P < 0:
             raise ValueError(
                 f"Carcass mass values must be non-negative. Provided: "
-                f"carbon={C}, N={N}, P={P}"
+                f"C={C}, N={N}, P={P}"
             )
 
         number_carcass_pools = len(carcass_pools)

--- a/virtual_ecosystem/models/animal/animal_model.py
+++ b/virtual_ecosystem/models/animal/animal_model.py
@@ -897,7 +897,7 @@ class AnimalModel(
             and the proportion of input carbon that is lignin [unitless].
         """
 
-        nutrients = ["carbon", "nitrogen", "phosphorus"]
+        nutrients = ["C", "N", "P"]
 
         leaf_cnp = stack(
             [
@@ -919,9 +919,9 @@ class AnimalModel(
 
         # Reset all of the herbivory waste pools to zero
         for waste in self.leaf_waste_pools.values():
-            waste.mass_cnp["carbon"] = 0.0
-            waste.mass_cnp["nitrogen"] = 0.0
-            waste.mass_cnp["phosphorus"] = 0.0
+            waste.mass_cnp["C"] = 0.0
+            waste.mass_cnp["N"] = 0.0
+            waste.mass_cnp["P"] = 0.0
 
         return {
             "herbivory_waste_leaf_cnp": DataArray(
@@ -956,9 +956,9 @@ class AnimalModel(
                 * self.update_interval_in_days
             )
             fungal_fruiting_bodies_pool.mass_cnp.update(
-                carbon=+production,
-                nitrogen=+production / fungal_fruiting_bodies_pool.c_n_ratio,
-                phosphorus=+production / fungal_fruiting_bodies_pool.c_p_ratio,
+                C=+production,
+                N=+production / fungal_fruiting_bodies_pool.c_n_ratio,
+                P=+production / fungal_fruiting_bodies_pool.c_p_ratio,
             )
 
         total_decay = [
@@ -980,7 +980,7 @@ class AnimalModel(
     def calculate_soil_additions(self) -> dict[str, DataArray]:
         """Calculate how much animal matter should be transferred to the soil."""
 
-        nutrients = ["carbon", "nitrogen", "phosphorus"]
+        nutrients = ["C", "N", "P"]
 
         # Find the size of all decomposed excrement and carcass pools, by cell_id
         decomposed_excrement = {
@@ -1018,9 +1018,9 @@ class AnimalModel(
             "decomposed_excrement_cnp": DataArray(
                 data=stack(
                     (
-                        self.to_per_day(array(decomposed_excrement["carbon"])),
-                        self.to_per_day(array(decomposed_excrement["nitrogen"])),
-                        self.to_per_day(array(decomposed_excrement["phosphorus"])),
+                        self.to_per_day(array(decomposed_excrement["C"])),
+                        self.to_per_day(array(decomposed_excrement["N"])),
+                        self.to_per_day(array(decomposed_excrement["P"])),
                     ),
                     axis=1,
                 ),
@@ -1029,9 +1029,9 @@ class AnimalModel(
             "decomposed_carcasses_cnp": DataArray(
                 data=stack(
                     (
-                        self.to_per_day(array(decomposed_carcasses["carbon"])),
-                        self.to_per_day(array(decomposed_carcasses["nitrogen"])),
-                        self.to_per_day(array(decomposed_carcasses["phosphorus"])),
+                        self.to_per_day(array(decomposed_carcasses["C"])),
+                        self.to_per_day(array(decomposed_carcasses["N"])),
+                        self.to_per_day(array(decomposed_carcasses["P"])),
                     ),
                     axis=1,
                 ),
@@ -1049,8 +1049,7 @@ class AnimalModel(
 
         for cell_id, fungal_fruiting_bodies_pool in self.fungal_fruiting_bodies.items():
             self.data["fungal_fruiting_bodies"].loc[{"cell_id": cell_id}] = (
-                fungal_fruiting_bodies_pool.mass_cnp["carbon"]
-                / self.data.grid.cell_area
+                fungal_fruiting_bodies_pool.mass_cnp["C"] / self.data.grid.cell_area
             )
 
     def to_per_day(self, change: NDArray[float32]) -> NDArray[float32]:
@@ -1270,16 +1269,14 @@ class AnimalModel(
             parent: The parent cohort.
 
         Returns:
-            Reproductive mass for carbon, nitrogen, phosphorus (kg).
+            Reproductive mass for C, N, P (kg).
         """
         semelparous_loss = self.calculate_semelparous_mass_loss(parent)
 
         return {
-            "carbon": parent.reproductive_mass_cnp.carbon + semelparous_loss["carbon"],
-            "nitrogen": parent.reproductive_mass_cnp.nitrogen
-            + semelparous_loss["nitrogen"],
-            "phosphorus": parent.reproductive_mass_cnp.phosphorus
-            + semelparous_loss["phosphorus"],
+            "C": parent.reproductive_mass_cnp.C + semelparous_loss["C"],
+            "N": parent.reproductive_mass_cnp.N + semelparous_loss["N"],
+            "P": parent.reproductive_mass_cnp.P + semelparous_loss["P"],
         }
 
     def calculate_offspring_count(
@@ -1302,9 +1299,9 @@ class AnimalModel(
 
         # Find the limiting element — how many offspring can be made from each element?
         max_per_parent = min(
-            reproductive_mass["carbon"] / birth_c,
-            reproductive_mass["nitrogen"] / birth_n,
-            reproductive_mass["phosphorus"] / birth_p,
+            reproductive_mass["C"] / birth_c,
+            reproductive_mass["N"] / birth_n,
+            reproductive_mass["P"] / birth_p,
         )
         # Total offspring is limited offspring per parent times the number of parents
         return int(max_per_parent * parent.individuals)
@@ -1332,9 +1329,9 @@ class AnimalModel(
 
         # TODO: double check that total_c can't be more than available mass
         parent.reproductive_mass_cnp.update(
-            carbon=-min(total_c, parent.reproductive_mass_cnp.carbon),
-            nitrogen=-min(total_n, parent.reproductive_mass_cnp.nitrogen),
-            phosphorus=-min(total_p, parent.reproductive_mass_cnp.phosphorus),
+            C=-min(total_c, parent.reproductive_mass_cnp.C),
+            N=-min(total_n, parent.reproductive_mass_cnp.N),
+            P=-min(total_p, parent.reproductive_mass_cnp.P),
         )
 
         if parent.functional_group.reproductive_type == "semelparous":
@@ -1355,9 +1352,9 @@ class AnimalModel(
         loss = self.calculate_semelparous_mass_loss(parent)
 
         parent.mass_cnp.update(
-            carbon=-loss["carbon"],
-            nitrogen=-loss["nitrogen"],
-            phosphorus=-loss["phosphorus"],
+            C=-loss["C"],
+            N=-loss["N"],
+            P=-loss["P"],
         )
         parent.is_alive = False
         self.remove_dead_cohort(parent)
@@ -1374,14 +1371,14 @@ class AnimalModel(
             Dictionary of mass loss (C, N, P).
         """
         if parent.functional_group.reproductive_type != "semelparous":
-            return {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0}
+            return {"C": 0.0, "N": 0.0, "P": 0.0}
 
         loss_fraction = parent.constants.semelparity_mass_loss
 
         return {
-            "carbon": parent.mass_cnp.carbon * loss_fraction,
-            "nitrogen": parent.mass_cnp.nitrogen * loss_fraction,
-            "phosphorus": parent.mass_cnp.phosphorus * loss_fraction,
+            "C": parent.mass_cnp.C * loss_fraction,
+            "N": parent.mass_cnp.N * loss_fraction,
+            "P": parent.mass_cnp.P * loss_fraction,
         }
 
     def calculate_birth_mass_cnp(
@@ -1398,9 +1395,9 @@ class AnimalModel(
         """
         proportions = parent.cnp_proportions
         return (
-            birth_mass * proportions["carbon"],
-            birth_mass * proportions["nitrogen"],
-            birth_mass * proportions["phosphorus"],
+            birth_mass * proportions["C"],
+            birth_mass * proportions["N"],
+            birth_mass * proportions["P"],
         )
 
     def create_offspring(

--- a/virtual_ecosystem/models/animal/cnp.py
+++ b/virtual_ecosystem/models/animal/cnp.py
@@ -19,14 +19,14 @@ class CNP:
     manipulations, stoichiometric calculations, and ratio/proportion retrieval.
 
     Attributes:
-        carbon (float): The mass of carbon in the entity [kg].
-        nitrogen (float): The mass of nitrogen in the entity [kg].
-        phosphorus (float): The mass of phosphorus in the entity [kg].
+        C (float): The mass of carbon in the entity [kg].
+        N (float): The mass of nitrogen in the entity [kg].
+        P (float): The mass of phosphorus in the entity [kg].
     """
 
-    carbon: float
-    nitrogen: float
-    phosphorus: float
+    C: float
+    N: float
+    P: float
 
     @property
     def total(self) -> float:
@@ -35,13 +35,13 @@ class CNP:
         Returns:
             float: The sum of carbon, nitrogen, and phosphorus mass.
         """
-        return self.carbon + self.nitrogen + self.phosphorus
+        return self.C + self.N + self.P
 
     def __getitem__(self, key: str) -> float:
         """Allow dictionary-style access to C, N, and P values.
 
         Args:
-            key (str): One of 'carbon', 'nitrogen', or 'phosphorus'.
+            key (str): One of 'C', 'N', or 'P'.
 
         Returns:
             float: The corresponding element's mass.
@@ -49,42 +49,38 @@ class CNP:
         Raises:
             KeyError: If the key is not one of the three valid elements.
         """
-        if key not in {"carbon", "nitrogen", "phosphorus"}:
-            raise KeyError(
-                f"Invalid key: {key}. Must be 'carbon', 'nitrogen', or 'phosphorus'."
-            )
+        if key not in {"C", "N", "P"}:
+            raise KeyError(f"Invalid key: {key}. Must be 'C', 'N', or 'P'.")
         return getattr(self, key)
 
     def _validate_non_negative(self) -> None:
         """Ensure that no element becomes negative after an update.
 
         Raises:
-            ValueError: If carbon, nitrogen, or phosphorus is negative.
+            ValueError: If C, N, or P is negative.
         """
         for name, value in asdict(self).items():
             if value < 0:
                 raise ValueError(
                     f"{name.capitalize()} mass cannot be negative. Current values: "
-                    f"carbon={self.carbon}, nitrogen={self.nitrogen},"
-                    f"phosphorus={self.phosphorus}."
+                    f"C={self.C}, N={self.N},"
+                    f"P={self.P}."
                 )
 
-    def update(
-        self, *, carbon: float = 0.0, nitrogen: float = 0.0, phosphorus: float = 0.0
-    ) -> None:
+    def update(self, *, C: float = 0.0, N: float = 0.0, P: float = 0.0) -> None:
         """Update C, N, and P values. Positive values add; negative values subtract.
 
         Args:
-            carbon: Amount of carbon to adjust. Defaults to 0.0.
-            nitrogen: Amount of nitrogen to adjust. Defaults to 0.0.
-            phosphorus: Amount of phosphorus to adjust. Defaults
+            C: Amount of carbon to adjust. Defaults to 0.0.
+            N: Amount of nitrogen to adjust. Defaults to 0.0.
+            P: Amount of phosphorus to adjust. Defaults
              to 0.0.
 
         """
 
-        self.carbon += carbon
-        self.nitrogen += nitrogen
-        self.phosphorus += phosphorus
+        self.C += C
+        self.N += N
+        self.P += P
         self._validate_non_negative()
 
     @classmethod
@@ -92,16 +88,16 @@ class CNP:
         """Create a CNP instance from a dictionary.
 
         Args:
-            data (dict[str, float]): A dictionary containing 'carbon', 'nitrogen', and
-                'phosphorus' as keys.
+            data (dict[str, float]): A dictionary containing 'C', 'N', and
+                'P' as keys.
 
         Returns:
             CNP: A new CNP instance with the values from the dictionary.
         """
         return cls(
-            carbon=data.get("carbon", 0.0),
-            nitrogen=data.get("nitrogen", 0.0),
-            phosphorus=data.get("phosphorus", 0.0),
+            C=data.get("C", 0.0),
+            N=data.get("N", 0.0),
+            P=data.get("P", 0.0),
         )
 
     def get_ratios(self) -> dict[str, float]:
@@ -115,8 +111,8 @@ class CNP:
                 - "C:P" (float): Carbon-to-phosphorus ratio
         """
         return {
-            "C:N": self.carbon / self.nitrogen if self.nitrogen > 0 else 0.0,
-            "C:P": self.carbon / self.phosphorus if self.phosphorus > 0 else 0.0,
+            "C:N": self.C / self.N if self.N > 0 else 0.0,
+            "C:P": self.C / self.P if self.P > 0 else 0.0,
         }
 
     def get_proportions(self) -> dict[str, float]:
@@ -126,15 +122,15 @@ class CNP:
 
         Returns:
             dict[str, float]: A dictionary containing:
-                - "carbon" (float): Proportion of carbon in total mass.
-                - "nitrogen" (float): Proportion of nitrogen in total mass.
-                - "phosphorus" (float): Proportion of phosphorus in total mass.
+                - "C" (float): Proportion of carbon in total mass.
+                - "N" (float): Proportion of nitrogen in total mass.
+                - "P" (float): Proportion of phosphorus in total mass.
         """
         total_mass = self.total
         return {
-            "carbon": self.carbon / total_mass if total_mass > 0 else 0.0,
-            "nitrogen": self.nitrogen / total_mass if total_mass > 0 else 0.0,
-            "phosphorus": self.phosphorus / total_mass if total_mass > 0 else 0.0,
+            "C": self.C / total_mass if total_mass > 0 else 0.0,
+            "N": self.N / total_mass if total_mass > 0 else 0.0,
+            "P": self.P / total_mass if total_mass > 0 else 0.0,
         }
 
 
@@ -159,6 +155,6 @@ def find_microbial_stoichiometries(
     )
 
     return {
-        group.name: {"nitrogen": group.c_n_ratio, "phosphorus": group.c_p_ratio}
+        group.name: {"N": group.c_n_ratio, "P": group.c_p_ratio}
         for group in soil_config.microbial_group_definition
     }

--- a/virtual_ecosystem/models/animal/decay.py
+++ b/virtual_ecosystem/models/animal/decay.py
@@ -30,7 +30,7 @@ class ScavengeableMixin:
             scavenger: The animal cohort consuming the material.
 
         Returns:
-            Dict with keys ``"carbon"``, ``"nitrogen"``, ``"phosphorus"`` giving
+            Dict with keys ``"C"``, ``"N"``, ``"P"`` giving
             the mass of each element actually ingested, and a second empty dict.
 
         Raises:
@@ -41,7 +41,7 @@ class ScavengeableMixin:
 
         available = self.scavengeable_cnp.total
         if available == 0.0:
-            return {"carbon": 0.0, "nitrogen": 0.0, "phosphorus": 0.0}, {}
+            return {"C": 0.0, "N": 0.0, "P": 0.0}, {}
 
         taken_wet = min(consumed_mass, available)
 
@@ -49,26 +49,26 @@ class ScavengeableMixin:
         ingested_wet = taken_wet * mech_eff
         missed_wet = taken_wet * (1.0 - mech_eff)
 
-        frac_C = self.scavengeable_cnp.carbon / available
-        frac_N = self.scavengeable_cnp.nitrogen / available
-        frac_P = self.scavengeable_cnp.phosphorus / available
+        frac_C = self.scavengeable_cnp.C / available
+        frac_N = self.scavengeable_cnp.N / available
+        frac_P = self.scavengeable_cnp.P / available
 
         ingested_cnp = {
-            "carbon": ingested_wet * frac_C,
-            "nitrogen": ingested_wet * frac_N,
-            "phosphorus": ingested_wet * frac_P,
+            "C": ingested_wet * frac_C,
+            "N": ingested_wet * frac_N,
+            "P": ingested_wet * frac_P,
         }
 
         # Update pool states
         self.scavengeable_cnp.update(
-            carbon=-taken_wet * frac_C,
-            nitrogen=-taken_wet * frac_N,
-            phosphorus=-taken_wet * frac_P,
+            C=-taken_wet * frac_C,
+            N=-taken_wet * frac_N,
+            P=-taken_wet * frac_P,
         )
         self.decomposed_cnp.update(
-            carbon=missed_wet * frac_C,
-            nitrogen=missed_wet * frac_N,
-            phosphorus=missed_wet * frac_P,
+            C=missed_wet * frac_C,
+            N=missed_wet * frac_N,
+            P=missed_wet * frac_P,
         )
 
         return ingested_cnp, {}
@@ -78,14 +78,10 @@ class ScavengeableMixin:
 class CarcassPool(ScavengeableMixin):
     """This class stores information about the carcass biomass in each grid cell."""
 
-    scavengeable_cnp: CNP = field(
-        default_factory=lambda: CNP(carbon=0.0, nitrogen=0.0, phosphorus=0.0)
-    )
+    scavengeable_cnp: CNP = field(default_factory=lambda: CNP(C=0.0, N=0.0, P=0.0))
     """A CNP object storing animal-accessible nutrients in the carcass pool."""
 
-    decomposed_cnp: CNP = field(
-        default_factory=lambda: CNP(carbon=0.0, nitrogen=0.0, phosphorus=0.0)
-    )
+    decomposed_cnp: CNP = field(default_factory=lambda: CNP(C=0.0, N=0.0, P=0.0))
     """A CNP object storing decomposed nutrients in the carcass pool."""
     cell_id: int = -1
     """Grid position of carcass pool."""
@@ -114,34 +110,30 @@ class CarcassPool(ScavengeableMixin):
             float: The nutrient content of the decomposed carcasses on a per area basis
               [kg m^-2].
         """
-        if nutrient not in {"carbon", "nitrogen", "phosphorus"}:
+        if nutrient not in {"C", "N", "P"}:
             raise ValueError(
-                f"{nutrient} is not a valid nutrient. Valid options: 'carbon', "
-                f"'nitrogen', or 'phosphorus'."
+                f"{nutrient} is not a valid nutrient. Valid options: 'C', 'N', or 'P'."
             )
 
         return getattr(self.decomposed_cnp, nutrient) / grid_cell_area
 
-    def add_carcass(self, carbon: float, nitrogen: float, phosphorus: float) -> None:
+    def add_carcass(self, C: float, N: float, P: float) -> None:
         """Add carcass mass to the pool based on the provided mass.
 
         Args:
-            carbon (float): The mass of carbon to add.
-            nitrogen (float): The mass of nitrogen to add.
-            phosphorus (float): The mass of phosphorus to add.
+            C (float): The mass of carbon to add.
+            N (float): The mass of nitrogen to add.
+            P (float): The mass of phosphorus to add.
 
         Raises:
             ValueError: If any input mass is negative.
         """
-        if carbon < 0 or nitrogen < 0 or phosphorus < 0:
+        if C < 0 or N < 0 or P < 0:
             raise ValueError(
-                f"CNP values must be non-negative. Provided values: carbon={carbon}, "
-                f"nitrogen={nitrogen}, phosphorus={phosphorus}"
+                f"CNP values must be non-negative. Provided values: C={C}, N={N}, P={P}"
             )
 
-        self.scavengeable_cnp.update(
-            carbon=carbon, nitrogen=nitrogen, phosphorus=phosphorus
-        )
+        self.scavengeable_cnp.update(C=C, N=N, P=P)
 
     def reset(self) -> None:
         """Reset tracking of the nutrients associated with decomposed carcasses.
@@ -157,14 +149,10 @@ class CarcassPool(ScavengeableMixin):
 class ExcrementPool(ScavengeableMixin):
     """This class stores information about the amount of excrement in each grid cell."""
 
-    scavengeable_cnp: CNP = field(
-        default_factory=lambda: CNP(carbon=0.0, nitrogen=0.0, phosphorus=0.0)
-    )
+    scavengeable_cnp: CNP = field(default_factory=lambda: CNP(C=0.0, N=0.0, P=0.0))
     """A CNP object storing animal-accessible nutrients in the excrement pool."""
 
-    decomposed_cnp: CNP = field(
-        default_factory=lambda: CNP(carbon=0.0, nitrogen=0.0, phosphorus=0.0)
-    )
+    decomposed_cnp: CNP = field(default_factory=lambda: CNP(C=0.0, N=0.0, P=0.0))
     """A CNP object storing decomposed nutrients in the excrement pool."""
     cell_id: int = -1
     """Grid position of carcass pool."""
@@ -193,34 +181,30 @@ class ExcrementPool(ScavengeableMixin):
             float: The nutrient content of the decomposed excrement on a per area basis
               [kg m^-2].
         """
-        if nutrient not in {"carbon", "nitrogen", "phosphorus"}:
+        if nutrient not in {"C", "N", "P"}:
             raise ValueError(
-                f"{nutrient} is not a valid nutrient. Valid options: 'carbon',"
-                f"'nitrogen', or 'phosphorus'."
+                f"{nutrient} is not a valid nutrient. Valid options: 'C','N', or 'P'."
             )
 
         return getattr(self.decomposed_cnp, nutrient) / grid_cell_area
 
-    def add_excrement(self, carbon: float, nitrogen: float, phosphorus: float) -> None:
+    def add_excrement(self, C: float, N: float, P: float) -> None:
         """Add excrement mass to the pool based on the provided input mass.
 
         Args:
-            carbon (float): The mass of carbon to add.
-            nitrogen (float): The mass of nitrogen to add.
-            phosphorus (float): The mass of phosphorus to add.
+            C (float): The mass of carbon to add.
+            N (float): The mass of nitrogen to add.
+            P (float): The mass of phosphorus to add.
 
         Raises:
             ValueError: If any input mass is negative.
         """
-        if carbon < 0 or nitrogen < 0 or phosphorus < 0:
+        if C < 0 or N < 0 or P < 0:
             raise ValueError(
-                f"CNP values must be non-negative. Provided values: carbon={carbon}, "
-                f"nitrogen={nitrogen}, phosphorus={phosphorus}"
+                f"CNP values must be non-negative. Provided values: C={C}, N={N}, P={P}"
             )
 
-        self.scavengeable_cnp.update(
-            carbon=carbon, nitrogen=nitrogen, phosphorus=phosphorus
-        )
+        self.scavengeable_cnp.update(C=C, N=N, P=P)
 
     def reset(self) -> None:
         """Reset tracking of the nutrients associated with decomposed excrement.
@@ -229,7 +213,7 @@ class ExcrementPool(ScavengeableMixin):
         It should only be called after transfers to the soil model due to decomposition
         have been calculated.
         """
-        self.decomposed_cnp = CNP(carbon=0.0, nitrogen=0.0, phosphorus=0.0)
+        self.decomposed_cnp = CNP(C=0.0, N=0.0, P=0.0)
 
 
 def find_decay_consumed_split(
@@ -283,9 +267,9 @@ class FungalFruitPool:
         # Convert to absolute mass (kg) and build stoichiometry
         carbon_mass = carbon_stock * cell_area
         self.mass_cnp = CNP(
-            carbon=carbon_mass,
-            nitrogen=carbon_mass / self.c_n_ratio,
-            phosphorus=carbon_mass / self.c_p_ratio,
+            C=carbon_mass,
+            N=carbon_mass / self.c_n_ratio,
+            P=carbon_mass / self.c_p_ratio,
         )
 
         # Sanity-check
@@ -301,7 +285,7 @@ class FungalFruitPool:
     @property
     def mass_current(self) -> float:
         """Return current carbon mass in the pool [kg]."""
-        return self.mass_cnp.carbon
+        return self.mass_cnp.C
 
     def get_eaten(
         self,
@@ -317,8 +301,8 @@ class FungalFruitPool:
               efficiency.
 
         Returns:
-            Dictionary of element masses actually assimilated, keys ``carbon``,
-            ``nitrogen``, ``phosphorus`` (kg).
+            Dictionary of element masses actually assimilated, keys ``C``,
+            ``N``, ``P`` (kg).
         """
         if consumed_mass < 0:
             raise ValueError("consumed_mass must be non-negative")
@@ -327,21 +311,21 @@ class FungalFruitPool:
         mech_eff = detritivore.functional_group.mechanical_efficiency
         actual = min(consumed_mass, total_available) * mech_eff
 
-        frac_C = self.mass_cnp.carbon / total_available
-        frac_N = self.mass_cnp.nitrogen / total_available
-        frac_P = self.mass_cnp.phosphorus / total_available
+        frac_C = self.mass_cnp.C / total_available
+        frac_N = self.mass_cnp.N / total_available
+        frac_P = self.mass_cnp.P / total_available
 
         taken = {
-            "carbon": actual * frac_C,
-            "nitrogen": actual * frac_N,
-            "phosphorus": actual * frac_P,
+            "C": actual * frac_C,
+            "N": actual * frac_N,
+            "P": actual * frac_P,
         }
 
         # in-place update
         self.mass_cnp.update(
-            carbon=-taken["carbon"],
-            nitrogen=-taken["nitrogen"],
-            phosphorus=-taken["phosphorus"],
+            C=-taken["C"],
+            N=-taken["N"],
+            P=-taken["P"],
         )
         return taken, {}
 
@@ -358,12 +342,12 @@ class FungalFruitPool:
         """
 
         # Calculate total decay in carbon terms
-        total_decay = (1 - exp(-decay_constant * time_period)) * self.mass_cnp.carbon
+        total_decay = (1 - exp(-decay_constant * time_period)) * self.mass_cnp.C
         # And then update the pool masses based on this and the fixed stoichiometry
         self.mass_cnp.update(
-            carbon=-total_decay,
-            nitrogen=-total_decay / self.c_n_ratio,
-            phosphorus=-total_decay / self.c_p_ratio,
+            C=-total_decay,
+            N=-total_decay / self.c_n_ratio,
+            P=-total_decay / self.c_p_ratio,
         )
 
         return total_decay
@@ -404,9 +388,9 @@ class LitterPool:
         # Convert to absolute mass (kg) and build stoichiometry
         carbon_mass = carbon_stock * cell_area
         self.mass_cnp = CNP(
-            carbon=carbon_mass,
-            nitrogen=carbon_mass / self.c_n_ratio,
-            phosphorus=carbon_mass / self.c_p_ratio,
+            C=carbon_mass,
+            N=carbon_mass / self.c_n_ratio,
+            P=carbon_mass / self.c_p_ratio,
         )
 
         # Sanity-check
@@ -419,7 +403,7 @@ class LitterPool:
     @property
     def mass_current(self) -> float:
         """Return current carbon mass in the pool [kg]."""
-        return self.mass_cnp.carbon
+        return self.mass_cnp.C
 
     def get_eaten(
         self,
@@ -435,8 +419,8 @@ class LitterPool:
               efficiency.
 
         Returns:
-            Dictionary of element masses actually assimilated, keys ``carbon``,
-            ``nitrogen``, ``phosphorus`` (kg).
+            Dictionary of element masses actually assimilated, keys ``C``,
+            ``N``, ``P`` (kg).
         """
         if consumed_mass < 0:
             raise ValueError("consumed_mass must be non-negative")
@@ -445,21 +429,21 @@ class LitterPool:
         mech_eff = detritivore.functional_group.mechanical_efficiency
         actual = min(consumed_mass, total_available) * mech_eff
 
-        frac_C = self.mass_cnp.carbon / total_available
-        frac_N = self.mass_cnp.nitrogen / total_available
-        frac_P = self.mass_cnp.phosphorus / total_available
+        frac_C = self.mass_cnp.C / total_available
+        frac_N = self.mass_cnp.N / total_available
+        frac_P = self.mass_cnp.P / total_available
 
         taken = {
-            "carbon": actual * frac_C,
-            "nitrogen": actual * frac_N,
-            "phosphorus": actual * frac_P,
+            "C": actual * frac_C,
+            "N": actual * frac_N,
+            "P": actual * frac_P,
         }
 
         # in-place update
         self.mass_cnp.update(
-            carbon=-taken["carbon"],
-            nitrogen=-taken["nitrogen"],
-            phosphorus=-taken["phosphorus"],
+            C=-taken["C"],
+            N=-taken["N"],
+            P=-taken["P"],
         )
         return taken, {}
 
@@ -545,9 +529,7 @@ class SoilPool:
         nitrogen_mass = nitrogen_stock * self.cell_area * biotic_activity_depth
         phosphorus_mass = phosphorus_stock * self.cell_area * biotic_activity_depth
 
-        return CNP(
-            carbon=carbon_mass, nitrogen=nitrogen_mass, phosphorus=phosphorus_mass
-        )
+        return CNP(C=carbon_mass, N=nitrogen_mass, P=phosphorus_mass)
 
     def _extract_bacteria_cnp_mass(
         self,
@@ -576,12 +558,10 @@ class SoilPool:
         # Convert stock (kg m^-3) into mass by multiplying by grid square area and by
         # soil active depth
         carbon_mass = carbon_stock * self.cell_area * biotic_activity_depth
-        nitrogen_mass = carbon_mass / c_n_p_ratios_bacteria["nitrogen"]
-        phosphorus_mass = carbon_mass / c_n_p_ratios_bacteria["phosphorus"]
+        nitrogen_mass = carbon_mass / c_n_p_ratios_bacteria["N"]
+        phosphorus_mass = carbon_mass / c_n_p_ratios_bacteria["P"]
 
-        return CNP(
-            carbon=carbon_mass, nitrogen=nitrogen_mass, phosphorus=phosphorus_mass
-        )
+        return CNP(C=carbon_mass, N=nitrogen_mass, P=phosphorus_mass)
 
     def _extract_fungi_cnp_mass(
         self,
@@ -634,20 +614,20 @@ class SoilPool:
             saprotrophic_stock + arbuscular_mycorrhizal_stock + ectomycorrhizal_stock
         )
         nitrogen_stock = (
-            (saprotrophic_stock / c_n_p_ratios["saprotrophic_fungi"]["nitrogen"])
+            (saprotrophic_stock / c_n_p_ratios["saprotrophic_fungi"]["N"])
             + (
                 arbuscular_mycorrhizal_stock
-                / c_n_p_ratios["arbuscular_mycorrhiza"]["nitrogen"]
+                / c_n_p_ratios["arbuscular_mycorrhiza"]["N"]
             )
-            + (ectomycorrhizal_stock / c_n_p_ratios["ectomycorrhiza"]["nitrogen"])
+            + (ectomycorrhizal_stock / c_n_p_ratios["ectomycorrhiza"]["N"])
         )
         phosphorus_stock = (
-            (saprotrophic_stock / c_n_p_ratios["saprotrophic_fungi"]["phosphorus"])
+            (saprotrophic_stock / c_n_p_ratios["saprotrophic_fungi"]["P"])
             + (
                 arbuscular_mycorrhizal_stock
-                / c_n_p_ratios["arbuscular_mycorrhiza"]["phosphorus"]
+                / c_n_p_ratios["arbuscular_mycorrhiza"]["P"]
             )
-            + (ectomycorrhizal_stock / c_n_p_ratios["ectomycorrhiza"]["phosphorus"])
+            + (ectomycorrhizal_stock / c_n_p_ratios["ectomycorrhiza"]["P"])
         )
 
         # Convert stock (kg m^-3) into mass by multiplying by grid square area and by
@@ -656,14 +636,12 @@ class SoilPool:
         nitrogen_mass = nitrogen_stock * self.cell_area * biotic_activity_depth
         phosphorus_mass = phosphorus_stock * self.cell_area * biotic_activity_depth
 
-        return CNP(
-            carbon=carbon_mass, nitrogen=nitrogen_mass, phosphorus=phosphorus_mass
-        )
+        return CNP(C=carbon_mass, N=nitrogen_mass, P=phosphorus_mass)
 
     @property
     def mass_current(self) -> float:
         """Return current carbon mass in the pool [kg]."""
-        return self.mass_cnp.carbon
+        return self.mass_cnp.C
 
     def get_eaten(
         self,
@@ -682,8 +660,8 @@ class SoilPool:
                 same function signature as SoilPool case
 
         Returns:
-            Dictionary of element masses actually assimilated, keys ``carbon``,
-            ``nitrogen``, ``phosphorus`` (kg).
+            Dictionary of element masses actually assimilated, keys ``C``,
+            ``N``, ``P`` (kg).
         """
         if consumed_mass < 0:
             raise ValueError("consumed_mass must be non-negative")
@@ -692,21 +670,21 @@ class SoilPool:
         mech_eff = detritivore.functional_group.mechanical_efficiency
         actual = min(consumed_mass, total_available) * mech_eff
 
-        frac_C = self.mass_cnp.carbon / total_available
-        frac_N = self.mass_cnp.nitrogen / total_available
-        frac_P = self.mass_cnp.phosphorus / total_available
+        frac_C = self.mass_cnp.C / total_available
+        frac_N = self.mass_cnp.N / total_available
+        frac_P = self.mass_cnp.P / total_available
 
         taken = {
-            "carbon": actual * frac_C,
-            "nitrogen": actual * frac_N,
-            "phosphorus": actual * frac_P,
+            "C": actual * frac_C,
+            "N": actual * frac_N,
+            "P": actual * frac_P,
         }
 
         # in-place update
         self.mass_cnp.update(
-            carbon=-taken["carbon"],
-            nitrogen=-taken["nitrogen"],
-            phosphorus=-taken["phosphorus"],
+            C=-taken["C"],
+            N=-taken["N"],
+            P=-taken["P"],
         )
         return taken, {}
 
@@ -750,12 +728,12 @@ class HerbivoryWaste:
         """Type of plant matter this waste pool contains."""
 
         self.mass_cnp: dict[str, float] = {
-            "carbon": 0.0,
-            "nitrogen": 0.0,
-            "phosphorus": 0.0,
+            "C": 0.0,
+            "N": 0.0,
+            "P": 0.0,
         }
         """The mass of each stoichiometric element found in the plant resources,
-        {"carbon": value, "nitrogen": value, "phosphorus": value}."""
+        {"C": value, "N": value, "P": value}."""
 
         self.lignin_proportion = 0.25
         """Proportion of the herbivory waste pool carbon that is lignin [unitless]."""
@@ -765,14 +743,14 @@ class HerbivoryWaste:
 
         Args:
             input_mass_cnp: Dictionary specifying the mass of each element in the waste
-                {"carbon": value, "nitrogen": value, "phosphorus": value}.
+                {"C": value, "N": value, "P": value}.
 
         Raises:
             ValueError: If the input dictionary is missing required elements or contains
                 negative values.
         """
         # Validate input structure and content
-        required_keys = {"carbon", "nitrogen", "phosphorus"}
+        required_keys = {"C", "N", "P"}
         if not required_keys.issubset(input_mass_cnp.keys()):
             raise ValueError(
                 f"mass_cnp must contain all required keys {required_keys}. "

--- a/virtual_ecosystem/models/animal/exporter.py
+++ b/virtual_ecosystem/models/animal/exporter.py
@@ -377,12 +377,12 @@ class AnimalCohortDataExporter:
             "territory": cohort.territory,
             "occupancy_proportion": cohort.occupancy_proportion,
             "largest_mass_achieved": cohort.largest_mass_achieved,
-            "mass_carbon": mass_cnp.carbon,
-            "mass_nitrogen": mass_cnp.nitrogen,
-            "mass_phosphorus": mass_cnp.phosphorus,
-            "reproductive_mass_carbon": repro_cnp.carbon,
-            "reproductive_mass_nitrogen": repro_cnp.nitrogen,
-            "reproductive_mass_phosphorus": repro_cnp.phosphorus,
+            "mass_carbon": mass_cnp.C,
+            "mass_nitrogen": mass_cnp.N,
+            "mass_phosphorus": mass_cnp.P,
+            "reproductive_mass_carbon": repro_cnp.C,
+            "reproductive_mass_nitrogen": repro_cnp.N,
+            "reproductive_mass_phosphorus": repro_cnp.P,
         }
 
     def _build_trophic_rows(
@@ -426,9 +426,9 @@ class AnimalCohortDataExporter:
                     "resource_id": resource_id,
                     "resource_cell_id": resource_cell_id,
                     "prey_territory": prey_territory,
-                    "carbon": cnp["carbon"],
-                    "nitrogen": cnp["nitrogen"],
-                    "phosphorus": cnp["phosphorus"],
+                    "C": cnp["C"],
+                    "N": cnp["N"],
+                    "P": cnp["P"],
                 }
             )
 

--- a/virtual_ecosystem/models/animal/functional_group.py
+++ b/virtual_ecosystem/models/animal/functional_group.py
@@ -102,7 +102,7 @@ class FunctionalGroup:
         """The broad trophic category, herbivore, carnivore, omnivore."""
         self.cnp_proportions = self.constants.cnp_proportion_terms[self.taxa]
         """The proportions of carbon/nitrogen/phosphorus in the functional group,
-            example {"carbon": 0.8, "nitrogen": 0.15, "phosphorus": 0.05}."""
+            example {"C": 0.8, "N": 0.15, "P": 0.05}."""
         self.metabolic_rate_terms = self.constants.metabolic_rate_terms[
             self.metabolic_type
         ]

--- a/virtual_ecosystem/models/animal/model_config.py
+++ b/virtual_ecosystem/models/animal/model_config.py
@@ -199,10 +199,10 @@ class AnimalConstants(Configuration):
 
     cnp_proportion_terms: dict[TaxaType, dict[str, float]] = Field(
         default_factory=lambda: {
-            TaxaType.MAMMAL: {"carbon": 0.5, "nitrogen": 0.3, "phosphorus": 0.2},
-            TaxaType.BIRD: {"carbon": 0.4, "nitrogen": 0.3, "phosphorus": 0.3},
-            TaxaType.INVERTEBRATE: {"carbon": 0.4, "nitrogen": 0.2, "phosphorus": 0.4},
-            TaxaType.AMPHIBIAN: {"carbon": 0.4, "nitrogen": 0.2, "phosphorus": 0.4},
+            TaxaType.MAMMAL: {"C": 0.5, "N": 0.3, "P": 0.2},
+            TaxaType.BIRD: {"C": 0.4, "N": 0.3, "P": 0.3},
+            TaxaType.INVERTEBRATE: {"C": 0.4, "N": 0.2, "P": 0.4},
+            TaxaType.AMPHIBIAN: {"C": 0.4, "N": 0.2, "P": 0.4},
         }
     )
     """Stoichiometric proportions structured by taxon type."""

--- a/virtual_ecosystem/models/animal/plant_resources.py
+++ b/virtual_ecosystem/models/animal/plant_resources.py
@@ -47,14 +47,14 @@ class PlantResources:
         self.is_alive = True
         """Indicating whether the plant cohort is alive [True] or dead [False]."""
         self.cnp_proportions: dict[str, float] = {
-            "carbon": 0.7,
-            "nitrogen": 0.2,
-            "phosphorus": 0.1,
+            "C": 0.7,
+            "N": 0.2,
+            "P": 0.1,
         }
         """Toy stoichiometric proportions of plants."""
         self.mass_stoich: dict[str, float] = {}
         """The mass of each stoichiometric element found in the plant resources,
-        {"carbon": value, "nitrogen": value, "phosphorus": value}."""
+        {"C": value, "N": value, "P": value}."""
 
         # Initialize stoichiometric masses
         self.update_stoichiometric_mass()


### PR DESCRIPTION
# Description

All this PR does is change the stoichiometry naming in the animal model to be CNP instead of carbon, nitrogen, phosphorus. 

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
