### PR TITLE
Naive fix for too high metabolic fractions

### DIFF
--- a/tests/models/litter/test_inputs.py
+++ b/tests/models/litter/test_inputs.py
@@ -174,50 +174,29 @@ def test_split_pool_into_metabolic_and_structural_litter(
 
 
 @pytest.mark.parametrize(
-    "c_n_ratios,expected_log",
+    "lignin_proportions",
     [
         pytest.param(
-            np.array([34.2, 55.5, 37.1, 400.7]),
-            (
-                (
-                    ERROR,
-                    "Fraction of input biomass going to metabolic pool has dropped "
-                    "below zero!",
-                ),
-            ),
-            id="negative_metabolic_flow",
+            np.array([-0.5, 0.4, 0.35, 0.23]),
+            id="negative_lignin",
         ),
         pytest.param(
-            np.array([34.2, 55.5, 37.1, 3.7]),
-            (
-                (
-                    ERROR,
-                    "Fraction of input biomass going to structural biomass is less than"
-                    " the lignin fraction!",
-                ),
-            ),
-            id="less_than_lignin",
+            np.array([0.5, 1.4, 0.35, 0.23]),
+            id="lignin_above_one",
         ),
     ],
 )
 def test_split_pool_into_metabolic_and_structural_litter_bad_data(
-    caplog, fixture_litter_constants, c_n_ratios, expected_log, request
+    caplog, fixture_litter_constants, lignin_proportions
 ):
     """Check that pool split functions raises an error if out of bounds data is used."""
-
-    if request.node.callspec.id == "negative_metabolic_flow":
-        pytest.skip(
-            "Current implementation does not raise an error here. This will be"
-            " fixed in Issue #1010."
-        )
 
     from virtual_ecosystem.models.litter.inputs import (
         split_pool_into_metabolic_and_structural_litter,
     )
 
-    # C:N ratio of >400 is far too high for the function to behave sensibly
-    lignin_proportions = np.array([0.5, 0.4, 0.35, 0.23])
-    c_p_ratios = np.array([[415.0, 327.4, 554.5, 145.0]])
+    c_n_ratios = np.array([34.2, 55.5, 37.1, 3.7])
+    c_p_ratios = np.array([415.0, 327.4, 554.5, 145.0])
 
     with pytest.raises(ValueError):
         split_pool_into_metabolic_and_structural_litter(
@@ -228,6 +207,8 @@ def test_split_pool_into_metabolic_and_structural_litter_bad_data(
             split_sensitivity_nitrogen=fixture_litter_constants.metabolic_split_nitrogen_sensitivity,
             split_sensitivity_phosphorus=fixture_litter_constants.metabolic_split_phosphorus_sensitivity,
         )
+
+    expected_log = ((ERROR, "Lignin proportion not between 0 and 1 (inclusive)!"),)
 
     # Check the error reports
     log_check(caplog, expected_log)

--- a/virtual_ecosystem/models/litter/inputs.py
+++ b/virtual_ecosystem/models/litter/inputs.py
@@ -381,7 +381,7 @@ def split_pool_into_metabolic_and_structural_litter(
 
     Raises:
         ValueError: If any values of lignin proportion are not between zero and one
-        (which breaks the logic of this function)
+            (which breaks the logic of this function)
 
     Returns:
         The fraction of the biomass that goes to the metabolic pool [unitless]

--- a/virtual_ecosystem/models/litter/inputs.py
+++ b/virtual_ecosystem/models/litter/inputs.py
@@ -380,13 +380,19 @@ def split_pool_into_metabolic_and_structural_litter(
             changing lignin and phosphorus contents [unitless]
 
     Raises:
-        ValueError: If any of the metabolic fractions drop below zero, or if any
-            structural fraction is less than the lignin proportion (which would push the
-            lignin proportion of the structural litter input above 100%).
+        ValueError: If any values of lignin proportion are not between zero and one
+        (which breaks the logic of this function)
 
     Returns:
         The fraction of the biomass that goes to the metabolic pool [unitless]
     """
+
+    # First check that lignin proportions are between zero and one (if they aren't that
+    # screws up the logic)
+    if np.any((lignin_proportion < 0.0) | (lignin_proportion > 1.0)):
+        to_raise = ValueError("Lignin proportion not between 0 and 1 (inclusive)!")
+        LOGGER.error(to_raise)
+        raise to_raise
 
     metabolic_fraction = max_metabolic_fraction - lignin_proportion * (
         split_sensitivity_nitrogen * carbon_nitrogen_ratio
@@ -396,23 +402,16 @@ def split_pool_into_metabolic_and_structural_litter(
     # This is a naive prevention of negative metabolic fraction rates.
     # TODO: full solution in Issue #1010.
     metabolic_fraction = np.where(metabolic_fraction < 0, 0.0, metabolic_fraction)
+    # Another naive prevention of metabolic fractions that are so large that all lignin
+    # cannot flow to the structural pool
+    # TODO: full solution again in Issue #1010.
+    metabolic_fraction = np.where(
+        metabolic_fraction > 1 - lignin_proportion,
+        1 - lignin_proportion,
+        metabolic_fraction,
+    )
 
-    if np.any(metabolic_fraction < 0.0):
-        to_raise = ValueError(
-            "Fraction of input biomass going to metabolic pool has dropped below zero!"
-        )
-        LOGGER.error(to_raise)
-        raise to_raise
-
-    elif np.any(1 - metabolic_fraction < lignin_proportion):
-        to_raise = ValueError(
-            "Fraction of input biomass going to structural biomass is less than the "
-            "lignin fraction!"
-        )
-        LOGGER.error(to_raise)
-        raise to_raise
-    else:
-        return metabolic_fraction
+    return metabolic_fraction
 
 
 def merge_input_lignin_proportions(


### PR DESCRIPTION
# Description

This PR is a naive fix for metabolic fractions of litter input being too high, basically be converting the existing test to a step that forces the value to conform. This will be handled more elegantly when I get round to addressing #1010, but I think this quick fix is good enough for now.

I've also changed what this function raises errors for, so that it now checks for lignin proportions outside the physically possible range, which would break the logic of the function.

Fixes #1359

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
