### PR TITLE
Adds the base disturbance model

### DIFF
--- a/docs/source/virtual_ecosystem/implementation/var_generator.py
+++ b/docs/source/virtual_ecosystem/implementation/var_generator.py
@@ -2,7 +2,7 @@
 
 from pydantic import fields
 
-from virtual_ecosystem.core.base_model import _discover_models
+from virtual_ecosystem.core.base_model import discover_models
 from virtual_ecosystem.core.variables import VariableMetadata, load_known_variables
 
 # TODO - merge these into a single generate_model_variable_markdown and probably move it
@@ -16,7 +16,7 @@ def generate_variable_listing(model_name: str, var_attributes: list[str]) -> str
     variables = load_known_variables()
 
     # Find the model reference
-    models = {m.__name__: m for m in _discover_models()}
+    models = {m.__name__: m for m in discover_models()}
     if model_name not in models:
         raise ValueError("Unknown model name")
     model = models[model_name]
@@ -103,7 +103,7 @@ def generate_variable_table(model_name: str, var_attributes: list[str]) -> str:
     variables = load_known_variables()
 
     # Find the model reference
-    models = {m.__name__: m for m in _discover_models()}
+    models = {m.__name__: m for m in discover_models()}
     if model_name not in models:
         raise ValueError("Unknown model name")
     model = models[model_name]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,20 @@ def reset_module_registry():
     MODULE_REGISTRY.clear()
 
 
+@pytest.fixture(autouse=True)
+def reset_disturbance_registry():
+    """Reset the disturbance registry.
+
+    The register_disturbance function updates the DISTURBANCE_REGISTRY, which persists
+    between tests. This autouse fixture is used to ensure that the registry is always
+    cleared before tests start, so that the correct registration of disturbances within
+    tests is enforced.
+    """
+    from virtual_ecosystem.core.registry import DISTURBANCE_REGISTRY
+
+    DISTURBANCE_REGISTRY.clear()
+
+
 # Shared fixtures
 
 FIXTURE_ROOT_DATA_DIR = Path(__file__).parent / "data"

--- a/tests/core/test_base_model.py
+++ b/tests/core/test_base_model.py
@@ -827,8 +827,8 @@ def test_to_camel_case():
 
 def test_discover_models():
     """Test the discover_all_variables_usage function."""
-    from virtual_ecosystem.core.base_model import BaseModel, _discover_models
+    from virtual_ecosystem.core.base_model import BaseModel, discover_models
 
-    models = _discover_models()
+    models = discover_models()
     assert len(models) > 0
     assert all(issubclass(x, BaseModel) for x in models)

--- a/tests/core/test_base_model.py
+++ b/tests/core/test_base_model.py
@@ -842,5 +842,5 @@ def test_discover_disturbances():
     from virtual_ecosystem.core.base_model import BaseDisturbance, discover_disturbances
 
     models = discover_disturbances()
-    assert len(models) == 0
+    assert len(models) > 0
     assert all(issubclass(x, BaseDisturbance) for x in models)

--- a/tests/core/test_base_model.py
+++ b/tests/core/test_base_model.py
@@ -826,9 +826,21 @@ def test_to_camel_case():
 
 
 def test_discover_models():
-    """Test the discover_all_variables_usage function."""
+    """Test the discover_models function."""
     from virtual_ecosystem.core.base_model import BaseModel, discover_models
 
     models = discover_models()
     assert len(models) > 0
     assert all(issubclass(x, BaseModel) for x in models)
+
+
+def test_discover_disturbances():
+    """Test the discover_disturbances function.
+
+    TODO: Update when there are disturbance models implemented.
+    """
+    from virtual_ecosystem.core.base_model import BaseDisturbance, discover_disturbances
+
+    models = discover_disturbances()
+    assert len(models) == 0
+    assert all(issubclass(x, BaseDisturbance) for x in models)

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -22,6 +22,11 @@ def test_pydantic_models(tmp_path):
         ("virtual_ecosystem.models.litter", "LitterConfiguration"),
         ("virtual_ecosystem.models.plants", "PlantsConfiguration"),
         ("virtual_ecosystem.models.soil", "SoilConfiguration"),
+        ("virtual_ecosystem.models.testing", "TestingConfiguration"),
+        (
+            "virtual_ecosystem.disturbances.disturbance_testing",
+            "DisturbanceTestingConfiguration",
+        ),
     )
 
     submodel_details = {}

--- a/tests/core/test_configuration_builder.py
+++ b/tests/core/test_configuration_builder.py
@@ -670,13 +670,14 @@ def test_ConfigurationLoader_load_configuration_data(
 
 
 @pytest.mark.parametrize(
-    argnames="requested, disturbances, outcome, expected",
+    argnames="requested, disturbances, outcome, expected, disturbance_configs",
     argvalues=(
         pytest.param(
             ["core", "plants"],
             [],
             does_not_raise(),
             ["core", "plants"],
+            [],
             id="core present",
         ),
         pytest.param(
@@ -684,6 +685,7 @@ def test_ConfigurationLoader_load_configuration_data(
             [],
             does_not_raise(),
             ["core", "plants"],
+            [],
             id="core added",
         ),
         pytest.param(
@@ -691,18 +693,22 @@ def test_ConfigurationLoader_load_configuration_data(
             [],
             pytest.raises(ModuleNotFoundError),
             None,
+            [],
             id="unknown model",
         ),
         pytest.param(
             ["plants"],
             ["disturbance_testing"],
             does_not_raise(),
-            ["core", "plants", "disturbance_testing"],
+            ["core", "plants", "disturbance"],
+            ["disturbance_testing"],
             id="disturbance added",
         ),
     ),
 )
-def test_build_configuration_model(requested, disturbances, outcome, expected):
+def test_build_configuration_model(
+    requested, disturbances, outcome, expected, disturbance_configs
+):
     """Tests build_configuration_model."""
     from virtual_ecosystem.core.config_builder import build_configuration_model
 
@@ -711,6 +717,10 @@ def test_build_configuration_model(requested, disturbances, outcome, expected):
 
         assert issubclass(model, BaseModel)
         assert set(expected) == set(model.model_fields.keys())
+        if "disturbance" in expected:
+            assert set(disturbance_configs) == set(
+                model.model_fields["disturbance"].annotation.model_fields.keys()  # type: ignore[union-attr]
+            )
 
 
 @pytest.mark.parametrize(
@@ -754,7 +764,7 @@ def test_build_configuration_model(requested, disturbances, outcome, expected):
                 },
             },
             does_not_raise(),
-            (("core.grid.cell_nx", 10), ("disturbance_testing.run_at", 42)),
+            (("core.grid.cell_nx", 10), ("disturbance.disturbance_testing.run_at", 42)),
             ((INFO, "Configuration validated."),),
             id="core_disturbance",
         ),
@@ -821,7 +831,7 @@ def test_generate_configuration(
                 "[disturbance.disturbance_testing]\nrun_at = 42",
             ],
             does_not_raise(),
-            (("core.grid.cell_nx", 10), ("disturbance_testing.run_at", 42)),
+            (("core.grid.cell_nx", 10), ("disturbance.disturbance_testing.run_at", 42)),
             ((INFO, "Configuration validated."),),
             id="core_disturbance",
         ),

--- a/tests/core/test_configuration_builder.py
+++ b/tests/core/test_configuration_builder.py
@@ -670,34 +670,44 @@ def test_ConfigurationLoader_load_configuration_data(
 
 
 @pytest.mark.parametrize(
-    argnames="requested, outcome, expected",
+    argnames="requested, disturbances, outcome, expected",
     argvalues=(
         pytest.param(
             ["core", "plants"],
+            [],
             does_not_raise(),
             ["core", "plants"],
             id="core present",
         ),
         pytest.param(
             ["plants"],
+            [],
             does_not_raise(),
             ["core", "plants"],
             id="core added",
         ),
         pytest.param(
             ["planets"],
+            [],
             pytest.raises(ModuleNotFoundError),
             None,
             id="unknown model",
         ),
+        pytest.param(
+            ["plants"],
+            ["disturbance_testing"],
+            does_not_raise(),
+            ["core", "plants", "disturbance_testing"],
+            id="disturbance added",
+        ),
     ),
 )
-def test_build_configuration_model(requested, outcome, expected):
+def test_build_configuration_model(requested, disturbances, outcome, expected):
     """Tests build_configuration_model."""
     from virtual_ecosystem.core.config_builder import build_configuration_model
 
     with outcome:
-        model = build_configuration_model(requested)
+        model = build_configuration_model(requested, disturbances)
 
         assert issubclass(model, BaseModel)
         assert set(expected) == set(model.model_fields.keys())
@@ -735,6 +745,18 @@ def test_build_configuration_model(requested, outcome, expected):
                 (CRITICAL, "Configuration validation failed. See errors above."),
             ),
             id="core_plants_bad_type",
+        ),
+        pytest.param(
+            {
+                "core": {"grid": {"cell_nx": 10}},
+                "disturbance": {
+                    "disturbance_testing": {"run_at": 42},
+                },
+            },
+            does_not_raise(),
+            (("core.grid.cell_nx", 10), ("disturbance_testing.run_at", 42)),
+            ((INFO, "Configuration validated."),),
+            id="core_disturbance",
         ),
     ),
 )
@@ -792,6 +814,16 @@ def test_generate_configuration(
                 (CRITICAL, "Configuration validation failed. See errors above."),
             ),
             id="core_plants_bad_type",
+        ),
+        pytest.param(
+            [
+                "[core]\n[core.grid]\ncell_nx =  10\n",
+                "[disturbance.disturbance_testing]\nrun_at = 42",
+            ],
+            does_not_raise(),
+            (("core.grid.cell_nx", 10), ("disturbance_testing.run_at", 42)),
+            ((INFO, "Configuration validated."),),
+            id="core_disturbance",
         ),
     ),
 )

--- a/tests/core/test_registry.py
+++ b/tests/core/test_registry.py
@@ -108,7 +108,7 @@ from tests.conftest import log_check
         ),
     ],
 )
-def test_registry(caplog, module_name, raises, exp_log):
+def test_register_module(caplog, module_name, raises, exp_log):
     """Test the registry loading.
 
     This runs tests on the actual core and testing modules and then uses some local
@@ -139,6 +139,74 @@ def test_registry(caplog, module_name, raises, exp_log):
 
             if not mod_info.is_core:
                 assert issubclass(mod_info.model, BaseModel)
+
+            assert issubclass(mod_info.config, Configuration)
+
+        # Check the last N entries in the log match the expectation.
+        log_check(
+            caplog=caplog, expected_log=exp_log, subset=slice(-len(exp_log), None, None)
+        )
+
+
+@pytest.mark.parametrize(
+    argnames="module_name, raises, exp_log",
+    argvalues=[
+        pytest.param(
+            "virtual_ecosystem.disturbances.disturbance_testing",
+            does_not_raise(),
+            (
+                (
+                    INFO,
+                    "Registering module: "
+                    "virtual_ecosystem.disturbances.disturbance_testing",
+                ),
+                (
+                    INFO,
+                    "Registering model class for "
+                    "virtual_ecosystem.disturbances.disturbance_testing: "
+                    "DisturbanceTestingModel",
+                ),
+                (
+                    INFO,
+                    "Configuration class registered for "
+                    "virtual_ecosystem.disturbances.disturbance_testing",
+                ),
+            ),
+            id="disturbance_testing_import_good",
+        ),
+    ],
+)
+def test_register_disturbance(caplog, module_name, raises, exp_log):
+    """Test the registry loading.
+
+    This runs tests on the actual core and testing modules and then uses some local
+    badly formatted models to check error handling.
+    """
+
+    from virtual_ecosystem.core.base_model import BaseDisturbance
+    from virtual_ecosystem.core.configuration import Configuration
+    from virtual_ecosystem.core.registry import (
+        DISTURBANCE_REGISTRY,
+        ModuleInfo,
+        register_disturbance,
+    )
+
+    # Get the short name
+    _, _, short_name = module_name.rpartition(".")
+
+    caplog.clear()
+
+    with raises:
+        register_disturbance(module_name=module_name)
+
+        if isinstance(raises, does_not_raise):
+            # Test the detailed structure of the registry for the module
+            assert short_name in DISTURBANCE_REGISTRY
+            mod_info = DISTURBANCE_REGISTRY[short_name]
+            assert isinstance(mod_info, ModuleInfo)
+
+            if not mod_info.is_core:
+                assert issubclass(mod_info.model, BaseDisturbance)
 
             assert issubclass(mod_info.config, Configuration)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -243,11 +243,99 @@ def test_sort_disturbances(mocker):
     }
     expected_order = ["more_important", "important", "normal"]
 
-    class MockConfig:
+    class MockConfig(CompiledConfiguration):
         _model_classes = models
 
-        def get_subconfiguration(self, model_name, _) -> DisturbanceConfigurationRoot:
+        def get_subconfiguration(self, model_name, _):
             return self._model_classes[model_name]
+
+        @property
+        def disturbance(self):
+            return self
 
     actual_order = sort_disturbances(cast(CompiledConfiguration, MockConfig()))
     assert expected_order == actual_order
+
+
+DISTURBANCE_INITIALISATION_LOG = [
+    (INFO, "Initialising disturbances: disturbance_testing"),
+    (INFO, "Initialising disturbance_testing disturbance"),
+    (
+        INFO,
+        "Disturbance testing model instance generated from configuration.",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "cfg_strings,output,raises,expected_log_entries",
+    [
+        pytest.param(
+            "[core.timing]\nupdate_interval = '7 days'\n"
+            "[testing]\n"
+            "[disturbance.disturbance_testing]\n",
+            "DisturbanceTestingModel(_run_at=[0])",
+            does_not_raise(),
+            tuple(
+                [
+                    *DISTURBANCE_INITIALISATION_LOG,
+                ],
+            ),
+            id="valid config",
+        ),
+        pytest.param(
+            "[core.timing]\nupdate_interval = '7 days'\n"
+            "[disturbance.disturbance_testing]\n",
+            None,
+            pytest.raises(InitialisationError),
+            tuple(
+                [
+                    *DISTURBANCE_INITIALISATION_LOG[:-1],
+                    (
+                        CRITICAL,
+                        "Configuration failed for disturbances: disturbance_testing",
+                    ),
+                ],
+            ),
+            id="model required for disturbance missing",
+        ),
+    ],
+)
+def test_initialise_disturbances(
+    caplog,
+    dummy_litter_data,
+    cfg_strings,
+    output,
+    raises,
+    expected_log_entries,
+):
+    """Test the function that initialises the models."""
+
+    from virtual_ecosystem.core.config_builder import (
+        ConfigurationLoader,
+        generate_configuration,
+    )
+    from virtual_ecosystem.core.core_components import CoreComponents
+    from virtual_ecosystem.main import initialise_disturbances
+
+    # Generate a configuration to use, using simple inputs to populate most from
+    # defaults. Then clear the caplog to isolate the logging for the function,
+    config_data = ConfigurationLoader(cfg_strings=cfg_strings)
+    configuration = generate_configuration(config_data.data)
+    core_components = CoreComponents(configuration.core)
+    caplog.clear()
+
+    with raises:
+        models = initialise_disturbances(
+            configuration=configuration,
+            data=dummy_litter_data,
+            core_components=core_components,
+            models=configuration._model_classes,
+        )
+
+        if output is None:
+            assert models == [None]
+        else:
+            assert repr(models["disturbance_testing"]) == output
+
+    log_check(caplog, expected_log_entries)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,6 +6,7 @@ defined in main.py that it calls.
 
 from contextlib import nullcontext as does_not_raise
 from logging import CRITICAL, DEBUG, ERROR, INFO
+from typing import cast
 
 import pytest
 
@@ -225,3 +226,28 @@ variable = []
     assert len(err.splitlines()) == 0
     output = [v for v in out.splitlines() if v]  # drop blank lines
     assert len(output) == output_length
+
+
+def test_sort_disturbances(mocker):
+    """Test the sort_disturbances function."""
+    from virtual_ecosystem.core.configuration import (
+        CompiledConfiguration,
+        DisturbanceConfigurationRoot,
+    )
+    from virtual_ecosystem.main import sort_disturbances
+
+    models = {
+        "normal": DisturbanceConfigurationRoot(run_at=0, priority=0),
+        "more_important": DisturbanceConfigurationRoot(run_at=0, priority=2),
+        "important": DisturbanceConfigurationRoot(run_at=0, priority=1),
+    }
+    expected_order = ["more_important", "important", "normal"]
+
+    class MockConfig:
+        _model_classes = models
+
+        def get_subconfiguration(self, model_name, _) -> DisturbanceConfigurationRoot:
+            return self._model_classes[model_name]
+
+    actual_order = sort_disturbances(cast(CompiledConfiguration, MockConfig()))
+    assert expected_order == actual_order

--- a/virtual_ecosystem/core/base_model.py
+++ b/virtual_ecosystem/core/base_model.py
@@ -104,7 +104,8 @@ from __future__ import annotations
 import pkgutil
 from abc import ABC, abstractmethod
 from importlib import import_module
-from typing import Any
+from types import ModuleType
+from typing import Any, TypeVar
 
 import pint
 
@@ -782,9 +783,11 @@ def to_camel_case(snake_str: str) -> str:
     return "".join(x.capitalize() for x in snake_str.lower().split("_"))
 
 
-def _discover_models() -> list[type[BaseModel]]:
+T = TypeVar("T")
+
+
+def _discover_models(models: ModuleType, of_type: type[T]) -> list[type[T]]:
     """Discover all the models in Virtual Ecosystem."""
-    import virtual_ecosystem.models as models
 
     models_found = []
     for mod in pkgutil.iter_modules(models.__path__):
@@ -800,16 +803,25 @@ def _discover_models() -> list[type[BaseModel]]:
             continue
 
         mod_class_name = to_camel_case(mod.name) + "Model"
-        if hasattr(module, mod_class_name):
+        if hasattr(module, mod_class_name) and issubclass(
+            getattr(module, mod_class_name), of_type
+        ):
             models_found.append(getattr(module, mod_class_name))
         else:
             LOGGER.warning(
-                f"No model class '{mod_class_name}' found in module "
-                f"'{models.__name__}.{mod.name}.{mod.name}_model'."
+                f"No model class '{mod_class_name}' of type `{of_type}` found in module"
+                f" '{models.__name__}.{mod.name}.{mod.name}_model'."
             )
             continue
 
     return models_found
+
+
+def discover_models() -> list[type[BaseModel]]:
+    """Discover all the models in Virtual Ecosystem."""
+    import virtual_ecosystem.models as models
+
+    return _discover_models(models, BaseModel)  # type: ignore[type-abstract]
 
 
 class BaseDisturbance(ABC):

--- a/virtual_ecosystem/core/base_model.py
+++ b/virtual_ecosystem/core/base_model.py
@@ -111,6 +111,7 @@ import pint
 from virtual_ecosystem.core.configuration import CompiledConfiguration
 from virtual_ecosystem.core.core_components import (
     CoreComponents,
+    DisturbanceTiming,
     LayerStructure,
     ModelTiming,
 )
@@ -809,3 +810,122 @@ def _discover_models() -> list[type[BaseModel]]:
             continue
 
     return models_found
+
+
+class BaseDisturbance(ABC):
+    """A superclass for all Virtual Ecosystem disturbance models.
+
+    This abstract base class defines the shared common methods and attributes used as an
+    API across all Virtual Ecosystem disturbance models. This includes functions to
+    setup and run the specific model.
+
+    The base class defines the core abstract methods that must be defined in subclasses
+    as well as shared helper functions.
+
+    Args:
+        data: A :class:`~virtual_ecosystem.core.data.Data` instance containing
+            variables to be used in the model.
+        core_components: A
+            :class:`~virtual_ecosystem.core.core_components.CoreComponents`
+            instance containing shared core elements used throughout models.
+    """
+
+    disturbance_name: str
+    """The model name.
+
+    This class attribute sets the name used to refer to identify the disturbance class
+    in the disturbance registry, within the configuration settings and in logging
+    messages.
+    """
+
+    disturbed_models: list[str]
+    """A list of model names that this disturbance will affect.
+    
+    This list will be used to validate the configuration - check that all the models
+    to disturb are available in the simulation - as well at runtime to select those 
+    models when creating an instance of the disturbance."""
+
+    data_variables_disturbed: list[str]
+    """A list of data variables that will be updated.
+    
+    This list will be used to validate the configuration and ensure that all the
+    variables to be disturbed will be available in the simulation. Disturbance models
+    do not create new variables.
+    """
+
+    def __init__(
+        self,
+        data: Data,
+        models: dict[str, BaseModel],
+        disturbance_timing: DisturbanceTiming,
+        **kwargs,
+    ):
+        """Performs core initialization for BaseModel subclasses.
+
+        This method **must** be called in the ``__init__`` method of all subclasses.
+
+        * ``data``: the provided :class:`~virtual_ecosystem.core.data.Data` instance.
+        * ``models``: dictionary of
+          :class:`~virtual_ecosystem.core.base_model.BaseModel` instances of the models
+          available in the simulation.
+        * ``disturbance_timing``: the
+          :class:`~virtual_ecosystem.core.core_components.DisturbanceTiming` instance.
+        """
+        self.data = data
+        """A Data instance providing access to the shared simulation data."""
+        self.timing = disturbance_timing
+        """The DisturbanceTiming details used in the model."""
+
+        missing = set(self.disturbed_models).difference(models.keys())
+        if missing:
+            raise ConfigurationError(
+                f"Models {missing} required by disturbance {self.disturbance_name}"
+                "not available."
+            )
+        self.models = {
+            name: model
+            for name, model in models.items()
+            if name in self.disturbed_models
+        }
+        """The models this disturbance will disturb."""
+
+    def __init_subclass__(self, disturbance_name: str, disturbed_models: list[str]):
+        """Checks the disturbed models and variables are all known.
+
+        If so, it adds the disturbance to the registry.
+
+        TODO: Complete when the registry is implemented in #1368.
+        """
+
+    @classmethod
+    @abstractmethod
+    def from_config(
+        cls,
+        data: Data,
+        configuration: CompiledConfiguration,
+        core_components: CoreComponents,
+        models: dict[str, BaseModel],
+    ) -> BaseDisturbance:
+        """Factory function to unpack config and initialise a model instance."""
+
+    def disturb(self, time_index: int) -> None:
+        """Run the disturbance, updating the self.data and/or self.models as needed.
+
+        First, the timing is checked, returning if the disturbance shall not be run
+        at this timestep. Otherwise, it calls the inner _disturb method where the actual
+        disturbance is executed.
+
+        Args:
+            time_index: The index of the current timestep.
+        """
+        if not self.timing.check_run(time_index):
+            return
+        self._disturb(time_index)
+
+    @abstractmethod
+    def _disturb(self, time_index: int) -> None:
+        """Run the disturbance, updating the self.data and/or self.models as needed.
+
+        Args:
+            time_index: The index of the current timestep.
+        """

--- a/virtual_ecosystem/core/base_model.py
+++ b/virtual_ecosystem/core/base_model.py
@@ -842,7 +842,7 @@ class BaseDisturbance(ABC):
             instance containing shared core elements used throughout models.
     """
 
-    disturbance_name: str
+    model_name: str
     """The model name.
 
     This class attribute sets the name used to refer to identify the disturbance class
@@ -850,14 +850,14 @@ class BaseDisturbance(ABC):
     messages.
     """
 
-    disturbed_models: list[str]
+    disturbed_models: tuple[str, ...]
     """A list of model names that this disturbance will affect.
     
     This list will be used to validate the configuration - check that all the models
     to disturb are available in the simulation - as well at runtime to select those 
     models when creating an instance of the disturbance."""
 
-    data_variables_disturbed: list[str]
+    data_variables_disturbed: tuple[str, ...]
     """A list of data variables that will be updated.
     
     This list will be used to validate the configuration and ensure that all the
@@ -891,7 +891,7 @@ class BaseDisturbance(ABC):
         missing = set(self.disturbed_models).difference(models.keys())
         if missing:
             raise ConfigurationError(
-                f"Models {missing} required by disturbance {self.disturbance_name}"
+                f"Models {missing} required by disturbance {self.model_name}"
                 "not available."
             )
         self.models = {
@@ -901,13 +901,22 @@ class BaseDisturbance(ABC):
         }
         """The models this disturbance will disturb."""
 
-    def __init_subclass__(self, disturbance_name: str, disturbed_models: list[str]):
+    @classmethod
+    def __init_subclass__(
+        cls,
+        model_name: str,
+        disturbed_models: tuple[str, ...],
+        data_variables_disturbed: tuple[str, ...],
+    ):
         """Checks the disturbed models and variables are all known.
 
         If so, it adds the disturbance to the registry.
 
         TODO: Complete when the registry is implemented in #1368.
         """
+        cls.model_name = model_name
+        cls.disturbed_models = disturbed_models
+        cls.data_variables_disturbed = data_variables_disturbed
 
     @classmethod
     @abstractmethod

--- a/virtual_ecosystem/core/base_model.py
+++ b/virtual_ecosystem/core/base_model.py
@@ -787,7 +787,13 @@ T = TypeVar("T")
 
 
 def _discover_models(models: ModuleType, of_type: type[T]) -> list[type[T]]:
-    """Discover all the models in Virtual Ecosystem."""
+    """Discover all the models in Virtual Ecosystem.
+
+    We use the generic T type to ensure that the types of the inputs and the
+    outputs are linked together. In practice, T will be either
+    :attr:`~virtual_ecosystem.core.base_model.BaseModel` or
+    :attr:`~virtual_ecosystem.core.base_model.BaseDisturbance`.
+    """
 
     models_found = []
     for mod in pkgutil.iter_modules(models.__path__):

--- a/virtual_ecosystem/core/base_model.py
+++ b/virtual_ecosystem/core/base_model.py
@@ -911,12 +911,65 @@ class BaseDisturbance(ABC):
         """Checks the disturbed models and variables are all known.
 
         If so, it adds the disturbance to the registry.
-
-        TODO: Complete when the registry is implemented in #1368.
         """
-        cls.model_name = model_name
-        cls.disturbed_models = disturbed_models
-        cls.data_variables_disturbed = data_variables_disturbed
+        cls.model_name = cls._check_model_name(model_name)
+        cls.disturbed_models = cls._check_attributes(disturbed_models)
+        cls.data_variables_disturbed = cls._check_attributes(data_variables_disturbed)
+
+    @classmethod
+    def _check_model_name(cls, model_name: str) -> str:
+        """Check the model_name attribute is valid.
+
+        Args:
+            model_name: The
+                :attr:`~virtual_ecosystem.core.base_model.BaseModel.model_name`
+                attribute to be used for a subclass.
+
+        Raises:
+            ValueError: the model_name is not a string.
+
+        Returns:
+            The provided ``model_name`` if valid
+        """
+
+        if not isinstance(model_name, str):
+            excep = TypeError(
+                f"Class attribute model_name in {cls.__name__} is not a string"
+            )
+            LOGGER.error(excep)
+            raise excep
+
+        return model_name
+
+    @classmethod
+    def _check_attributes(cls, attribute_value: tuple[str, ...]) -> tuple[str, ...]:
+        """Check that disturbance variables and models attributes are valid.
+
+        They both need to be tuples of strings, so we make sure that is the case
+        when creating the class.
+
+        Args:
+            attribute_value: The provided value for the attribute
+
+        Raises:
+            TypeError: the value of the model attribute has the wrong type structure.
+
+        Returns:
+            The validated variables attribute value
+        """
+
+        # Check the structure
+        if isinstance(attribute_value, tuple) and all(
+            isinstance(vname, str) for vname in attribute_value
+        ):
+            return attribute_value
+
+        to_raise = TypeError(
+            f"Class attribute {attribute_value} has the wrong "
+            f"structure in {cls.__name__}"
+        )
+        LOGGER.error(to_raise)
+        raise to_raise
 
     @classmethod
     @abstractmethod

--- a/virtual_ecosystem/core/base_model.py
+++ b/virtual_ecosystem/core/base_model.py
@@ -941,3 +941,10 @@ class BaseDisturbance(ABC):
         Args:
             time_index: The index of the current timestep.
         """
+
+
+def discover_disturbances() -> list[type[BaseDisturbance]]:
+    """Discover all the disturbances in Virtual Ecosystem."""
+    import virtual_ecosystem.disturbances as disturbances
+
+    return _discover_models(disturbances, BaseDisturbance)  # type: ignore[type-abstract]

--- a/virtual_ecosystem/core/base_model.py
+++ b/virtual_ecosystem/core/base_model.py
@@ -887,6 +887,8 @@ class BaseDisturbance(ABC):
         """A Data instance providing access to the shared simulation data."""
         self.timing = disturbance_timing
         """The DisturbanceTiming details used in the model."""
+        self._repr: list[tuple[str, ...]] = [("timing", "_run_at")]
+        """A list of attributes to be included in the class __repr__ output"""
 
         missing = set(self.disturbed_models).difference(models.keys())
         if missing:
@@ -1003,6 +1005,26 @@ class BaseDisturbance(ABC):
         Args:
             time_index: The index of the current timestep.
         """
+
+    def __repr__(self) -> str:
+        """Represent a Disturbance as a string from the attributes listed in _repr.
+
+        Each entry in self._repr is a tuple of strings providing a path through the
+        model hierarchy. The method assembles the tips of each path into a repr string.
+        """
+
+        repr_elements: list[str] = []
+
+        for repr_entry in self._repr:
+            obj = self
+            for attr in repr_entry:
+                obj = getattr(obj, attr)
+            repr_elements.append(f"{attr}={obj}")
+
+        # Add all args to the function signature
+        repr_string = ", ".join(repr_elements)
+
+        return f"{self.__class__.__name__}({repr_string})"
 
 
 def discover_disturbances() -> list[type[BaseDisturbance]]:

--- a/virtual_ecosystem/core/config_builder.py
+++ b/virtual_ecosystem/core/config_builder.py
@@ -34,7 +34,12 @@ from pydantic import ValidationError, create_model
 from virtual_ecosystem.core.configuration import CompiledConfiguration
 from virtual_ecosystem.core.exceptions import ConfigurationError
 from virtual_ecosystem.core.logger import LOGGER
-from virtual_ecosystem.core.registry import MODULE_REGISTRY, register_module
+from virtual_ecosystem.core.registry import (
+    DISTURBANCE_REGISTRY,
+    MODULE_REGISTRY,
+    register_disturbance,
+    register_module,
+)
 
 
 def merge_configuration_dicts(
@@ -494,7 +499,7 @@ class ConfigurationLoader:
 
 
 def build_configuration_model(
-    requested_modules: list[str],
+    requested_modules: list[str], requested_disturbances: list[str] | None = None
 ) -> type[CompiledConfiguration]:
     """Build a configuration model for a simulation.
 
@@ -516,6 +521,9 @@ def build_configuration_model(
     if "core" not in requested_modules:
         requested_modules = ["core", *requested_modules]
 
+    # If there are no disturbances, it should be an empty list
+    requested_disturbances = requested_disturbances or []
+
     # Register the requested modules, which handles unknown module names. This step is
     # required to populate the module registry with the details of the requested modules
     for module in requested_modules:
@@ -526,9 +534,22 @@ def build_configuration_model(
         )
         register_module(module)
 
+    # Register requested disturbances in the same way
+    for disturbance in requested_disturbances:
+        disturbance = f"virtual_ecosystem.disturbances.{disturbance}"
+        register_disturbance(disturbance)
+
     # Create a list of submodels in the configuration.
-    submodels = (
+    submodels = [
         (module, MODULE_REGISTRY[module].config) for module in requested_modules
+    ]
+
+    # Extend with the disturbances
+    submodels.extend(
+        [
+            (disturbance, DISTURBANCE_REGISTRY[disturbance].config)
+            for disturbance in requested_disturbances
+        ]
     )
 
     # Use pydantic create_model to dynamically generate a model with a field for each
@@ -545,6 +566,11 @@ def build_configuration_model(
     # BaseModel science models by requested model name.
     combined_model._model_classes = {
         m: MODULE_REGISTRY[m].model for m in requested_modules if m != "core"
+    }
+
+    # And do the same with the disturbances
+    combined_model._disturbance_classes = {
+        m: DISTURBANCE_REGISTRY[m].model for m in requested_disturbances
     }
 
     return combined_model
@@ -568,17 +594,28 @@ def generate_configuration(data: dict[str, Any] = {}) -> CompiledConfiguration:
     Args:
         data: A dictionary of unvalidated configuration data.
     """
+    # Extract the disturbances, if any
+    disturbances = data.pop("disturbance", {})
 
     # Build the configuration model from the compiled configuration
     try:
         ConfigurationModel = build_configuration_model(
-            requested_modules=list(data.keys())
+            requested_modules=list(data.keys()),
+            requested_disturbances=list(disturbances.keys()),
         )
     except (ModuleNotFoundError, RuntimeError) as err:
         LOGGER.critical(str(err))
         raise
 
     LOGGER.info("Configuration model built.")
+
+    # Flatten the configuration to have it at the same level as other models
+    # First we check that there are common names
+    duplicates = set(data.keys()).intersection(disturbances.keys())
+    if duplicates:
+        LOGGER.error(f"Names for disturbances also found in models: {duplicates}")
+        raise ConfigurationError("Validation errors in configuration data - check log.")
+    data.update(disturbances)
 
     try:
         configuration = ConfigurationModel().model_validate(data)

--- a/virtual_ecosystem/core/config_builder.py
+++ b/virtual_ecosystem/core/config_builder.py
@@ -499,7 +499,7 @@ class ConfigurationLoader:
 
 
 def build_configuration_model(
-    requested_modules: list[str], requested_disturbances: list[str] | None = None
+    requested_modules: list[str], requested_disturbances: list[str]
 ) -> type[CompiledConfiguration]:
     """Build a configuration model for a simulation.
 
@@ -521,9 +521,6 @@ def build_configuration_model(
     if "core" not in requested_modules:
         requested_modules = ["core", *requested_modules]
 
-    # If there are no disturbances, it should be an empty list
-    requested_disturbances = requested_disturbances or []
-
     # Register the requested modules, which handles unknown module names. This step is
     # required to populate the module registry with the details of the requested modules
     for module in requested_modules:
@@ -544,18 +541,31 @@ def build_configuration_model(
         (module, MODULE_REGISTRY[module].config) for module in requested_modules
     ]
 
-    # Extend with the disturbances
-    submodels.extend(
-        [
-            (disturbance, DISTURBANCE_REGISTRY[disturbance].config)
-            for disturbance in requested_disturbances
-        ]
-    )
+    # And the same with the disturbances
+    subdisturbance_models = [
+        (disturbance, DISTURBANCE_REGISTRY[disturbance].config)
+        for disturbance in requested_disturbances
+    ]
 
     # Use pydantic create_model to dynamically generate a model with a field for each
     # requested module
     #  Mypy does not like this, but it seems to be used as intended:
     # https://docs.pydantic.dev/latest/concepts/models/#dynamic-model-creation
+    # First the disturbances, if any
+    if subdisturbance_models:
+        combined_disturbance_model = create_model(
+            "CompiledConfiguration",
+            __base__=CompiledConfiguration,
+            **{fname: (cname, cname()) for fname, cname in subdisturbance_models},
+        )  # type: ignore[call-overload]
+        # Populate the _model_classes class variable with the required dictionary of VE
+        # BaseDisturbance models by requested model name.
+        combined_disturbance_model._model_classes = {
+            m: DISTURBANCE_REGISTRY[m].model for m in requested_disturbances
+        }
+        submodels.append(("disturbance", combined_disturbance_model))
+
+    # And now, the normal models
     combined_model = create_model(
         "CompiledConfiguration",
         __base__=CompiledConfiguration,
@@ -566,11 +576,6 @@ def build_configuration_model(
     # BaseModel science models by requested model name.
     combined_model._model_classes = {
         m: MODULE_REGISTRY[m].model for m in requested_modules if m != "core"
-    }
-
-    # And do the same with the disturbances
-    combined_model._disturbance_classes = {
-        m: DISTURBANCE_REGISTRY[m].model for m in requested_disturbances
     }
 
     return combined_model
@@ -594,28 +599,21 @@ def generate_configuration(data: dict[str, Any] = {}) -> CompiledConfiguration:
     Args:
         data: A dictionary of unvalidated configuration data.
     """
-    # Extract the disturbances, if any
-    disturbances = data.pop("disturbance", {})
+    requested_modules = list(data.keys())
+    if "disturbance" in requested_modules:
+        requested_modules.remove("disturbance")
 
     # Build the configuration model from the compiled configuration
     try:
         ConfigurationModel = build_configuration_model(
-            requested_modules=list(data.keys()),
-            requested_disturbances=list(disturbances.keys()),
+            requested_modules=requested_modules,
+            requested_disturbances=list(data.get("disturbance", {}).keys()),
         )
     except (ModuleNotFoundError, RuntimeError) as err:
         LOGGER.critical(str(err))
         raise
 
     LOGGER.info("Configuration model built.")
-
-    # Flatten the configuration to have it at the same level as other models
-    # First we check that there are no common names
-    duplicates = set(data.keys()).intersection(disturbances.keys())
-    if duplicates:
-        LOGGER.error(f"Names for disturbances also found in models: {duplicates}")
-        raise ConfigurationError("Validation errors in configuration data - check log.")
-    data.update(disturbances)
 
     try:
         configuration = ConfigurationModel().model_validate(data)

--- a/virtual_ecosystem/core/config_builder.py
+++ b/virtual_ecosystem/core/config_builder.py
@@ -610,7 +610,7 @@ def generate_configuration(data: dict[str, Any] = {}) -> CompiledConfiguration:
     LOGGER.info("Configuration model built.")
 
     # Flatten the configuration to have it at the same level as other models
-    # First we check that there are common names
+    # First we check that there are no common names
     duplicates = set(data.keys()).intersection(disturbances.keys())
     if duplicates:
         LOGGER.error(f"Names for disturbances also found in models: {duplicates}")

--- a/virtual_ecosystem/core/configuration.py
+++ b/virtual_ecosystem/core/configuration.py
@@ -14,6 +14,8 @@ The basic details of how this system is used can be
 found :doc:`here </using_the_ve/configuration/config>`.
 """  # noqa: D205
 
+from __future__ import annotations
+
 from collections.abc import Callable
 from pathlib import Path
 from typing import Annotated, Any, ClassVar, TypeAlias, TypeVar
@@ -26,6 +28,7 @@ from pydantic import (
     DirectoryPath,
     Field,
     FilePath,
+    model_validator,
 )
 from pydantic._internal._model_construction import ModelMetaclass
 from pydantic_core import PydanticUndefined
@@ -171,6 +174,45 @@ class ModelConfigurationRoot(Configuration):
 
     static: bool = False
     """The model static mode setting."""
+
+
+class DisturbanceConfigurationRoot(Configuration):
+    """Root configuration class for disturbance Virtual Ecosystem models.
+
+    This model provides a common Pydantic base class that must be used to define
+    the root configuration class of a Virtual Ecosystem disturbance model. Each
+    disturbance must define an object ``model_name.model_config.ModelConfiguration``
+    that inherits from :class:`DisturbanceConfigurationRoot`. The
+    ``model_name.model_config`` module can then include other :class:`Configuration`
+    classes that are used as nested fields within the root configuration but can be only
+    one :class:`ModelConfigurationRoot` class per model. This base model sets common
+    shared attributes across models: currently just the timing options.
+
+    It also validates the timing fields to ensure that at least one of them is set.
+    """
+
+    run_at: int | list[int] | None = None
+    """Define time indices to run at specific times.
+    
+    Either a single integer or a list of integers indicating the time indices when the
+    disturbance is to run.
+    """
+    run_every: tuple[int, ...] | None = None
+    """Define a range of indices to run the disturbance.
+    
+    A tuple of integers indicating (start), or (start, step), or (start, step, stop),
+    from where a list of integers indicating the time indices when the disturbance is to
+    run can be constructed. If not provided, 'step' defaults to 1 and 'stop' defaults to
+    the last time index. 'start' must always be provided."""
+
+    @model_validator(mode="after")
+    def timing_options_are_not_both_none(self) -> DisturbanceConfigurationRoot:
+        """Validate the timing options of the configuration."""
+        if self.run_at is None and self.run_every is None:
+            raise ValueError(
+                "Timing options 'run_at' and 'run_every' cannot be both None."
+            )
+        return self
 
 
 def model_config_to_html(

--- a/virtual_ecosystem/core/configuration.py
+++ b/virtual_ecosystem/core/configuration.py
@@ -195,13 +195,13 @@ class DisturbanceConfigurationRoot(Configuration):
     It also validates the timing fields to ensure that at least one of them is set.
     """
 
-    run_at: int | list[int] | None = None
+    run_at: int | tuple[int, ...] = ()
     """Define time indices to run at specific times.
     
     Either a single integer or a list of integers indicating the time indices when the
     disturbance is to run.
     """
-    run_every: tuple[int, ...] | None = None
+    run_every: tuple[int, ...] = ()
     """Define a range of indices to run the disturbance.
     
     A tuple of integers indicating (start), or (start, step), or (start, step, stop),
@@ -210,11 +210,11 @@ class DisturbanceConfigurationRoot(Configuration):
     the last time index. 'start' must always be provided."""
 
     @model_validator(mode="after")
-    def timing_options_are_not_both_none(self) -> DisturbanceConfigurationRoot:
+    def timing_options_are_not_both_empty(self) -> DisturbanceConfigurationRoot:
         """Validate the timing options of the configuration."""
-        if self.run_at is None and self.run_every is None:
+        if self.run_at == () and self.run_every == ():
             raise ValueError(
-                "Timing options 'run_at' and 'run_every' cannot be both None."
+                "Timing options 'run_at' and 'run_every' cannot be both ()."
             )
         return self
 

--- a/virtual_ecosystem/core/configuration.py
+++ b/virtual_ecosystem/core/configuration.py
@@ -121,6 +121,10 @@ class CompiledConfiguration(Configuration):
     """A dictionary of the requested modules in the simulation and their
     VirtualEcosystem BaseModel classes."""
 
+    _disturbance_classes: ClassVar[dict[str, Any]]  # FIXME - VEBaseDisturbance
+    """A dictionary of the requested disturbances in the simulation and their
+    VirtualEcosystem BaseDisturbance classes."""
+
     def get_subconfiguration(self, name: str, _: Callable[..., T]) -> T:
         """Get a named subconfiguration object from a compiled configuration.
 

--- a/virtual_ecosystem/core/configuration.py
+++ b/virtual_ecosystem/core/configuration.py
@@ -121,11 +121,7 @@ class CompiledConfiguration(Configuration):
     """A dictionary of the requested modules in the simulation and their
     VirtualEcosystem BaseModel classes."""
 
-    _disturbance_classes: ClassVar[dict[str, Any]]  # FIXME - VEBaseDisturbance
-    """A dictionary of the requested disturbances in the simulation and their
-    VirtualEcosystem BaseDisturbance classes."""
-
-    def get_subconfiguration(self, name: str, _: Callable[..., T]) -> T:
+    def get_subconfiguration(self, name: str, as_class: Callable[..., T]) -> T:
         """Get a named subconfiguration object from a compiled configuration.
 
         This method can be used to extract model configurations or the core
@@ -143,14 +139,19 @@ class CompiledConfiguration(Configuration):
 
         Args:
             name: The required subconfiguration.
-            _: The class of objected returned by the method. This is not used by the
-                method itself but is used to support static typing of the return value.
+            as_class: The class of objected returned by the method. This is not used by
+            the method itself but is used to support static typing of the return value.
         """
 
         try:
             return getattr(self, name)
         except AttributeError:
-            raise AttributeError(f"Model configuration for {name} not loaded")
+            try:
+                return getattr(self, "disturbance").get_subconfiguration(name, as_class)
+            except AttributeError:
+                raise AttributeError(
+                    f"Model or disturbance configuration for {name} not loaded"
+                )
 
     def export_toml(self, path: Path):
         """TOML export method for a compiled configuration.

--- a/virtual_ecosystem/core/configuration.py
+++ b/virtual_ecosystem/core/configuration.py
@@ -146,9 +146,9 @@ class CompiledConfiguration(Configuration):
         try:
             return getattr(self, name)
         except AttributeError:
-            try:
-                return getattr(self, "disturbance").get_subconfiguration(name, as_class)
-            except AttributeError:
+            if disturbance := self.get_disturbance_config():
+                return disturbance.get_subconfiguration(name, as_class)
+            else:
                 raise AttributeError(
                     f"Model or disturbance configuration for {name} not loaded"
                 )
@@ -162,6 +162,10 @@ class CompiledConfiguration(Configuration):
 
         with open(path, "wb") as destination:
             tomli_w.dump(self.model_dump(mode="json"), destination)
+
+    def get_disturbance_config(self) -> CompiledConfiguration | None:
+        """Get the compile configuration for disturbances, if any."""
+        return getattr(self, "disturbance", None)
 
 
 class ModelConfigurationRoot(Configuration):
@@ -209,6 +213,13 @@ class DisturbanceConfigurationRoot(Configuration):
     from where a list of integers indicating the time indices when the disturbance is to
     run can be constructed. If not provided, 'step' defaults to 1 and 'stop' defaults to
     the last time index. 'start' must always be provided."""
+
+    priority: int = 0
+    """Priority for the disturbance. 
+
+    Higher priority disturbances will be executed first. In case of having the same
+    disturbances are sorted by alphabetical order.
+    """
 
     @model_validator(mode="after")
     def timing_options_are_not_both_empty(self) -> DisturbanceConfigurationRoot:

--- a/virtual_ecosystem/core/configuration.py
+++ b/virtual_ecosystem/core/configuration.py
@@ -217,8 +217,7 @@ class DisturbanceConfigurationRoot(Configuration):
     priority: int = 0
     """Priority for the disturbance. 
 
-    Higher priority disturbances will be executed first. In case of having the same
-    disturbances are sorted by alphabetical order.
+    Every disturbance model must have a different priority.
     """
 
     @model_validator(mode="after")

--- a/virtual_ecosystem/core/core_components.py
+++ b/virtual_ecosystem/core/core_components.py
@@ -7,6 +7,7 @@ these components to be cascaded down to individual model subclass instances via 
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import InitVar, dataclass, field
 
 import numpy as np
@@ -625,8 +626,8 @@ class DisturbanceTiming:
     def __init__(
         self,
         model_timing: ModelTiming,
-        run_at: int | list[int] | None = None,
-        run_every: tuple[int, ...] | None = None,
+        run_at: int | tuple[int, ...] = (),
+        run_every: tuple[int, ...] = (),
     ) -> None:
         """Constructor for the DisturbanceTiming class.
 
@@ -634,7 +635,7 @@ class DisturbanceTiming:
 
         Args:
             model_timing: The timing for the models.
-            run_at: Either a single integer or a list of integers indicating the time
+            run_at: Either a single integer or a tuple of integers indicating the time
                 indices when the disturbance is to run.
             run_every: A tuple of integers indicating (start), or (start, step), or
                 (start, step, stop), from where a list of integers indicating the time
@@ -644,10 +645,10 @@ class DisturbanceTiming:
 
         """
 
-        if run_at is not None:
-            self._run_at = sorted(run_at) if isinstance(run_at, list) else [run_at]
+        if run_at != ():
+            self._run_at = sorted(run_at) if isinstance(run_at, Iterable) else [run_at]
 
-        elif run_every is not None:
+        elif run_every != ():
             match len(run_every):
                 case 1:
                     start = run_every[0]

--- a/virtual_ecosystem/core/registry.py
+++ b/virtual_ecosystem/core/registry.py
@@ -12,7 +12,7 @@ function, which is used to populate the registry with the components of a given 
 
 from dataclasses import dataclass
 from importlib import import_module
-from typing import Any
+from typing import Any, TypeVar
 
 from virtual_ecosystem.core.base_model import to_camel_case
 from virtual_ecosystem.core.configuration import Configuration
@@ -80,11 +80,43 @@ def register_module(module_name: str) -> None:
             :class:`~virtual_ecosystem.core.base_model.BaseModel` class.
         Exception: other exceptions can occur when loading the JSON schema fails.
     """
+    from virtual_ecosystem.core.base_model import BaseModel
+
+    _register_module(
+        module_name,
+        MODULE_REGISTRY,
+        BaseModel,  # type: ignore[type-abstract]
+    )
+
+
+_T = TypeVar("_T")
+
+
+def _register_module(
+    module_name: str,
+    registry: dict[str, ModuleInfo],
+    of_type: type[_T],
+) -> None:
+    """Internal function to register models and disturbances.
+
+    Args:
+        module_name: The full name of the module to be registered (e.g.
+            'virtual_ecosystem.model.animal').
+        registry: The registry to use to register this module.
+        of_type: The type of the model that should be expected within the module
+            (e.g. BaseModel).
+
+    Raises:
+        RuntimeError: if the requested module cannot be found or where a module does not
+            provide a single subclass of the
+            :class:`~virtual_ecosystem.core.base_model.BaseModel` class.
+        Exception: other exceptions can occur when loading the JSON schema fails.
+    """
 
     # Extract the last component of the module name to act as unique short name
     module_name_short = module_name.rpartition(".")[-1]
 
-    if module_name_short in MODULE_REGISTRY:
+    if module_name_short in registry:
         LOGGER.warning(f"Module already registered: {module_name}")
         return
 
@@ -94,23 +126,27 @@ def register_module(module_name: str) -> None:
         model = None
     else:
         is_core = False
-        model = get_model(module_name, module_name_short)
+        model = _get_model(module_name, module_name_short, of_type)
 
     # Find and register the model configuration
-    model_config_class = get_model_configuration_class(
+    model_config_class = _get_model_configuration_class(
         module_name=module_name, module_name_short=module_name_short
     )
 
     LOGGER.info("Configuration class registered for %s", module_name)
 
-    MODULE_REGISTRY[module_name_short] = ModuleInfo(
+    registry[module_name_short] = ModuleInfo(
         model=model,
         config=model_config_class,
         is_core=is_core,
     )
 
 
-def get_model(module_name: str, module_name_short: str):
+def _get_model(
+    module_name: str,
+    module_name_short: str,
+    of_type: type[_T],
+):
     """Get the main model class for a model.
 
     Model classes are discovered by name, following the pattern below:
@@ -122,9 +158,9 @@ def get_model(module_name: str, module_name_short: str):
     Args:
         module_name: The full module name (e.g. ``virtual_ecosystem.models.plants``)
         module_name_short: The short module name (e.g ``plants``)
+        of_type: The type of the model that should be expected within the module
+            (e.g. BaseModel).
     """
-
-    from virtual_ecosystem.core.base_model import BaseModel
 
     # Try and import the submodule containing the model
     model_submodule_name = module_name + f".{module_name_short}_model"
@@ -145,7 +181,7 @@ def get_model(module_name: str, module_name_short: str):
         )
 
     # Raises a runtime error if the retrieved class is not a Configuration.
-    if not issubclass(model, BaseModel):
+    if not issubclass(model, of_type):
         raise RuntimeError(f"Model is not a BaseModel subclass: {expected_model_name}")
 
     # Trap models that do not follow the requirement that the BaseModel.model_name
@@ -163,7 +199,7 @@ def get_model(module_name: str, module_name_short: str):
     return model
 
 
-def get_model_configuration_class(module_name: str, module_name_short: str):
+def _get_model_configuration_class(module_name: str, module_name_short: str):
     """Get the root configuration class for a model.
 
     Discovery is name based, with the function attempting to retrieve a class based on

--- a/virtual_ecosystem/core/registry.py
+++ b/virtual_ecosystem/core/registry.py
@@ -23,20 +23,22 @@ from virtual_ecosystem.core.logger import LOGGER
 class ModuleInfo:
     """Dataclass for module information.
 
-    This dataclass holds references to BaseModel subclass and configuration class for a
-    model and is used to hold that information with  the
-    data:`~virtual_ecosystem.core.registry.MODULE_REGISTRY`. Note that the
-    :mod:`virtual_ecosystem.core` module does not have an associated BaseModel subclass
-    and the ``model`` attribute for the ``core`` module will be None.
+    This dataclass holds references to Base subclasses and configuration class for a
+    model or disturbance and is used to hold that information with the corresponding
+    registry. Note that the :mod:`virtual_ecosystem.core` module does not have an
+    associated BaseModel subclass and the ``model`` attribute for the ``core`` module
+    will be None.
     """
 
     # FIXME The typing below for model should be `None | type[BaseModel]`, but this is
     # circular. When core.base_model is imported, that imports core.config.Config, which
     # imports core.registry, which would then need to import core.base_model to use this
     # type. Not sure how to break out of this one, so for the moment, leaving as Any.
+    #
+    # Actually, model can be a BaseModel or a BaseDisturbance, so probably Any is OK.
 
     model: Any
-    """The BaseModel subclass associated with the module."""
+    """The Base subclass associated with the module."""
     config: type[Configuration]
     """A Configuration subclass that provides a pydantic model to populate and validate
     the model configuration."""
@@ -50,6 +52,15 @@ MODULE_REGISTRY: dict[str, ModuleInfo] = {}
 
 As each module is registered using
 :func:`~virtual_ecosystem.core.registry.register_module`, a
+:class:`~virtual_ecosystem.core.registry.ModuleInfo` dataclass will be added to this
+registry using the short name of the module being registered.
+"""
+
+DISTURBANCE_REGISTRY: dict[str, ModuleInfo] = {}
+"""The global disturbance module registry.
+
+As each module is registered using
+:func:`~virtual_ecosystem.core.registry.register_disturbance`, a
 :class:`~virtual_ecosystem.core.registry.ModuleInfo` dataclass will be added to this
 registry using the short name of the module being registered.
 """
@@ -72,7 +83,7 @@ def register_module(module_name: str) -> None:
 
     Args:
         module_name: The full name of the module to be registered (e.g.
-            'virtual_ecosystem.model.animal').
+            'virtual_ecosystem.models.animal').
 
     Raises:
         RuntimeError: if the requested module cannot be found or where a module does not
@@ -86,6 +97,40 @@ def register_module(module_name: str) -> None:
         module_name,
         MODULE_REGISTRY,
         BaseModel,  # type: ignore[type-abstract]
+    )
+
+
+def register_disturbance(module_name: str) -> None:
+    """Register module components.
+
+    This function loads the :func:`~virtual_ecosystem.core.base_model.BaseDisturbance`
+    subclass for a module and its root configuration object. It then adds a
+    :class:`~virtual_ecosystem.core.registry.ModuleInfo` dataclass instance to the
+    :data:`~virtual_ecosystem.core.registry.DISTURBANCE_REGISTRY` containing references
+    to those classes. The :mod:`~virtual_ecosystem.core` module does not have an
+    associated module.
+
+    This function is primarily used within the
+    :meth:`~virtual_ecosystem.core.config_builder.generate_configuration` method to
+    register the components required to validate and setup the model configuration for a
+    particular simulation.
+
+    Args:
+        module_name: The full name of the module to be registered (e.g.
+            'virtual_ecosystem.disturbances.logging').
+
+    Raises:
+        RuntimeError: if the requested module cannot be found or where a module does not
+            provide a single subclass of the
+            :class:`~virtual_ecosystem.core.base_model.BaseDisturbance` class.
+        Exception: other exceptions can occur when loading the JSON schema fails.
+    """
+    from virtual_ecosystem.core.base_model import BaseDisturbance
+
+    _register_module(
+        module_name,
+        DISTURBANCE_REGISTRY,
+        BaseDisturbance,  # type: ignore[type-abstract]
     )
 
 
@@ -108,8 +153,7 @@ def _register_module(
 
     Raises:
         RuntimeError: if the requested module cannot be found or where a module does not
-            provide a single subclass of the
-            :class:`~virtual_ecosystem.core.base_model.BaseModel` class.
+            provide a single subclass of the required parent class.
         Exception: other exceptions can occur when loading the JSON schema fails.
     """
 

--- a/virtual_ecosystem/disturbances/__init__.py
+++ b/virtual_ecosystem/disturbances/__init__.py
@@ -1,0 +1,1 @@
+"""A module providing the different disturbance components of the Virtual Ecosystem."""

--- a/virtual_ecosystem/disturbances/disturbance_testing/__init__.py
+++ b/virtual_ecosystem/disturbances/disturbance_testing/__init__.py
@@ -1,0 +1,1 @@
+"""A minimal model for testing."""

--- a/virtual_ecosystem/disturbances/disturbance_testing/disturbance_testing_model.py
+++ b/virtual_ecosystem/disturbances/disturbance_testing/disturbance_testing_model.py
@@ -1,0 +1,64 @@
+"""A testing model to use in minimal ve_run testing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from virtual_ecosystem.core.base_model import BaseDisturbance, BaseModel
+from virtual_ecosystem.core.configuration import CompiledConfiguration
+from virtual_ecosystem.core.core_components import CoreComponents, DisturbanceTiming
+from virtual_ecosystem.core.data import Data
+from virtual_ecosystem.core.logger import LOGGER
+from virtual_ecosystem.disturbances.disturbance_testing.model_config import (
+    DisturbanceTestingConfiguration,
+)
+
+
+class DisturbanceTestingModel(
+    BaseDisturbance,
+    model_name="disturbance_testing",
+    disturbed_models=("testing",),
+    data_variables_disturbed=tuple(),
+):
+    """A disturbance model that does literally nothing.
+
+    Args:
+        data: The data object to be used in the model.
+        core_components: The core components used across models.
+        static: Boolean flag indicating if the model should run in static mode.
+    """
+
+    @classmethod
+    def from_config(
+        cls,
+        data: Data,
+        configuration: CompiledConfiguration,
+        core_components: CoreComponents,
+        models: dict[str, BaseModel],
+    ) -> DisturbanceTestingModel:
+        """Factory function to initialise a testing model from configuration."""
+
+        # Extract the validated model configuration from the complete compiled
+        # configuration. This syntax is odd but required to support static typing
+        model_configuration: DisturbanceTestingConfiguration = (
+            configuration.get_subconfiguration(
+                cls.model_name, DisturbanceTestingConfiguration
+            )
+        )
+
+        # Get the disturbance timing
+        model_timing = core_components.model_timing
+        disturbance_timing = DisturbanceTiming(
+            model_timing,
+            run_at=model_configuration.run_at,
+            run_every=model_configuration.run_every,
+        )
+
+        # Create the instance
+        inst = cls(data=data, models=models, disturbance_timing=disturbance_timing)
+
+        LOGGER.info("Disturbance testing model instance generated from configuration.")
+        return inst
+
+    def _disturb(self, time_index: int, **kwargs: Any) -> None:
+        """Placeholder function to disturb the models."""

--- a/virtual_ecosystem/disturbances/disturbance_testing/model_config.py
+++ b/virtual_ecosystem/disturbances/disturbance_testing/model_config.py
@@ -6,4 +6,4 @@ from virtual_ecosystem.core.configuration import DisturbanceConfigurationRoot
 class DisturbanceTestingConfiguration(DisturbanceConfigurationRoot):
     """Root configuration class for the testing model."""
 
-    run_at: int | list[int] | None = 0
+    run_at: int | tuple[int, ...] = 0

--- a/virtual_ecosystem/disturbances/disturbance_testing/model_config.py
+++ b/virtual_ecosystem/disturbances/disturbance_testing/model_config.py
@@ -1,0 +1,9 @@
+"""Configuration classes for the testing model."""
+
+from virtual_ecosystem.core.configuration import DisturbanceConfigurationRoot
+
+
+class DisturbanceTestingConfiguration(DisturbanceConfigurationRoot):
+    """Root configuration class for the testing model."""
+
+    run_at: int | list[int] | None = 0

--- a/virtual_ecosystem/main.py
+++ b/virtual_ecosystem/main.py
@@ -13,12 +13,15 @@ from typing import Any
 
 from tqdm import tqdm
 
-from virtual_ecosystem.core.base_model import BaseModel
+from virtual_ecosystem.core.base_model import BaseDisturbance, BaseModel
 from virtual_ecosystem.core.config_builder import (
     ConfigurationLoader,
     generate_configuration,
 )
-from virtual_ecosystem.core.configuration import CompiledConfiguration
+from virtual_ecosystem.core.configuration import (
+    CompiledConfiguration,
+    DisturbanceConfigurationRoot,
+)
 from virtual_ecosystem.core.core_components import CoreComponents
 from virtual_ecosystem.core.data import Data, merge_continuous_data_files
 from virtual_ecosystem.core.exceptions import ConfigurationError, InitialisationError
@@ -146,6 +149,85 @@ def initialise_models(
     return models_cfd
 
 
+def sort_disturbances(disturbance_config: CompiledConfiguration) -> list[str]:
+    """Sort disturbances based on priority and name.
+
+    Args:
+        disturbance_config: CompiledConfiguration object for disturbances.
+
+    Returns:
+        Tuple of disturbance model names in the order they need to be executed.
+    """
+    return sorted(
+        disturbance_config._model_classes.keys(),
+        key=lambda name: (
+            -disturbance_config.get_subconfiguration(
+                name, DisturbanceConfigurationRoot
+            ).priority,
+            name,
+        ),
+    )
+
+
+def initialise_disturbances(
+    sorted_disturbances: list[str],
+    configuration: CompiledConfiguration,
+    data: Data,
+    core_components: CoreComponents,
+    models: dict[str, BaseModel],
+) -> dict[str, BaseDisturbance]:
+    """Initialise a set of disturbances for use in a `virtual_ecosystem` simulation.
+
+    Args:
+        sorted_disturbances: list of disturbances in the right execution order.
+        configuration: A validated Virtual Ecosystem configuration object containing the
+            disturbance configuration.
+        data: A Data instance.
+        core_components: A CoreComponents instance.
+        models: A dictionary of initialised models.
+
+    Raises:
+        InitialisationError: If one or more disturbances cannot be properly configured
+
+    Returns:
+        Dictionary of initialised disturbances in the right execution order.
+    """
+
+    LOGGER.info("Initialising disturbances: {}".format(",".join(sorted_disturbances)))
+
+    # Use factory methods to configure the desired disturbances
+    failed_disturbances = []
+    models_cfd = {}
+
+    for disturbance_name in sorted_disturbances:
+        LOGGER.info(f"Initialising {disturbance_name} disturbance")
+
+        try:
+            disturbance_class: BaseDisturbance = configuration._model_classes[
+                disturbance_name
+            ]
+            this_disturbance = disturbance_class.from_config(
+                data=data,
+                configuration=configuration,
+                core_components=core_components,
+                models=models,
+            )
+            models_cfd[disturbance_name] = this_disturbance
+
+        except (InitialisationError, ConfigurationError, KeyError):
+            failed_disturbances.append(disturbance_name)
+
+    # If any models fail to configure inform the user about it
+    if failed_disturbances:
+        to_raise: Exception = InitialisationError(
+            f"Configuration failed for disturbances: {','.join(failed_disturbances)}"
+        )
+        LOGGER.critical(to_raise)
+        raise to_raise
+
+    return models_cfd
+
+
 def ve_run(
     cfg_paths: str | Path | Sequence[str | Path] = [],
     cfg_strings: str | list[str] = [],
@@ -253,6 +335,20 @@ def ve_run(
 
     LOGGER.info("All models successfully initialised.")
 
+    # Get disturbances order and initialise them
+    if disturbance_config := configuration.get_disturbance_config():
+        disturbances = initialise_disturbances(
+            sorted_disturbances=sort_disturbances(disturbance_config),
+            configuration=disturbance_config,
+            data=data,
+            core_components=core_components,
+            models=models_init,
+        )
+
+        LOGGER.info("All disturbances successfully initialised.")
+    else:
+        disturbances = {}
+
     # TODO - A model spin up might be needed here in future
 
     # Data output options
@@ -331,6 +427,9 @@ def ve_run(
                     model=model.model_name,
                     attr="vars_populated_by_first_update",
                 )
+
+        for disturbance in disturbances.values():
+            disturbance.disturb(time_index)
 
         # If there are mismatches in the variable specifications, fail.
         if not model_variables_ok:

--- a/virtual_ecosystem/main.py
+++ b/virtual_ecosystem/main.py
@@ -9,7 +9,7 @@ from collections.abc import Sequence
 from enum import IntEnum
 from itertools import chain
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from tqdm import tqdm
 
@@ -149,15 +149,19 @@ def initialise_models(
     return models_cfd
 
 
-def sort_disturbances(disturbance_config: CompiledConfiguration) -> list[str]:
+def sort_disturbances(configuration: CompiledConfiguration) -> list[str]:
     """Sort disturbances based on priority and name.
 
     Args:
-        disturbance_config: CompiledConfiguration object for disturbances.
+        configuration: CompiledConfiguration object for disturbances.
 
     Returns:
         Tuple of disturbance model names in the order they need to be executed.
     """
+    disturbance_config = configuration.get_disturbance_config()
+    if not disturbance_config:
+        return []
+
     priorities = {
         name: -disturbance_config.get_subconfiguration(
             name, DisturbanceConfigurationRoot
@@ -202,11 +206,16 @@ def initialise_disturbances(
     failed_disturbances = []
     models_cfd = {}
 
+    # We do know there are disturbances at this point, so this casting is OK.
+    disturbance_config = cast(
+        CompiledConfiguration, configuration.get_disturbance_config()
+    )
+
     for disturbance_name in sorted_disturbances:
         LOGGER.info(f"Initialising {disturbance_name} disturbance")
 
         try:
-            disturbance_class: BaseDisturbance = configuration._model_classes[
+            disturbance_class: BaseDisturbance = disturbance_config._model_classes[
                 disturbance_name
             ]
             this_disturbance = disturbance_class.from_config(

--- a/virtual_ecosystem/main.py
+++ b/virtual_ecosystem/main.py
@@ -158,15 +158,19 @@ def sort_disturbances(disturbance_config: CompiledConfiguration) -> list[str]:
     Returns:
         Tuple of disturbance model names in the order they need to be executed.
     """
-    return sorted(
-        disturbance_config._model_classes.keys(),
-        key=lambda name: (
-            -disturbance_config.get_subconfiguration(
-                name, DisturbanceConfigurationRoot
-            ).priority,
-            name,
-        ),
-    )
+    priorities = {
+        name: -disturbance_config.get_subconfiguration(
+            name, DisturbanceConfigurationRoot
+        ).priority
+        for name in disturbance_config._model_classes.keys()
+    }
+    if len(set(priorities.values())) != len(priorities):
+        to_raise: Exception = InitialisationError(
+            "Configuration failed for disturbances: 2 or more disturbance models have "
+            "the same priority"
+        )
+        LOGGER.critical(to_raise)
+    return sorted(priorities.keys(), key=lambda name: priorities[name])
 
 
 def initialise_disturbances(

--- a/virtual_ecosystem/main.py
+++ b/virtual_ecosystem/main.py
@@ -170,7 +170,6 @@ def sort_disturbances(disturbance_config: CompiledConfiguration) -> list[str]:
 
 
 def initialise_disturbances(
-    sorted_disturbances: list[str],
     configuration: CompiledConfiguration,
     data: Data,
     core_components: CoreComponents,
@@ -179,7 +178,6 @@ def initialise_disturbances(
     """Initialise a set of disturbances for use in a `virtual_ecosystem` simulation.
 
     Args:
-        sorted_disturbances: list of disturbances in the right execution order.
         configuration: A validated Virtual Ecosystem configuration object containing the
             disturbance configuration.
         data: A Data instance.
@@ -192,6 +190,7 @@ def initialise_disturbances(
     Returns:
         Dictionary of initialised disturbances in the right execution order.
     """
+    sorted_disturbances = sort_disturbances(configuration)
 
     LOGGER.info("Initialising disturbances: {}".format(",".join(sorted_disturbances)))
 
@@ -338,7 +337,6 @@ def ve_run(
     # Get disturbances order and initialise them
     if disturbance_config := configuration.get_disturbance_config():
         disturbances = initialise_disturbances(
-            sorted_disturbances=sort_disturbances(disturbance_config),
             configuration=disturbance_config,
             data=data,
             core_components=core_components,


### PR DESCRIPTION
# Description

Adds the base disturbance model that all the other disturbances will need to inherit from.

Note: No tests have been added as this will be come simpler when there are more bits and pieces put together (in particular, the model discovery and registry).

Fixes #1367 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
