### PR TITLE
Add disturbances to input layer

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,20 @@ def reset_module_registry():
     MODULE_REGISTRY.clear()
 
 
+@pytest.fixture(autouse=True)
+def reset_disturbance_registry():
+    """Reset the disturbance registry.
+
+    The register_disturbance function updates the DISTURBANCE_REGISTRY, which persists
+    between tests. This autouse fixture is used to ensure that the registry is always
+    cleared before tests start, so that the correct registration of disturbances within
+    tests is enforced.
+    """
+    from virtual_ecosystem.core.registry import DISTURBANCE_REGISTRY
+
+    DISTURBANCE_REGISTRY.clear()
+
+
 # Shared fixtures
 
 FIXTURE_ROOT_DATA_DIR = Path(__file__).parent / "data"

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -22,6 +22,11 @@ def test_pydantic_models(tmp_path):
         ("virtual_ecosystem.models.litter", "LitterConfiguration"),
         ("virtual_ecosystem.models.plants", "PlantsConfiguration"),
         ("virtual_ecosystem.models.soil", "SoilConfiguration"),
+        ("virtual_ecosystem.models.testing", "TestingConfiguration"),
+        (
+            "virtual_ecosystem.disturbances.disturbance_testing",
+            "DisturbanceTestingConfiguration",
+        ),
     )
 
     submodel_details = {}

--- a/tests/core/test_configuration_builder.py
+++ b/tests/core/test_configuration_builder.py
@@ -670,13 +670,14 @@ def test_ConfigurationLoader_load_configuration_data(
 
 
 @pytest.mark.parametrize(
-    argnames="requested, disturbances, outcome, expected",
+    argnames="requested, disturbances, outcome, expected, disturbance_configs",
     argvalues=(
         pytest.param(
             ["core", "plants"],
             [],
             does_not_raise(),
             ["core", "plants"],
+            [],
             id="core present",
         ),
         pytest.param(
@@ -684,6 +685,7 @@ def test_ConfigurationLoader_load_configuration_data(
             [],
             does_not_raise(),
             ["core", "plants"],
+            [],
             id="core added",
         ),
         pytest.param(
@@ -691,18 +693,22 @@ def test_ConfigurationLoader_load_configuration_data(
             [],
             pytest.raises(ModuleNotFoundError),
             None,
+            [],
             id="unknown model",
         ),
         pytest.param(
             ["plants"],
             ["disturbance_testing"],
             does_not_raise(),
-            ["core", "plants", "disturbance_testing"],
+            ["core", "plants", "disturbance"],
+            ["disturbance_testing"],
             id="disturbance added",
         ),
     ),
 )
-def test_build_configuration_model(requested, disturbances, outcome, expected):
+def test_build_configuration_model(
+    requested, disturbances, outcome, expected, disturbance_configs
+):
     """Tests build_configuration_model."""
     from virtual_ecosystem.core.config_builder import build_configuration_model
 
@@ -711,6 +717,10 @@ def test_build_configuration_model(requested, disturbances, outcome, expected):
 
         assert issubclass(model, BaseModel)
         assert set(expected) == set(model.model_fields.keys())
+        if "disturbance" in expected:
+            assert set(disturbance_configs) == set(
+                model.model_fields["disturbance"].annotation.model_fields.keys()  # type: ignore[union-attr]
+            )
 
 
 @pytest.mark.parametrize(
@@ -754,7 +764,7 @@ def test_build_configuration_model(requested, disturbances, outcome, expected):
                 },
             },
             does_not_raise(),
-            (("core.grid.cell_nx", 10), ("disturbance_testing.run_at", 42)),
+            (("core.grid.cell_nx", 10), ("disturbance.disturbance_testing.run_at", 42)),
             ((INFO, "Configuration validated."),),
             id="core_disturbance",
         ),
@@ -821,7 +831,7 @@ def test_generate_configuration(
                 "[disturbance.disturbance_testing]\nrun_at = 42",
             ],
             does_not_raise(),
-            (("core.grid.cell_nx", 10), ("disturbance_testing.run_at", 42)),
+            (("core.grid.cell_nx", 10), ("disturbance.disturbance_testing.run_at", 42)),
             ((INFO, "Configuration validated."),),
             id="core_disturbance",
         ),

--- a/tests/core/test_configuration_builder.py
+++ b/tests/core/test_configuration_builder.py
@@ -670,34 +670,44 @@ def test_ConfigurationLoader_load_configuration_data(
 
 
 @pytest.mark.parametrize(
-    argnames="requested, outcome, expected",
+    argnames="requested, disturbances, outcome, expected",
     argvalues=(
         pytest.param(
             ["core", "plants"],
+            [],
             does_not_raise(),
             ["core", "plants"],
             id="core present",
         ),
         pytest.param(
             ["plants"],
+            [],
             does_not_raise(),
             ["core", "plants"],
             id="core added",
         ),
         pytest.param(
             ["planets"],
+            [],
             pytest.raises(ModuleNotFoundError),
             None,
             id="unknown model",
         ),
+        pytest.param(
+            ["plants"],
+            ["disturbance_testing"],
+            does_not_raise(),
+            ["core", "plants", "disturbance_testing"],
+            id="disturbance added",
+        ),
     ),
 )
-def test_build_configuration_model(requested, outcome, expected):
+def test_build_configuration_model(requested, disturbances, outcome, expected):
     """Tests build_configuration_model."""
     from virtual_ecosystem.core.config_builder import build_configuration_model
 
     with outcome:
-        model = build_configuration_model(requested)
+        model = build_configuration_model(requested, disturbances)
 
         assert issubclass(model, BaseModel)
         assert set(expected) == set(model.model_fields.keys())
@@ -735,6 +745,18 @@ def test_build_configuration_model(requested, outcome, expected):
                 (CRITICAL, "Configuration validation failed. See errors above."),
             ),
             id="core_plants_bad_type",
+        ),
+        pytest.param(
+            {
+                "core": {"grid": {"cell_nx": 10}},
+                "disturbance": {
+                    "disturbance_testing": {"run_at": 42},
+                },
+            },
+            does_not_raise(),
+            (("core.grid.cell_nx", 10), ("disturbance_testing.run_at", 42)),
+            ((INFO, "Configuration validated."),),
+            id="core_disturbance",
         ),
     ),
 )
@@ -792,6 +814,16 @@ def test_generate_configuration(
                 (CRITICAL, "Configuration validation failed. See errors above."),
             ),
             id="core_plants_bad_type",
+        ),
+        pytest.param(
+            [
+                "[core]\n[core.grid]\ncell_nx =  10\n",
+                "[disturbance.disturbance_testing]\nrun_at = 42",
+            ],
+            does_not_raise(),
+            (("core.grid.cell_nx", 10), ("disturbance_testing.run_at", 42)),
+            ((INFO, "Configuration validated."),),
+            id="core_disturbance",
         ),
     ),
 )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -243,11 +243,99 @@ def test_sort_disturbances(mocker):
     }
     expected_order = ["more_important", "important", "normal"]
 
-    class MockConfig:
+    class MockConfig(CompiledConfiguration):
         _model_classes = models
 
-        def get_subconfiguration(self, model_name, _) -> DisturbanceConfigurationRoot:
+        def get_subconfiguration(self, model_name, _):
             return self._model_classes[model_name]
+
+        @property
+        def disturbance(self):
+            return self
 
     actual_order = sort_disturbances(cast(CompiledConfiguration, MockConfig()))
     assert expected_order == actual_order
+
+
+DISTURBANCE_INITIALISATION_LOG = [
+    (INFO, "Initialising disturbances: disturbance_testing"),
+    (INFO, "Initialising disturbance_testing disturbance"),
+    (
+        INFO,
+        "Disturbance testing model instance generated from configuration.",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "cfg_strings,output,raises,expected_log_entries",
+    [
+        pytest.param(
+            "[core.timing]\nupdate_interval = '7 days'\n"
+            "[testing]\n"
+            "[disturbance.disturbance_testing]\n",
+            "DisturbanceTestingModel(_run_at=[0])",
+            does_not_raise(),
+            tuple(
+                [
+                    *DISTURBANCE_INITIALISATION_LOG,
+                ],
+            ),
+            id="valid config",
+        ),
+        pytest.param(
+            "[core.timing]\nupdate_interval = '7 days'\n"
+            "[disturbance.disturbance_testing]\n",
+            None,
+            pytest.raises(InitialisationError),
+            tuple(
+                [
+                    *DISTURBANCE_INITIALISATION_LOG[:-1],
+                    (
+                        CRITICAL,
+                        "Configuration failed for disturbances: disturbance_testing",
+                    ),
+                ],
+            ),
+            id="model required for disturbance missing",
+        ),
+    ],
+)
+def test_initialise_disturbances(
+    caplog,
+    dummy_litter_data,
+    cfg_strings,
+    output,
+    raises,
+    expected_log_entries,
+):
+    """Test the function that initialises the models."""
+
+    from virtual_ecosystem.core.config_builder import (
+        ConfigurationLoader,
+        generate_configuration,
+    )
+    from virtual_ecosystem.core.core_components import CoreComponents
+    from virtual_ecosystem.main import initialise_disturbances
+
+    # Generate a configuration to use, using simple inputs to populate most from
+    # defaults. Then clear the caplog to isolate the logging for the function,
+    config_data = ConfigurationLoader(cfg_strings=cfg_strings)
+    configuration = generate_configuration(config_data.data)
+    core_components = CoreComponents(configuration.core)
+    caplog.clear()
+
+    with raises:
+        models = initialise_disturbances(
+            configuration=configuration,
+            data=dummy_litter_data,
+            core_components=core_components,
+            models=configuration._model_classes,
+        )
+
+        if output is None:
+            assert models == [None]
+        else:
+            assert repr(models["disturbance_testing"]) == output
+
+    log_check(caplog, expected_log_entries)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,6 +6,7 @@ defined in main.py that it calls.
 
 from contextlib import nullcontext as does_not_raise
 from logging import CRITICAL, DEBUG, ERROR, INFO
+from typing import cast
 
 import pytest
 
@@ -225,3 +226,28 @@ variable = []
     assert len(err.splitlines()) == 0
     output = [v for v in out.splitlines() if v]  # drop blank lines
     assert len(output) == output_length
+
+
+def test_sort_disturbances(mocker):
+    """Test the sort_disturbances function."""
+    from virtual_ecosystem.core.configuration import (
+        CompiledConfiguration,
+        DisturbanceConfigurationRoot,
+    )
+    from virtual_ecosystem.main import sort_disturbances
+
+    models = {
+        "normal": DisturbanceConfigurationRoot(run_at=0, priority=0),
+        "more_important": DisturbanceConfigurationRoot(run_at=0, priority=2),
+        "important": DisturbanceConfigurationRoot(run_at=0, priority=1),
+    }
+    expected_order = ["more_important", "important", "normal"]
+
+    class MockConfig:
+        _model_classes = models
+
+        def get_subconfiguration(self, model_name, _) -> DisturbanceConfigurationRoot:
+            return self._model_classes[model_name]
+
+    actual_order = sort_disturbances(cast(CompiledConfiguration, MockConfig()))
+    assert expected_order == actual_order

--- a/virtual_ecosystem/core/base_model.py
+++ b/virtual_ecosystem/core/base_model.py
@@ -887,6 +887,8 @@ class BaseDisturbance(ABC):
         """A Data instance providing access to the shared simulation data."""
         self.timing = disturbance_timing
         """The DisturbanceTiming details used in the model."""
+        self._repr: list[tuple[str, ...]] = [("timing", "_run_at")]
+        """A list of attributes to be included in the class __repr__ output"""
 
         missing = set(self.disturbed_models).difference(models.keys())
         if missing:
@@ -1003,6 +1005,26 @@ class BaseDisturbance(ABC):
         Args:
             time_index: The index of the current timestep.
         """
+
+    def __repr__(self) -> str:
+        """Represent a Disturbance as a string from the attributes listed in _repr.
+
+        Each entry in self._repr is a tuple of strings providing a path through the
+        model hierarchy. The method assembles the tips of each path into a repr string.
+        """
+
+        repr_elements: list[str] = []
+
+        for repr_entry in self._repr:
+            obj = self
+            for attr in repr_entry:
+                obj = getattr(obj, attr)
+            repr_elements.append(f"{attr}={obj}")
+
+        # Add all args to the function signature
+        repr_string = ", ".join(repr_elements)
+
+        return f"{self.__class__.__name__}({repr_string})"
 
 
 def discover_disturbances() -> list[type[BaseDisturbance]]:

--- a/virtual_ecosystem/core/config_builder.py
+++ b/virtual_ecosystem/core/config_builder.py
@@ -34,7 +34,12 @@ from pydantic import ValidationError, create_model
 from virtual_ecosystem.core.configuration import CompiledConfiguration
 from virtual_ecosystem.core.exceptions import ConfigurationError
 from virtual_ecosystem.core.logger import LOGGER
-from virtual_ecosystem.core.registry import MODULE_REGISTRY, register_module
+from virtual_ecosystem.core.registry import (
+    DISTURBANCE_REGISTRY,
+    MODULE_REGISTRY,
+    register_disturbance,
+    register_module,
+)
 
 
 def merge_configuration_dicts(
@@ -494,7 +499,7 @@ class ConfigurationLoader:
 
 
 def build_configuration_model(
-    requested_modules: list[str],
+    requested_modules: list[str], requested_disturbances: list[str] | None = None
 ) -> type[CompiledConfiguration]:
     """Build a configuration model for a simulation.
 
@@ -516,6 +521,9 @@ def build_configuration_model(
     if "core" not in requested_modules:
         requested_modules = ["core", *requested_modules]
 
+    # If there are no disturbances, it should be an empty list
+    requested_disturbances = requested_disturbances or []
+
     # Register the requested modules, which handles unknown module names. This step is
     # required to populate the module registry with the details of the requested modules
     for module in requested_modules:
@@ -526,9 +534,22 @@ def build_configuration_model(
         )
         register_module(module)
 
+    # Register requested disturbances in the same way
+    for disturbance in requested_disturbances:
+        disturbance = f"virtual_ecosystem.disturbances.{disturbance}"
+        register_disturbance(disturbance)
+
     # Create a list of submodels in the configuration.
-    submodels = (
+    submodels = [
         (module, MODULE_REGISTRY[module].config) for module in requested_modules
+    ]
+
+    # Extend with the disturbances
+    submodels.extend(
+        [
+            (disturbance, DISTURBANCE_REGISTRY[disturbance].config)
+            for disturbance in requested_disturbances
+        ]
     )
 
     # Use pydantic create_model to dynamically generate a model with a field for each
@@ -545,6 +566,11 @@ def build_configuration_model(
     # BaseModel science models by requested model name.
     combined_model._model_classes = {
         m: MODULE_REGISTRY[m].model for m in requested_modules if m != "core"
+    }
+
+    # And do the same with the disturbances
+    combined_model._disturbance_classes = {
+        m: DISTURBANCE_REGISTRY[m].model for m in requested_disturbances
     }
 
     return combined_model
@@ -568,17 +594,28 @@ def generate_configuration(data: dict[str, Any] = {}) -> CompiledConfiguration:
     Args:
         data: A dictionary of unvalidated configuration data.
     """
+    # Extract the disturbances, if any
+    disturbances = data.pop("disturbance", {})
 
     # Build the configuration model from the compiled configuration
     try:
         ConfigurationModel = build_configuration_model(
-            requested_modules=list(data.keys())
+            requested_modules=list(data.keys()),
+            requested_disturbances=list(disturbances.keys()),
         )
     except (ModuleNotFoundError, RuntimeError) as err:
         LOGGER.critical(str(err))
         raise
 
     LOGGER.info("Configuration model built.")
+
+    # Flatten the configuration to have it at the same level as other models
+    # First we check that there are common names
+    duplicates = set(data.keys()).intersection(disturbances.keys())
+    if duplicates:
+        LOGGER.error(f"Names for disturbances also found in models: {duplicates}")
+        raise ConfigurationError("Validation errors in configuration data - check log.")
+    data.update(disturbances)
 
     try:
         configuration = ConfigurationModel().model_validate(data)

--- a/virtual_ecosystem/core/config_builder.py
+++ b/virtual_ecosystem/core/config_builder.py
@@ -499,7 +499,7 @@ class ConfigurationLoader:
 
 
 def build_configuration_model(
-    requested_modules: list[str], requested_disturbances: list[str] | None = None
+    requested_modules: list[str], requested_disturbances: list[str]
 ) -> type[CompiledConfiguration]:
     """Build a configuration model for a simulation.
 
@@ -521,9 +521,6 @@ def build_configuration_model(
     if "core" not in requested_modules:
         requested_modules = ["core", *requested_modules]
 
-    # If there are no disturbances, it should be an empty list
-    requested_disturbances = requested_disturbances or []
-
     # Register the requested modules, which handles unknown module names. This step is
     # required to populate the module registry with the details of the requested modules
     for module in requested_modules:
@@ -544,18 +541,31 @@ def build_configuration_model(
         (module, MODULE_REGISTRY[module].config) for module in requested_modules
     ]
 
-    # Extend with the disturbances
-    submodels.extend(
-        [
-            (disturbance, DISTURBANCE_REGISTRY[disturbance].config)
-            for disturbance in requested_disturbances
-        ]
-    )
+    # And the same with the disturbances
+    subdisturbance_models = [
+        (disturbance, DISTURBANCE_REGISTRY[disturbance].config)
+        for disturbance in requested_disturbances
+    ]
 
     # Use pydantic create_model to dynamically generate a model with a field for each
     # requested module
     #  Mypy does not like this, but it seems to be used as intended:
     # https://docs.pydantic.dev/latest/concepts/models/#dynamic-model-creation
+    # First the disturbances, if any
+    if subdisturbance_models:
+        combined_disturbance_model = create_model(
+            "CompiledConfiguration",
+            __base__=CompiledConfiguration,
+            **{fname: (cname, cname()) for fname, cname in subdisturbance_models},
+        )  # type: ignore[call-overload]
+        # Populate the _model_classes class variable with the required dictionary of VE
+        # BaseDisturbance models by requested model name.
+        combined_disturbance_model._model_classes = {
+            m: DISTURBANCE_REGISTRY[m].model for m in requested_disturbances
+        }
+        submodels.append(("disturbance", combined_disturbance_model))
+
+    # And now, the normal models
     combined_model = create_model(
         "CompiledConfiguration",
         __base__=CompiledConfiguration,
@@ -566,11 +576,6 @@ def build_configuration_model(
     # BaseModel science models by requested model name.
     combined_model._model_classes = {
         m: MODULE_REGISTRY[m].model for m in requested_modules if m != "core"
-    }
-
-    # And do the same with the disturbances
-    combined_model._disturbance_classes = {
-        m: DISTURBANCE_REGISTRY[m].model for m in requested_disturbances
     }
 
     return combined_model
@@ -594,28 +599,21 @@ def generate_configuration(data: dict[str, Any] = {}) -> CompiledConfiguration:
     Args:
         data: A dictionary of unvalidated configuration data.
     """
-    # Extract the disturbances, if any
-    disturbances = data.pop("disturbance", {})
+    requested_modules = list(data.keys())
+    if "disturbance" in requested_modules:
+        requested_modules.remove("disturbance")
 
     # Build the configuration model from the compiled configuration
     try:
         ConfigurationModel = build_configuration_model(
-            requested_modules=list(data.keys()),
-            requested_disturbances=list(disturbances.keys()),
+            requested_modules=requested_modules,
+            requested_disturbances=list(data.get("disturbance", {}).keys()),
         )
     except (ModuleNotFoundError, RuntimeError) as err:
         LOGGER.critical(str(err))
         raise
 
     LOGGER.info("Configuration model built.")
-
-    # Flatten the configuration to have it at the same level as other models
-    # First we check that there are no common names
-    duplicates = set(data.keys()).intersection(disturbances.keys())
-    if duplicates:
-        LOGGER.error(f"Names for disturbances also found in models: {duplicates}")
-        raise ConfigurationError("Validation errors in configuration data - check log.")
-    data.update(disturbances)
 
     try:
         configuration = ConfigurationModel().model_validate(data)

--- a/virtual_ecosystem/core/config_builder.py
+++ b/virtual_ecosystem/core/config_builder.py
@@ -610,7 +610,7 @@ def generate_configuration(data: dict[str, Any] = {}) -> CompiledConfiguration:
     LOGGER.info("Configuration model built.")
 
     # Flatten the configuration to have it at the same level as other models
-    # First we check that there are common names
+    # First we check that there are no common names
     duplicates = set(data.keys()).intersection(disturbances.keys())
     if duplicates:
         LOGGER.error(f"Names for disturbances also found in models: {duplicates}")

--- a/virtual_ecosystem/core/configuration.py
+++ b/virtual_ecosystem/core/configuration.py
@@ -195,13 +195,13 @@ class DisturbanceConfigurationRoot(Configuration):
     It also validates the timing fields to ensure that at least one of them is set.
     """
 
-    run_at: int | list[int] | None = None
+    run_at: int | tuple[int, ...] = ()
     """Define time indices to run at specific times.
     
     Either a single integer or a list of integers indicating the time indices when the
     disturbance is to run.
     """
-    run_every: tuple[int, ...] | None = None
+    run_every: tuple[int, ...] = ()
     """Define a range of indices to run the disturbance.
     
     A tuple of integers indicating (start), or (start, step), or (start, step, stop),
@@ -210,11 +210,11 @@ class DisturbanceConfigurationRoot(Configuration):
     the last time index. 'start' must always be provided."""
 
     @model_validator(mode="after")
-    def timing_options_are_not_both_none(self) -> DisturbanceConfigurationRoot:
+    def timing_options_are_not_both_empty(self) -> DisturbanceConfigurationRoot:
         """Validate the timing options of the configuration."""
-        if self.run_at is None and self.run_every is None:
+        if self.run_at == () and self.run_every == ():
             raise ValueError(
-                "Timing options 'run_at' and 'run_every' cannot be both None."
+                "Timing options 'run_at' and 'run_every' cannot be both ()."
             )
         return self
 

--- a/virtual_ecosystem/core/configuration.py
+++ b/virtual_ecosystem/core/configuration.py
@@ -121,6 +121,10 @@ class CompiledConfiguration(Configuration):
     """A dictionary of the requested modules in the simulation and their
     VirtualEcosystem BaseModel classes."""
 
+    _disturbance_classes: ClassVar[dict[str, Any]]  # FIXME - VEBaseDisturbance
+    """A dictionary of the requested disturbances in the simulation and their
+    VirtualEcosystem BaseDisturbance classes."""
+
     def get_subconfiguration(self, name: str, _: Callable[..., T]) -> T:
         """Get a named subconfiguration object from a compiled configuration.
 

--- a/virtual_ecosystem/core/configuration.py
+++ b/virtual_ecosystem/core/configuration.py
@@ -121,11 +121,7 @@ class CompiledConfiguration(Configuration):
     """A dictionary of the requested modules in the simulation and their
     VirtualEcosystem BaseModel classes."""
 
-    _disturbance_classes: ClassVar[dict[str, Any]]  # FIXME - VEBaseDisturbance
-    """A dictionary of the requested disturbances in the simulation and their
-    VirtualEcosystem BaseDisturbance classes."""
-
-    def get_subconfiguration(self, name: str, _: Callable[..., T]) -> T:
+    def get_subconfiguration(self, name: str, as_class: Callable[..., T]) -> T:
         """Get a named subconfiguration object from a compiled configuration.
 
         This method can be used to extract model configurations or the core
@@ -143,14 +139,19 @@ class CompiledConfiguration(Configuration):
 
         Args:
             name: The required subconfiguration.
-            _: The class of objected returned by the method. This is not used by the
-                method itself but is used to support static typing of the return value.
+            as_class: The class of objected returned by the method. This is not used by
+            the method itself but is used to support static typing of the return value.
         """
 
         try:
             return getattr(self, name)
         except AttributeError:
-            raise AttributeError(f"Model configuration for {name} not loaded")
+            try:
+                return getattr(self, "disturbance").get_subconfiguration(name, as_class)
+            except AttributeError:
+                raise AttributeError(
+                    f"Model or disturbance configuration for {name} not loaded"
+                )
 
     def export_toml(self, path: Path):
         """TOML export method for a compiled configuration.

--- a/virtual_ecosystem/core/configuration.py
+++ b/virtual_ecosystem/core/configuration.py
@@ -146,9 +146,9 @@ class CompiledConfiguration(Configuration):
         try:
             return getattr(self, name)
         except AttributeError:
-            try:
-                return getattr(self, "disturbance").get_subconfiguration(name, as_class)
-            except AttributeError:
+            if disturbance := self.get_disturbance_config():
+                return disturbance.get_subconfiguration(name, as_class)
+            else:
                 raise AttributeError(
                     f"Model or disturbance configuration for {name} not loaded"
                 )
@@ -162,6 +162,10 @@ class CompiledConfiguration(Configuration):
 
         with open(path, "wb") as destination:
             tomli_w.dump(self.model_dump(mode="json"), destination)
+
+    def get_disturbance_config(self) -> CompiledConfiguration | None:
+        """Get the compile configuration for disturbances, if any."""
+        return getattr(self, "disturbance", None)
 
 
 class ModelConfigurationRoot(Configuration):
@@ -209,6 +213,13 @@ class DisturbanceConfigurationRoot(Configuration):
     from where a list of integers indicating the time indices when the disturbance is to
     run can be constructed. If not provided, 'step' defaults to 1 and 'stop' defaults to
     the last time index. 'start' must always be provided."""
+
+    priority: int = 0
+    """Priority for the disturbance. 
+
+    Higher priority disturbances will be executed first. In case of having the same
+    disturbances are sorted by alphabetical order.
+    """
 
     @model_validator(mode="after")
     def timing_options_are_not_both_empty(self) -> DisturbanceConfigurationRoot:

--- a/virtual_ecosystem/core/configuration.py
+++ b/virtual_ecosystem/core/configuration.py
@@ -217,8 +217,7 @@ class DisturbanceConfigurationRoot(Configuration):
     priority: int = 0
     """Priority for the disturbance. 
 
-    Higher priority disturbances will be executed first. In case of having the same
-    disturbances are sorted by alphabetical order.
+    Every disturbance model must have a different priority.
     """
 
     @model_validator(mode="after")

--- a/virtual_ecosystem/core/core_components.py
+++ b/virtual_ecosystem/core/core_components.py
@@ -7,6 +7,7 @@ these components to be cascaded down to individual model subclass instances via 
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import InitVar, dataclass, field
 
 import numpy as np
@@ -625,8 +626,8 @@ class DisturbanceTiming:
     def __init__(
         self,
         model_timing: ModelTiming,
-        run_at: int | list[int] | None = None,
-        run_every: tuple[int, ...] | None = None,
+        run_at: int | tuple[int, ...] = (),
+        run_every: tuple[int, ...] = (),
     ) -> None:
         """Constructor for the DisturbanceTiming class.
 
@@ -634,7 +635,7 @@ class DisturbanceTiming:
 
         Args:
             model_timing: The timing for the models.
-            run_at: Either a single integer or a list of integers indicating the time
+            run_at: Either a single integer or a tuple of integers indicating the time
                 indices when the disturbance is to run.
             run_every: A tuple of integers indicating (start), or (start, step), or
                 (start, step, stop), from where a list of integers indicating the time
@@ -644,10 +645,10 @@ class DisturbanceTiming:
 
         """
 
-        if run_at is not None:
-            self._run_at = sorted(run_at) if isinstance(run_at, list) else [run_at]
+        if run_at != ():
+            self._run_at = sorted(run_at) if isinstance(run_at, Iterable) else [run_at]
 
-        elif run_every is not None:
+        elif run_every != ():
             match len(run_every):
                 case 1:
                     start = run_every[0]

--- a/virtual_ecosystem/disturbances/disturbance_testing/model_config.py
+++ b/virtual_ecosystem/disturbances/disturbance_testing/model_config.py
@@ -6,4 +6,4 @@ from virtual_ecosystem.core.configuration import DisturbanceConfigurationRoot
 class DisturbanceTestingConfiguration(DisturbanceConfigurationRoot):
     """Root configuration class for the testing model."""
 
-    run_at: int | list[int] | None = 0
+    run_at: int | tuple[int, ...] = 0

--- a/virtual_ecosystem/main.py
+++ b/virtual_ecosystem/main.py
@@ -13,12 +13,15 @@ from typing import Any
 
 from tqdm import tqdm
 
-from virtual_ecosystem.core.base_model import BaseModel
+from virtual_ecosystem.core.base_model import BaseDisturbance, BaseModel
 from virtual_ecosystem.core.config_builder import (
     ConfigurationLoader,
     generate_configuration,
 )
-from virtual_ecosystem.core.configuration import CompiledConfiguration
+from virtual_ecosystem.core.configuration import (
+    CompiledConfiguration,
+    DisturbanceConfigurationRoot,
+)
 from virtual_ecosystem.core.core_components import CoreComponents
 from virtual_ecosystem.core.data import Data, merge_continuous_data_files
 from virtual_ecosystem.core.exceptions import ConfigurationError, InitialisationError
@@ -146,6 +149,85 @@ def initialise_models(
     return models_cfd
 
 
+def sort_disturbances(disturbance_config: CompiledConfiguration) -> list[str]:
+    """Sort disturbances based on priority and name.
+
+    Args:
+        disturbance_config: CompiledConfiguration object for disturbances.
+
+    Returns:
+        Tuple of disturbance model names in the order they need to be executed.
+    """
+    return sorted(
+        disturbance_config._model_classes.keys(),
+        key=lambda name: (
+            -disturbance_config.get_subconfiguration(
+                name, DisturbanceConfigurationRoot
+            ).priority,
+            name,
+        ),
+    )
+
+
+def initialise_disturbances(
+    sorted_disturbances: list[str],
+    configuration: CompiledConfiguration,
+    data: Data,
+    core_components: CoreComponents,
+    models: dict[str, BaseModel],
+) -> dict[str, BaseDisturbance]:
+    """Initialise a set of disturbances for use in a `virtual_ecosystem` simulation.
+
+    Args:
+        sorted_disturbances: list of disturbances in the right execution order.
+        configuration: A validated Virtual Ecosystem configuration object containing the
+            disturbance configuration.
+        data: A Data instance.
+        core_components: A CoreComponents instance.
+        models: A dictionary of initialised models.
+
+    Raises:
+        InitialisationError: If one or more disturbances cannot be properly configured
+
+    Returns:
+        Dictionary of initialised disturbances in the right execution order.
+    """
+
+    LOGGER.info("Initialising disturbances: {}".format(",".join(sorted_disturbances)))
+
+    # Use factory methods to configure the desired disturbances
+    failed_disturbances = []
+    models_cfd = {}
+
+    for disturbance_name in sorted_disturbances:
+        LOGGER.info(f"Initialising {disturbance_name} disturbance")
+
+        try:
+            disturbance_class: BaseDisturbance = configuration._model_classes[
+                disturbance_name
+            ]
+            this_disturbance = disturbance_class.from_config(
+                data=data,
+                configuration=configuration,
+                core_components=core_components,
+                models=models,
+            )
+            models_cfd[disturbance_name] = this_disturbance
+
+        except (InitialisationError, ConfigurationError, KeyError):
+            failed_disturbances.append(disturbance_name)
+
+    # If any models fail to configure inform the user about it
+    if failed_disturbances:
+        to_raise: Exception = InitialisationError(
+            f"Configuration failed for disturbances: {','.join(failed_disturbances)}"
+        )
+        LOGGER.critical(to_raise)
+        raise to_raise
+
+    return models_cfd
+
+
 def ve_run(
     cfg_paths: str | Path | Sequence[str | Path] = [],
     cfg_strings: str | list[str] = [],
@@ -253,6 +335,20 @@ def ve_run(
 
     LOGGER.info("All models successfully initialised.")
 
+    # Get disturbances order and initialise them
+    if disturbance_config := configuration.get_disturbance_config():
+        disturbances = initialise_disturbances(
+            sorted_disturbances=sort_disturbances(disturbance_config),
+            configuration=disturbance_config,
+            data=data,
+            core_components=core_components,
+            models=models_init,
+        )
+
+        LOGGER.info("All disturbances successfully initialised.")
+    else:
+        disturbances = {}
+
     # TODO - A model spin up might be needed here in future
 
     # Data output options
@@ -331,6 +427,9 @@ def ve_run(
                     model=model.model_name,
                     attr="vars_populated_by_first_update",
                 )
+
+        for disturbance in disturbances.values():
+            disturbance.disturb(time_index)
 
         # If there are mismatches in the variable specifications, fail.
         if not model_variables_ok:

--- a/virtual_ecosystem/main.py
+++ b/virtual_ecosystem/main.py
@@ -9,7 +9,7 @@ from collections.abc import Sequence
 from enum import IntEnum
 from itertools import chain
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from tqdm import tqdm
 
@@ -149,15 +149,19 @@ def initialise_models(
     return models_cfd
 
 
-def sort_disturbances(disturbance_config: CompiledConfiguration) -> list[str]:
+def sort_disturbances(configuration: CompiledConfiguration) -> list[str]:
     """Sort disturbances based on priority and name.
 
     Args:
-        disturbance_config: CompiledConfiguration object for disturbances.
+        configuration: CompiledConfiguration object for disturbances.
 
     Returns:
         Tuple of disturbance model names in the order they need to be executed.
     """
+    disturbance_config = configuration.get_disturbance_config()
+    if not disturbance_config:
+        return []
+
     priorities = {
         name: -disturbance_config.get_subconfiguration(
             name, DisturbanceConfigurationRoot
@@ -202,11 +206,16 @@ def initialise_disturbances(
     failed_disturbances = []
     models_cfd = {}
 
+    # We do know there are disturbances at this point, so this casting is OK.
+    disturbance_config = cast(
+        CompiledConfiguration, configuration.get_disturbance_config()
+    )
+
     for disturbance_name in sorted_disturbances:
         LOGGER.info(f"Initialising {disturbance_name} disturbance")
 
         try:
-            disturbance_class: BaseDisturbance = configuration._model_classes[
+            disturbance_class: BaseDisturbance = disturbance_config._model_classes[
                 disturbance_name
             ]
             this_disturbance = disturbance_class.from_config(

--- a/virtual_ecosystem/main.py
+++ b/virtual_ecosystem/main.py
@@ -158,15 +158,19 @@ def sort_disturbances(disturbance_config: CompiledConfiguration) -> list[str]:
     Returns:
         Tuple of disturbance model names in the order they need to be executed.
     """
-    return sorted(
-        disturbance_config._model_classes.keys(),
-        key=lambda name: (
-            -disturbance_config.get_subconfiguration(
-                name, DisturbanceConfigurationRoot
-            ).priority,
-            name,
-        ),
-    )
+    priorities = {
+        name: -disturbance_config.get_subconfiguration(
+            name, DisturbanceConfigurationRoot
+        ).priority
+        for name in disturbance_config._model_classes.keys()
+    }
+    if len(set(priorities.values())) != len(priorities):
+        to_raise: Exception = InitialisationError(
+            "Configuration failed for disturbances: 2 or more disturbance models have "
+            "the same priority"
+        )
+        LOGGER.critical(to_raise)
+    return sorted(priorities.keys(), key=lambda name: priorities[name])
 
 
 def initialise_disturbances(

--- a/virtual_ecosystem/main.py
+++ b/virtual_ecosystem/main.py
@@ -170,7 +170,6 @@ def sort_disturbances(disturbance_config: CompiledConfiguration) -> list[str]:
 
 
 def initialise_disturbances(
-    sorted_disturbances: list[str],
     configuration: CompiledConfiguration,
     data: Data,
     core_components: CoreComponents,
@@ -179,7 +178,6 @@ def initialise_disturbances(
     """Initialise a set of disturbances for use in a `virtual_ecosystem` simulation.
 
     Args:
-        sorted_disturbances: list of disturbances in the right execution order.
         configuration: A validated Virtual Ecosystem configuration object containing the
             disturbance configuration.
         data: A Data instance.
@@ -192,6 +190,7 @@ def initialise_disturbances(
     Returns:
         Dictionary of initialised disturbances in the right execution order.
     """
+    sorted_disturbances = sort_disturbances(configuration)
 
     LOGGER.info("Initialising disturbances: {}".format(",".join(sorted_disturbances)))
 
@@ -338,7 +337,6 @@ def ve_run(
     # Get disturbances order and initialise them
     if disturbance_config := configuration.get_disturbance_config():
         disturbances = initialise_disturbances(
-            sorted_disturbances=sort_disturbances(disturbance_config),
             configuration=disturbance_config,
             data=data,
             core_components=core_components,


### PR DESCRIPTION
# Description

Adds the relevant bits in the input layer to handle disturbances. Tests have been updated as appropriate.

A couple of bugs have been fixed along the way as, it would seem, `tomli_w` cannot handle `None`.

Fixes #1369

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
