### PR TITLE
Bumping version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ license = "BSD-3-Clause"
 license-files = ["LICENSE"]
 name = "virtual_ecosystem"
 readme = "README.md"
-version = "0.1.1a15"
+version = "0.1.1a16"
 
 requires-python = ">=3.12"
 


### PR DESCRIPTION
# Description

This PR is only to bump the version number for a `0.1.1a16` release, mostly to ship the faster data loading and the option to use Python 3.14.

I haven't bothered trying to update the docs notebooks.

Fixes #1456 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
