### PR TITLE
Updated readthedocs ubuntu build image from 20.04 to 24.04

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.13"
   jobs:


### PR DESCRIPTION
# Description

Change described in the title needed to be made as the `ubuntu-20.04` build image is being deprecated by Read the Docs. The [docs still seem to build fine](https://virtual-ecosystem.readthedocs.io/en/1488-update-readthedocs-build-image-to-one-that-isnt-about-to-be-dropped/) with this change.

Once this is merged I need to make sure the docs improvement feature gets updated

Fixes #1488 

