### PR TITLE
Added ignore block for sphinx to the dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,24 +14,17 @@ updates:
       day: "sunday"
       time: "03:00"
       timezone: "Europe/London"
+    # Ignore major version updates for the sphinx ecosystem packages 
+    ignore:
+      - dependency-name: "sphinx*"
+        update-types: ["version-update:semver-major"]
     groups:
       # Bundle updates in the pyproject.toml [tool.poetry.dependencies] section
       production-dependencies:
         dependency-type: "production"
       # Should bundle updates in the pyproject.toml [tool.poetry.groups.*] sections
-      # but leave the sphinx ecosystem alone
       development-dependencies:
         dependency-type: "development"
-        exclude-patterns:
-        - "sphinx*"
-      sphinx: 
-      # Separately allow it to move sphinx updates within minor versions
-        applies-to: version-updates
-        patterns:
-        - "sphinx*"
-        update-types:
-        - "minor"
-        - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
# Description

I also removed the existing handling for `sphinx` ecosystem dependancies as I think the ignore block handles them more cleanly

I couldn't figure out anyway to test this. So I guess (provided there aren't any issues you can see), we just need to merge this and wait till next Sunday to see if it resolves the issue?

Fixes #1501

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
