### PR TITLE
Replacing `loc[]` with `sel()` in the soil and litter models 

### DIFF
--- a/tests/models/litter/test_chemistry.py
+++ b/tests/models/litter/test_chemistry.py
@@ -142,7 +142,7 @@ def test_calculate_updated_pool_lignin_proportion(
 
     actual_lignin = calculate_updated_pool_lignin_proportion(
         initial_carbon=post_consumption_pools["above_structural"]
-        .loc[:, "C"]
+        .sel(element="C")
         .to_numpy(),
         input_carbon_rate=litter_inputs.above_structural,
         carbon_loss=litter_losses.above_structural_carbon,

--- a/tests/models/litter/test_inputs.py
+++ b/tests/models/litter/test_inputs.py
@@ -65,7 +65,7 @@ def test_convert_to_input_masses_to_rates_per_area(
     expected_input_rate = [0.0375, 0.0495, 0.0315, 0.0165]
 
     actual_input_rate = convert_to_input_masses_to_rates_per_area(
-        input_mass=dummy_litter_data["stem_turnover_cnp"].loc[:, "C"],
+        input_mass=dummy_litter_data["stem_turnover_cnp"].sel(element="C"),
         cell_area=fixture_litter_model.grid.cell_area,
         update_interval=2.0,
     )
@@ -160,10 +160,10 @@ def test_split_pool_into_metabolic_and_structural_litter(
     expected_split = [0.812403025, 0.640197595, 0.424077745, 0.0089426731]
 
     actual_split = split_pool_into_metabolic_and_structural_litter(
-        input_carbon=dummy_litter_data["foliage_turnover_cnp"].loc[:, "C"],
+        input_carbon=dummy_litter_data["foliage_turnover_cnp"].sel(element="C"),
         lignin_proportion=dummy_litter_data["senesced_leaf_lignin"],
-        input_nitrogen=dummy_litter_data["foliage_turnover_cnp"].loc[:, "N"],
-        input_phosphorus=dummy_litter_data["foliage_turnover_cnp"].loc[:, "P"],
+        input_nitrogen=dummy_litter_data["foliage_turnover_cnp"].sel(element="N"),
+        input_phosphorus=dummy_litter_data["foliage_turnover_cnp"].sel(element="P"),
         max_metabolic_fraction=fixture_litter_constants.max_metabolic_fraction_of_input,
         split_sensitivity_nitrogen=fixture_litter_constants.metabolic_split_nitrogen_sensitivity,
         split_sensitivity_phosphorus=fixture_litter_constants.metabolic_split_phosphorus_sensitivity,
@@ -196,10 +196,10 @@ def test_split_pool_into_metabolic_and_structural_litter_bad_data(
 
     with pytest.raises(ValueError):
         split_pool_into_metabolic_and_structural_litter(
-            input_carbon=dummy_litter_data["foliage_turnover_cnp"].loc[:, "C"],
+            input_carbon=dummy_litter_data["foliage_turnover_cnp"].sel(element="C"),
             lignin_proportion=lignin_proportions,
-            input_nitrogen=dummy_litter_data["foliage_turnover_cnp"].loc[:, "N"],
-            input_phosphorus=dummy_litter_data["foliage_turnover_cnp"].loc[:, "P"],
+            input_nitrogen=dummy_litter_data["foliage_turnover_cnp"].sel(element="N"),
+            input_phosphorus=dummy_litter_data["foliage_turnover_cnp"].sel(element="P"),
             max_metabolic_fraction=fixture_litter_constants.max_metabolic_fraction_of_input,
             split_sensitivity_nitrogen=fixture_litter_constants.metabolic_split_nitrogen_sensitivity,
             split_sensitivity_phosphorus=fixture_litter_constants.metabolic_split_phosphorus_sensitivity,
@@ -218,10 +218,12 @@ def test_merge_input_lignin_proportions(dummy_litter_data):
     expected_proportions = [0.05008879, 0.10125, 0.29641509, 0.53971154]
 
     actual_proportions = merge_input_lignin_proportions(
-        turnover_mass=dummy_litter_data["foliage_turnover_cnp"].loc[:, "C"],
-        herbivory_waste_mass=dummy_litter_data["herbivory_waste_leaf_cnp"].loc[:, "C"],
-        total_mass=dummy_litter_data["foliage_turnover_cnp"].loc[:, "C"]
-        + dummy_litter_data["herbivory_waste_leaf_cnp"].loc[:, "C"],
+        turnover_mass=dummy_litter_data["foliage_turnover_cnp"].sel(element="C"),
+        herbivory_waste_mass=dummy_litter_data["herbivory_waste_leaf_cnp"].sel(
+            element="C"
+        ),
+        total_mass=dummy_litter_data["foliage_turnover_cnp"].sel(element="C")
+        + dummy_litter_data["herbivory_waste_leaf_cnp"].sel(element="C"),
         turnover_lignin_proportion=dummy_litter_data["senesced_leaf_lignin"],
         herbivory_waste_lignin_proportion=dummy_litter_data[
             "herbivory_waste_leaf_lignin"
@@ -237,15 +239,17 @@ def test_average_nutrient_ratios(dummy_litter_data):
     expected_proportions = [15.00583994, 32.23584906, 39.05894298, 47.80986065]
 
     actual_proportions = average_nutrient_ratios(
-        mass_1=dummy_litter_data["foliage_turnover_cnp"].loc[:, "C"].to_numpy(),
-        mass_2=dummy_litter_data["herbivory_waste_leaf_cnp"].loc[:, "C"].to_numpy(),
+        mass_1=dummy_litter_data["foliage_turnover_cnp"].sel(element="C").to_numpy(),
+        mass_2=dummy_litter_data["herbivory_waste_leaf_cnp"]
+        .sel(element="C")
+        .to_numpy(),
         nutrient_ratio_1=(
-            dummy_litter_data["foliage_turnover_cnp"].loc[:, "C"]
-            / dummy_litter_data["foliage_turnover_cnp"].loc[:, "N"]
+            dummy_litter_data["foliage_turnover_cnp"].sel(element="C")
+            / dummy_litter_data["foliage_turnover_cnp"].sel(element="N")
         ),
         nutrient_ratio_2=(
-            dummy_litter_data["herbivory_waste_leaf_cnp"].loc[:, "C"]
-            / dummy_litter_data["herbivory_waste_leaf_cnp"].loc[:, "N"]
+            dummy_litter_data["herbivory_waste_leaf_cnp"].sel(element="C")
+            / dummy_litter_data["herbivory_waste_leaf_cnp"].sel(element="N")
         ),
     )
     assert np.allclose(actual_proportions, expected_proportions)
@@ -433,8 +437,8 @@ def test_calculate_nutrient_split_between_litter_pools(
     expected_n_struct = np.array([0.8858875316, 0.91902302, 0.009277350, 1.214462735])
 
     actual_n_meta, actual_n_struct = calculate_nutrient_split_between_litter_pools(
-        input_carbon_rate=dummy_litter_data["root_turnover_cnp"].loc[:, "C"],
-        input_nutrient_rate=dummy_litter_data["root_turnover_cnp"].loc[:, "N"],
+        input_carbon_rate=dummy_litter_data["root_turnover_cnp"].sel(element="C"),
+        input_nutrient_rate=dummy_litter_data["root_turnover_cnp"].sel(element="N"),
         metabolic_split=litter_inputs.roots_meta_split,
         struct_to_meta_nutrient_ratio=fixture_litter_constants.structural_to_metabolic_n_ratio,
     )

--- a/tests/models/litter/test_losses.py
+++ b/tests/models/litter/test_losses.py
@@ -69,7 +69,9 @@ def test_calculate_carbon_pool_loss(
     expected_loss = [0.00921022, 0.00446856, 0.00223770, 0.00214006]
 
     actual_loss = calculate_carbon_pool_loss(
-        old_pool_size=post_consumption_pools["above_metabolic"].loc[:, "C"].to_numpy(),
+        old_pool_size=post_consumption_pools["above_metabolic"]
+        .sel(element="C")
+        .to_numpy(),
         final_pool_size=updated_pools["above_metabolic"],
         input_rate=litter_inputs.above_metabolic,
         update_interval=2.0,
@@ -105,10 +107,10 @@ def test_calculate_nutrient_pool_loss(
 
     actual_nutrient_loss = calculate_nutrient_pool_loss(
         initial_pool_carbon=post_consumption_pools["above_metabolic"]
-        .loc[:, "C"]
+        .sel(element="C")
         .to_numpy(),
         initial_pool_nutrient=post_consumption_pools["above_metabolic"]
-        .loc[:, "N"]
+        .sel(element="N")
         .to_numpy(),
         carbon_loss=carbon_loss,
         input_rate_carbon=litter_inputs.above_metabolic,
@@ -147,7 +149,7 @@ def test_calculate_lignin_pool_loss(
 
     actual_lignin_loss = calculate_lignin_pool_loss(
         initial_pool_size=post_consumption_pools["above_structural"]
-        .loc[:, "C"]
+        .sel(element="C")
         .to_numpy(),
         carbon_loss=carbon_loss,
         input_rate=litter_inputs.above_structural,

--- a/tests/models/soil/conftest.py
+++ b/tests/models/soil/conftest.py
@@ -297,7 +297,7 @@ def soil_pool_data(dummy_carbon_data):
 
     pools = {
         **{
-            f"{var}_{full_name}": pool.loc[:, code]
+            f"{var}_{full_name}": pool.sel(element=code)
             for code, full_name in elements.items()
             for var, pool in dummy_carbon_data.data.items()
             if var in SoilModel.vars_updated and var.startswith("soil_cnp_")
@@ -343,7 +343,9 @@ def necromass_breakdown(dummy_carbon_data, fixture_soil_constants):
     from virtual_ecosystem.models.soil.pools import calculate_necromass_breakdown
 
     return calculate_necromass_breakdown(
-        soil_c_pool_necromass=dummy_carbon_data["soil_cnp_pool_necromass"].loc[:, "C"],
+        soil_c_pool_necromass=dummy_carbon_data["soil_cnp_pool_necromass"].sel(
+            element="C"
+        ),
         necromass_decay_rate=fixture_soil_constants.necromass_decay_rate,
     )
 
@@ -354,7 +356,7 @@ def necromass_sorption(dummy_carbon_data, fixture_soil_constants):
     from virtual_ecosystem.models.soil.pools import calculate_sorption_to_maom
 
     return calculate_sorption_to_maom(
-        soil_c_pool=dummy_carbon_data["soil_cnp_pool_necromass"].loc[:, "C"],
+        soil_c_pool=dummy_carbon_data["soil_cnp_pool_necromass"].sel(element="C"),
         sorption_rate_constant=fixture_soil_constants.necromass_sorption_rate,
     )
 
@@ -365,7 +367,7 @@ def lmwc_sorption(dummy_carbon_data, fixture_soil_constants):
     from virtual_ecosystem.models.soil.pools import calculate_sorption_to_maom
 
     return calculate_sorption_to_maom(
-        soil_c_pool=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "C"],
+        soil_c_pool=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C"),
         sorption_rate_constant=fixture_soil_constants.lmwc_sorption_rate,
     )
 
@@ -376,7 +378,7 @@ def maom_desorption(dummy_carbon_data, fixture_soil_constants):
     from virtual_ecosystem.models.soil.pools import calculate_maom_desorption
 
     return calculate_maom_desorption(
-        soil_c_pool_maom=dummy_carbon_data["soil_cnp_pool_maom"].loc[:, "C"],
+        soil_c_pool_maom=dummy_carbon_data["soil_cnp_pool_maom"].sel(element="C"),
         desorption_rate_constant=fixture_soil_constants.maom_desorption_rate,
     )
 
@@ -549,11 +551,11 @@ def max_uptake_rates(
     from virtual_ecosystem.models.soil.uptake import calculate_maximum_uptake_rates
 
     return calculate_maximum_uptake_rates(
-        soil_c_pool_lmwc=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "C"],
-        soil_n_pool_don=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "N"],
+        soil_c_pool_lmwc=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C"),
+        soil_n_pool_don=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="N"),
         soil_n_pool_ammonium=dummy_carbon_data["soil_n_pool_ammonium"],
         soil_n_pool_nitrate=dummy_carbon_data["soil_n_pool_nitrate"],
-        soil_p_pool_dop=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "P"],
+        soil_p_pool_dop=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="P"),
         soil_p_pool_labile=dummy_carbon_data["soil_p_pool_labile"],
         microbial_pool_size=dummy_carbon_data["soil_c_pool_bacteria"],
         water_factor=environmental_factors.water,

--- a/tests/models/soil/test_env_factors.py
+++ b/tests/models/soil/test_env_factors.py
@@ -401,7 +401,7 @@ def test_calculate_solute_removal_by_soil_water(
     exit_flow_per_day = np.array([0.1, 0.5, 2.5, 15.9])
 
     actual_rate = calculate_solute_removal_by_soil_water(
-        solute_density=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "C"],
+        solute_density=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C"),
         exit_rate=exit_flow_per_day,
         soil_moisture=dummy_carbon_data["soil_moisture"][
             fixture_core_components.layer_structure.index_topsoil_scalar

--- a/tests/models/soil/test_pools.py
+++ b/tests/models/soil/test_pools.py
@@ -36,7 +36,7 @@ def test_calculate_all_pool_updates(
         (
             np.concatenate(
                 [
-                    dummy_carbon_data[name].loc[:, element].to_numpy()
+                    dummy_carbon_data[name].sel(element=element).to_numpy()
                     for element in elements.keys()
                     for name in SoilModel.vars_updated
                     if name.startswith("soil_cnp_")
@@ -270,7 +270,7 @@ def test_to_per_volume(
         (
             np.concatenate(
                 [
-                    dummy_carbon_data[name].loc[:, element].to_numpy()
+                    dummy_carbon_data[name].sel(element=element).to_numpy()
                     for element in elements.keys()
                     for name in SoilModel.vars_updated
                     if name.startswith("soil_cnp_")
@@ -512,9 +512,9 @@ def test_calculate_nutrient_removal_by_water(
     }
 
     actual_removal = calculate_nutrient_removal_by_water(
-        soil_c_pool_lmwc=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "C"],
-        soil_n_pool_don=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "N"],
-        soil_p_pool_dop=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "P"],
+        soil_c_pool_lmwc=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C"),
+        soil_n_pool_don=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="N"),
+        soil_p_pool_dop=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="P"),
         soil_n_pool_ammonium=dummy_carbon_data["soil_n_pool_ammonium"],
         soil_n_pool_nitrate=dummy_carbon_data["soil_n_pool_nitrate"],
         soil_p_pool_labile=dummy_carbon_data["soil_p_pool_labile"],
@@ -551,9 +551,9 @@ def test_negative_nutrient_removal_by_water(
     expected_labile_P = [2.274653e-11, 4.130485e-10, 6.749199e-9, 0.0]
 
     actual_removal = calculate_nutrient_removal_by_water(
-        soil_c_pool_lmwc=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "C"],
-        soil_n_pool_don=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "C"],
-        soil_p_pool_dop=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "C"],
+        soil_c_pool_lmwc=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C"),
+        soil_n_pool_don=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C"),
+        soil_p_pool_dop=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C"),
         soil_n_pool_ammonium=ammonium_data,
         soil_n_pool_nitrate=nitrate_data,
         soil_p_pool_labile=labile_p_data,
@@ -764,7 +764,7 @@ def test_calculate_enzyme_mediated_decomposition(
     expected_decomp = [3.39844565e-4, 8.91990315e-3, 1.66740158e-2, 4.14247999e-5]
 
     actual_decomp = calculate_enzyme_mediated_decomposition(
-        soil_c_pool=dummy_carbon_data["soil_cnp_pool_pom"].loc[:, "C"],
+        soil_c_pool=dummy_carbon_data["soil_cnp_pool_pom"].sel(element="C"),
         soil_enzyme=dummy_carbon_data["soil_enzyme_pom_bacteria"],
         soil_temp=dummy_carbon_data["soil_temperature"][
             fixture_core_components.layer_structure.index_topsoil_scalar
@@ -784,7 +784,7 @@ def test_calculate_maom_desorption(dummy_carbon_data, fixture_soil_constants):
     expected_desorption = [2.5e-5, 1.7e-5, 4.5e-5, 5.0e-6]
 
     actual_desorption = calculate_maom_desorption(
-        soil_c_pool_maom=dummy_carbon_data["soil_cnp_pool_maom"].loc[:, "C"],
+        soil_c_pool_maom=dummy_carbon_data["soil_cnp_pool_maom"].sel(element="C"),
         desorption_rate_constant=fixture_soil_constants.maom_desorption_rate,
     )
 
@@ -818,7 +818,7 @@ def test_calculate_sorption_to_maom(
     from virtual_ecosystem.models.soil.pools import calculate_sorption_to_maom
 
     actual_sorption = calculate_sorption_to_maom(
-        soil_c_pool=dummy_carbon_data[pool_name].loc[:, "C"],
+        soil_c_pool=dummy_carbon_data[pool_name].sel(element="C"),
         sorption_rate_constant=getattr(fixture_soil_constants, sorption_rate_constant),
     )
 
@@ -833,7 +833,9 @@ def test_calculate_necromass_breakdown(dummy_carbon_data, fixture_soil_constants
     expected_breakdown = [0.0134008455, 0.0034657359, 0.0214875626, 0.0242601513]
 
     actual_breakdown = calculate_necromass_breakdown(
-        soil_c_pool_necromass=dummy_carbon_data["soil_cnp_pool_necromass"].loc[:, "C"],
+        soil_c_pool_necromass=dummy_carbon_data["soil_cnp_pool_necromass"].sel(
+            element="C"
+        ),
         necromass_decay_rate=fixture_soil_constants.necromass_decay_rate,
     )
 
@@ -884,7 +886,7 @@ def test_calculate_litter_mineralisation_split(
 
     actual_particulate, expected_dissolved = calculate_litter_mineralisation_split(
         mineralisation_rate=dummy_carbon_data["litter_mineralisation_rate_cnp"]
-        .loc[:, "C"]
+        .sel(element="C")
         .to_numpy(),
         litter_leaching_coefficient=fixture_soil_constants.litter_leaching_fraction_carbon,
     )
@@ -904,8 +906,8 @@ def test_calculate_soil_nutrient_mineralisation(
     expected_rate = [0.00013585646, 2.16036801e-5, 1.030577177e-4, 1.15848952e-5]
 
     actual_rate = calculate_soil_nutrient_mineralisation(
-        pool_carbon=dummy_carbon_data["soil_cnp_pool_pom"].loc[:, "C"],
-        pool_nutrient=dummy_carbon_data["soil_cnp_pool_pom"].loc[:, "N"],
+        pool_carbon=dummy_carbon_data["soil_cnp_pool_pom"].sel(element="C"),
+        pool_nutrient=dummy_carbon_data["soil_cnp_pool_pom"].sel(element="N"),
         breakdown_rate=enzyme_mediated_rates.pom_to_lmwc,
     )
 
@@ -950,9 +952,13 @@ def test_find_necromass_nutrient_outflows(
     }
 
     actual_rates = find_necromass_nutrient_outflows(
-        necromass_carbon=dummy_carbon_data["soil_cnp_pool_necromass"].loc[:, "C"],
-        necromass_nitrogen=dummy_carbon_data["soil_cnp_pool_necromass"].loc[:, "N"],
-        necromass_phosphorus=dummy_carbon_data["soil_cnp_pool_necromass"].loc[:, "P"],
+        necromass_carbon=dummy_carbon_data["soil_cnp_pool_necromass"].sel(element="C"),
+        necromass_nitrogen=dummy_carbon_data["soil_cnp_pool_necromass"].sel(
+            element="N"
+        ),
+        necromass_phosphorus=dummy_carbon_data["soil_cnp_pool_necromass"].sel(
+            element="P"
+        ),
         necromass_decay=necromass_breakdown,
         necromass_sorption=necromass_sorption,
     )
@@ -977,12 +983,12 @@ def test_calculate_net_nutrient_transfers_from_maom_to_lmwc(
     }
 
     actual_transfers = calculate_net_nutrient_transfers_from_maom_to_lmwc(
-        lmwc_carbon=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "C"],
-        lmwc_nitrogen=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "N"],
-        lmwc_phosphorus=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "P"],
-        maom_carbon=dummy_carbon_data["soil_cnp_pool_maom"].loc[:, "C"],
-        maom_nitrogen=dummy_carbon_data["soil_cnp_pool_maom"].loc[:, "N"],
-        maom_phosphorus=dummy_carbon_data["soil_cnp_pool_maom"].loc[:, "P"],
+        lmwc_carbon=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C"),
+        lmwc_nitrogen=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="N"),
+        lmwc_phosphorus=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="P"),
+        maom_carbon=dummy_carbon_data["soil_cnp_pool_maom"].sel(element="C"),
+        maom_nitrogen=dummy_carbon_data["soil_cnp_pool_maom"].sel(element="N"),
+        maom_phosphorus=dummy_carbon_data["soil_cnp_pool_maom"].sel(element="P"),
         maom_breakdown=enzyme_mediated_rates.maom_to_lmwc,
         maom_desorption=maom_desorption,
         lmwc_sorption=lmwc_sorption,

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -151,7 +151,7 @@ def test_soil_model_initialization_bounds_error(
 
     with pytest.raises(InitialisationError):
         # Put incorrect data in for lmwc
-        dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "C"] = DataArray(
+        dummy_carbon_data["soil_cnp_pool_lmwc"].loc[dict(element="C")] = DataArray(
             [0.05, 0.02, 0.1, -0.005], dims=["cell_id"]
         )
 
@@ -201,7 +201,7 @@ def test_soil_model_all_pools_positive(
     assert soil_model._all_pools_positive()
 
     # Change data to be incorrect for necromass
-    dummy_carbon_data["soil_cnp_pool_necromass"].loc[:, "C"] = DataArray(
+    dummy_carbon_data["soil_cnp_pool_necromass"].loc[dict(element="C")] = DataArray(
         [0.05, -0.02, 0.1, 0.005], dims=["cell_id"]
     )
 
@@ -1011,7 +1011,7 @@ def test_construct_full_soil_model(
         (
             np.concatenate(
                 [
-                    dummy_carbon_data[name].loc[:, element].to_numpy()
+                    dummy_carbon_data[name].sel(element=element).to_numpy()
                     for element in elements.keys()
                     for name in SoilModel.vars_updated
                     if name.startswith("soil_cnp_")
@@ -1111,11 +1111,11 @@ def test_estimate_past_mycorrhizal_supply(
     expected_p_supply = [5.6815677e-8, 2.13568584e-6, 5.67834718e-6, 2.42661124e-6]
 
     actual_n_supply, actual_p_supply = estimate_past_mycorrhizal_supply(
-        soil_c_pool_lmwc=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "C"],
-        soil_n_pool_don=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "N"],
+        soil_c_pool_lmwc=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C"),
+        soil_n_pool_don=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="N"),
         soil_n_pool_ammonium=dummy_carbon_data["soil_n_pool_ammonium"],
         soil_n_pool_nitrate=dummy_carbon_data["soil_n_pool_nitrate"],
-        soil_p_pool_dop=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "P"],
+        soil_p_pool_dop=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="P"),
         soil_p_pool_labile=dummy_carbon_data["soil_p_pool_labile"],
         microbe_pool_size=dummy_carbon_data["soil_c_pool_ectomycorrhiza"],
         soil_temp=averaged_soil_temp,

--- a/tests/models/soil/test_uptake.py
+++ b/tests/models/soil/test_uptake.py
@@ -102,11 +102,11 @@ def test_calculate_nutrient_uptake_rates(
 
     if symbiotic:
         actual_carbon_gain, actual_consumption_rates = calculate_nutrient_uptake_rates(
-            soil_c_pool_lmwc=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "C"],
-            soil_n_pool_don=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "N"],
+            soil_c_pool_lmwc=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C"),
+            soil_n_pool_don=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="N"),
             soil_n_pool_ammonium=dummy_carbon_data["soil_n_pool_ammonium"],
             soil_n_pool_nitrate=dummy_carbon_data["soil_n_pool_nitrate"],
-            soil_p_pool_dop=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "P"],
+            soil_p_pool_dop=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="P"),
             soil_p_pool_labile=dummy_carbon_data["soil_p_pool_labile"],
             microbial_pool_size=dummy_carbon_data["soil_c_pool_ectomycorrhiza"],
             external_carbon_supply=carbon_supply_from_plants.ectomycorrhiza,
@@ -118,11 +118,11 @@ def test_calculate_nutrient_uptake_rates(
         )
     else:
         actual_carbon_gain, actual_consumption_rates = calculate_nutrient_uptake_rates(
-            soil_c_pool_lmwc=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "C"],
-            soil_n_pool_don=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "N"],
+            soil_c_pool_lmwc=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C"),
+            soil_n_pool_don=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="N"),
             soil_n_pool_ammonium=dummy_carbon_data["soil_n_pool_ammonium"],
             soil_n_pool_nitrate=dummy_carbon_data["soil_n_pool_nitrate"],
-            soil_p_pool_dop=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "P"],
+            soil_p_pool_dop=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="P"),
             soil_p_pool_labile=dummy_carbon_data["soil_p_pool_labile"],
             microbial_pool_size=dummy_carbon_data["soil_c_pool_bacteria"],
             external_carbon_supply=None,
@@ -162,11 +162,11 @@ def test_calculate_maximum_uptake_rates(
     }
 
     actual_max_rates = calculate_maximum_uptake_rates(
-        soil_c_pool_lmwc=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "C"],
-        soil_n_pool_don=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "N"],
+        soil_c_pool_lmwc=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C"),
+        soil_n_pool_don=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="N"),
         soil_n_pool_ammonium=dummy_carbon_data["soil_n_pool_ammonium"],
         soil_n_pool_nitrate=dummy_carbon_data["soil_n_pool_nitrate"],
-        soil_p_pool_dop=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "P"],
+        soil_p_pool_dop=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="P"),
         soil_p_pool_labile=dummy_carbon_data["soil_p_pool_labile"],
         microbial_pool_size=dummy_carbon_data["soil_c_pool_bacteria"],
         water_factor=environmental_factors.water,
@@ -329,7 +329,7 @@ def test_calculate_highest_achievable_nutrient_uptake(
     expected_uptake = [0.01024359, 0.006607655, 0.056746414, 5.198510e-5]
 
     actual_uptake = calculate_highest_achievable_nutrient_uptake(
-        labile_nutrient_pool=dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "C"],
+        labile_nutrient_pool=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C"),
         microbial_pool_size=dummy_carbon_data["soil_c_pool_bacteria"],
         water_factor=environmental_factors.water,
         pH_factor=environmental_factors.pH,
@@ -356,7 +356,7 @@ def test_negative_highest_achievable_nutrient_uptake_are_impossible(
         calculate_highest_achievable_nutrient_uptake,
     )
 
-    labile_carbon_data = dummy_carbon_data["soil_cnp_pool_lmwc"].loc[:, "C"]
+    labile_carbon_data = dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C")
     labile_carbon_data[1] = -0.0001
     labile_carbon_data[3] = -3.7e-5
 

--- a/virtual_ecosystem/models/litter/carbon.py
+++ b/virtual_ecosystem/models/litter/carbon.py
@@ -255,7 +255,7 @@ def calculate_updated_pools(
             input_rate=litter_inputs.above_metabolic,
             decay_rate=decay_rates["metabolic_above"],
             initial_pool=post_consumption_pools["above_metabolic"]
-            .loc[:, "C"]
+            .sel(element="C")
             .to_numpy(),
             update_interval=update_interval,
         ),
@@ -263,21 +263,21 @@ def calculate_updated_pools(
             input_rate=litter_inputs.above_structural,
             decay_rate=decay_rates["structural_above"],
             initial_pool=post_consumption_pools["above_structural"]
-            .loc[:, "C"]
+            .sel(element="C")
             .to_numpy(),
             update_interval=update_interval,
         ),
         "woody": calculate_final_pool_size(
             input_rate=litter_inputs.woody,
             decay_rate=decay_rates["woody"],
-            initial_pool=post_consumption_pools["woody"].loc[:, "C"].to_numpy(),
+            initial_pool=post_consumption_pools["woody"].sel(element="C").to_numpy(),
             update_interval=update_interval,
         ),
         "below_metabolic": calculate_final_pool_size(
             input_rate=litter_inputs.below_metabolic,
             decay_rate=decay_rates["metabolic_below"],
             initial_pool=post_consumption_pools["below_metabolic"]
-            .loc[:, "C"]
+            .sel(element="C")
             .to_numpy(),
             update_interval=update_interval,
         ),
@@ -285,7 +285,7 @@ def calculate_updated_pools(
             input_rate=litter_inputs.below_structural,
             decay_rate=decay_rates["structural_below"],
             initial_pool=post_consumption_pools["below_structural"]
-            .loc[:, "C"]
+            .sel(element="C")
             .to_numpy(),
             update_interval=update_interval,
         ),

--- a/virtual_ecosystem/models/litter/chemistry.py
+++ b/virtual_ecosystem/models/litter/chemistry.py
@@ -112,7 +112,9 @@ class LitterChemistry:
         """
 
         new_lignin_proportion_above_struct = calculate_updated_pool_lignin_proportion(
-            initial_carbon=original_pools["above_structural"].loc[:, "C"].to_numpy(),
+            initial_carbon=original_pools["above_structural"]
+            .sel(element="C")
+            .to_numpy(),
             input_carbon_rate=litter_inputs.above_structural,
             carbon_loss=litter_losses.above_structural_carbon,
             initial_lignin_proportion=self.data["lignin_above_structural"].to_numpy(),
@@ -121,7 +123,7 @@ class LitterChemistry:
             update_interval=update_interval,
         )
         new_lignin_proportion_woody = calculate_updated_pool_lignin_proportion(
-            initial_carbon=original_pools["woody"].loc[:, "C"].to_numpy(),
+            initial_carbon=original_pools["woody"].sel(element="C").to_numpy(),
             input_carbon_rate=litter_inputs.woody,
             carbon_loss=litter_losses.woody_carbon,
             initial_lignin_proportion=self.data["lignin_woody"].to_numpy(),
@@ -130,7 +132,9 @@ class LitterChemistry:
             update_interval=update_interval,
         )
         new_lignin_proportion_below_struct = calculate_updated_pool_lignin_proportion(
-            initial_carbon=original_pools["below_structural"].loc[:, "C"].to_numpy(),
+            initial_carbon=original_pools["below_structural"]
+            .sel(element="C")
+            .to_numpy(),
             input_carbon_rate=litter_inputs.below_structural,
             carbon_loss=litter_losses.below_structural_carbon,
             initial_lignin_proportion=self.data["lignin_below_structural"].to_numpy(),
@@ -185,7 +189,7 @@ def calculate_updated_nutrient_pools(
     ]
 
     return {
-        f"{pool}_{full_name}": original_pools[f"{pool}"].loc[:, abbrev].to_numpy()
+        f"{pool}_{full_name}": original_pools[f"{pool}"].sel(element=abbrev).to_numpy()
         + getattr(input_chemistries, f"{pool}_{full_name}") * update_interval
         - getattr(litter_losses, f"{pool}_{full_name}")
         for abbrev, full_name in elements.items()

--- a/virtual_ecosystem/models/litter/inputs.py
+++ b/virtual_ecosystem/models/litter/inputs.py
@@ -154,29 +154,31 @@ def combine_input_sources(
 
     # Calculate totals for each plant matter type
     leaf_total = convert_to_input_masses_to_rates_per_area(
-        data["foliage_turnover_cnp"].loc[:, "C"]
-        + data["herbivory_waste_leaf_cnp"].loc[:, "C"],
+        data["foliage_turnover_cnp"].sel(element="C")
+        + data["herbivory_waste_leaf_cnp"].sel(element="C"),
         cell_area=data.grid.cell_area,
         update_interval=update_interval,
     )
     root_total = convert_to_input_masses_to_rates_per_area(
-        data["root_turnover_cnp"].loc[:, "C"],
+        data["root_turnover_cnp"].sel(element="C"),
         cell_area=data.grid.cell_area,
         update_interval=update_interval,
     )
     deadwood_total = convert_to_input_masses_to_rates_per_area(
-        data["stem_turnover_cnp"].loc[:, "C"],
+        data["stem_turnover_cnp"].sel(element="C"),
         cell_area=data.grid.cell_area,
         update_interval=update_interval,
     )
 
     # Calculate lignin concentrations for each combined pool
     leaf_lignin = merge_input_lignin_proportions(
-        turnover_mass=data["foliage_turnover_cnp"].loc[:, "C"].to_numpy(),
-        herbivory_waste_mass=data["herbivory_waste_leaf_cnp"].loc[:, "C"].to_numpy(),
+        turnover_mass=data["foliage_turnover_cnp"].sel(element="C").to_numpy(),
+        herbivory_waste_mass=data["herbivory_waste_leaf_cnp"]
+        .sel(element="C")
+        .to_numpy(),
         total_mass=(
-            data["foliage_turnover_cnp"].loc[:, "C"]
-            + data["herbivory_waste_leaf_cnp"].loc[:, "C"]
+            data["foliage_turnover_cnp"].sel(element="C")
+            + data["herbivory_waste_leaf_cnp"].sel(element="C")
         ).to_numpy(),
         turnover_lignin_proportion=data["senesced_leaf_lignin"].to_numpy(),
         herbivory_waste_lignin_proportion=data[
@@ -188,36 +190,36 @@ def combine_input_sources(
 
     # Calculate leaf nitrogen concentrations for each combined pool
     leaf_nitrogen = convert_to_input_masses_to_rates_per_area(
-        data["foliage_turnover_cnp"].loc[:, "N"]
-        + data["herbivory_waste_leaf_cnp"].loc[:, "N"],
+        data["foliage_turnover_cnp"].sel(element="N")
+        + data["herbivory_waste_leaf_cnp"].sel(element="N"),
         cell_area=data.grid.cell_area,
         update_interval=update_interval,
     )
     root_nitrogen = convert_to_input_masses_to_rates_per_area(
-        data["root_turnover_cnp"].loc[:, "N"],
+        data["root_turnover_cnp"].sel(element="N"),
         cell_area=data.grid.cell_area,
         update_interval=update_interval,
     )
     deadwood_nitrogen = convert_to_input_masses_to_rates_per_area(
-        data["stem_turnover_cnp"].loc[:, "N"],
+        data["stem_turnover_cnp"].sel(element="N"),
         cell_area=data.grid.cell_area,
         update_interval=update_interval,
     )
 
     # Calculate leaf phosphorus concentrations for each combined pool
     leaf_phosphorus = convert_to_input_masses_to_rates_per_area(
-        data["foliage_turnover_cnp"].loc[:, "P"]
-        + data["herbivory_waste_leaf_cnp"].loc[:, "P"],
+        data["foliage_turnover_cnp"].sel(element="P")
+        + data["herbivory_waste_leaf_cnp"].sel(element="P"),
         cell_area=data.grid.cell_area,
         update_interval=update_interval,
     )
     root_phosphorus = convert_to_input_masses_to_rates_per_area(
-        data["root_turnover_cnp"].loc[:, "P"],
+        data["root_turnover_cnp"].sel(element="P"),
         cell_area=data.grid.cell_area,
         update_interval=update_interval,
     )
     deadwood_phosphorus = convert_to_input_masses_to_rates_per_area(
-        data["stem_turnover_cnp"].loc[:, "P"],
+        data["stem_turnover_cnp"].sel(element="P"),
         cell_area=data.grid.cell_area,
         update_interval=update_interval,
     )

--- a/virtual_ecosystem/models/litter/losses.py
+++ b/virtual_ecosystem/models/litter/losses.py
@@ -93,31 +93,31 @@ def calculate_litter_losses(
 
     # Calculate the loss of carbon from each litter pool
     above_metabolic_carbon = calculate_carbon_pool_loss(
-        old_pool_size=original_pools["above_metabolic"].loc[:, "C"].to_numpy(),
+        old_pool_size=original_pools["above_metabolic"].sel(element="C").to_numpy(),
         final_pool_size=final_pools["above_metabolic"],
         input_rate=litter_inputs.above_metabolic,
         update_interval=update_interval,
     )
     above_structural_carbon = calculate_carbon_pool_loss(
-        old_pool_size=original_pools["above_structural"].loc[:, "C"].to_numpy(),
+        old_pool_size=original_pools["above_structural"].sel(element="C").to_numpy(),
         final_pool_size=final_pools["above_structural"],
         input_rate=litter_inputs.above_structural,
         update_interval=update_interval,
     )
     woody_carbon = calculate_carbon_pool_loss(
-        old_pool_size=original_pools["woody"].loc[:, "C"].to_numpy(),
+        old_pool_size=original_pools["woody"].sel(element="C").to_numpy(),
         final_pool_size=final_pools["woody"],
         input_rate=litter_inputs.woody,
         update_interval=update_interval,
     )
     below_metabolic_carbon = calculate_carbon_pool_loss(
-        old_pool_size=original_pools["below_metabolic"].loc[:, "C"].to_numpy(),
+        old_pool_size=original_pools["below_metabolic"].sel(element="C").to_numpy(),
         final_pool_size=final_pools["below_metabolic"],
         input_rate=litter_inputs.below_metabolic,
         update_interval=update_interval,
     )
     below_structural_carbon = calculate_carbon_pool_loss(
-        old_pool_size=original_pools["below_structural"].loc[:, "C"].to_numpy(),
+        old_pool_size=original_pools["below_structural"].sel(element="C").to_numpy(),
         final_pool_size=final_pools["below_structural"],
         input_rate=litter_inputs.below_structural,
         update_interval=update_interval,
@@ -125,40 +125,56 @@ def calculate_litter_losses(
 
     # Calculate the loss of nitrogen from each litter pool
     above_metabolic_nitrogen = calculate_nutrient_pool_loss(
-        initial_pool_carbon=original_pools["above_metabolic"].loc[:, "C"].to_numpy(),
-        initial_pool_nutrient=original_pools["above_metabolic"].loc[:, "N"].to_numpy(),
+        initial_pool_carbon=original_pools["above_metabolic"]
+        .sel(element="C")
+        .to_numpy(),
+        initial_pool_nutrient=original_pools["above_metabolic"]
+        .sel(element="N")
+        .to_numpy(),
         carbon_loss=above_metabolic_carbon,
         input_rate_carbon=litter_inputs.above_metabolic,
         input_rate_nutrient=input_chemistries.above_metabolic_nitrogen,
         update_interval=update_interval,
     )
     above_structural_nitrogen = calculate_nutrient_pool_loss(
-        initial_pool_carbon=original_pools["above_structural"].loc[:, "C"].to_numpy(),
-        initial_pool_nutrient=original_pools["above_structural"].loc[:, "N"].to_numpy(),
+        initial_pool_carbon=original_pools["above_structural"]
+        .sel(element="C")
+        .to_numpy(),
+        initial_pool_nutrient=original_pools["above_structural"]
+        .sel(element="N")
+        .to_numpy(),
         carbon_loss=above_structural_carbon,
         input_rate_carbon=litter_inputs.above_structural,
         input_rate_nutrient=input_chemistries.above_structural_nitrogen,
         update_interval=update_interval,
     )
     woody_nitrogen = calculate_nutrient_pool_loss(
-        initial_pool_carbon=original_pools["woody"].loc[:, "C"].to_numpy(),
-        initial_pool_nutrient=original_pools["woody"].loc[:, "N"].to_numpy(),
+        initial_pool_carbon=original_pools["woody"].sel(element="C").to_numpy(),
+        initial_pool_nutrient=original_pools["woody"].sel(element="N").to_numpy(),
         carbon_loss=woody_carbon,
         input_rate_carbon=litter_inputs.woody,
         input_rate_nutrient=input_chemistries.woody_nitrogen,
         update_interval=update_interval,
     )
     below_metabolic_nitrogen = calculate_nutrient_pool_loss(
-        initial_pool_carbon=original_pools["below_metabolic"].loc[:, "C"].to_numpy(),
-        initial_pool_nutrient=original_pools["below_metabolic"].loc[:, "N"].to_numpy(),
+        initial_pool_carbon=original_pools["below_metabolic"]
+        .sel(element="C")
+        .to_numpy(),
+        initial_pool_nutrient=original_pools["below_metabolic"]
+        .sel(element="N")
+        .to_numpy(),
         carbon_loss=below_metabolic_carbon,
         input_rate_carbon=litter_inputs.below_metabolic,
         input_rate_nutrient=input_chemistries.below_metabolic_nitrogen,
         update_interval=update_interval,
     )
     below_structural_nitrogen = calculate_nutrient_pool_loss(
-        initial_pool_carbon=original_pools["below_structural"].loc[:, "C"].to_numpy(),
-        initial_pool_nutrient=original_pools["below_structural"].loc[:, "N"].to_numpy(),
+        initial_pool_carbon=original_pools["below_structural"]
+        .sel(element="C")
+        .to_numpy(),
+        initial_pool_nutrient=original_pools["below_structural"]
+        .sel(element="N")
+        .to_numpy(),
         carbon_loss=below_structural_carbon,
         input_rate_carbon=litter_inputs.below_structural,
         input_rate_nutrient=input_chemistries.below_structural_nitrogen,
@@ -167,40 +183,56 @@ def calculate_litter_losses(
 
     # Calculate the loss of nitrogen from each litter pool
     above_metabolic_phosphorus = calculate_nutrient_pool_loss(
-        initial_pool_carbon=original_pools["above_metabolic"].loc[:, "C"].to_numpy(),
-        initial_pool_nutrient=original_pools["above_metabolic"].loc[:, "P"].to_numpy(),
+        initial_pool_carbon=original_pools["above_metabolic"]
+        .sel(element="C")
+        .to_numpy(),
+        initial_pool_nutrient=original_pools["above_metabolic"]
+        .sel(element="P")
+        .to_numpy(),
         carbon_loss=above_metabolic_carbon,
         input_rate_carbon=litter_inputs.above_metabolic,
         input_rate_nutrient=input_chemistries.above_metabolic_phosphorus,
         update_interval=update_interval,
     )
     above_structural_phosphorus = calculate_nutrient_pool_loss(
-        initial_pool_carbon=original_pools["above_structural"].loc[:, "C"].to_numpy(),
-        initial_pool_nutrient=original_pools["above_structural"].loc[:, "P"].to_numpy(),
+        initial_pool_carbon=original_pools["above_structural"]
+        .sel(element="C")
+        .to_numpy(),
+        initial_pool_nutrient=original_pools["above_structural"]
+        .sel(element="P")
+        .to_numpy(),
         carbon_loss=above_structural_carbon,
         input_rate_carbon=litter_inputs.above_structural,
         input_rate_nutrient=input_chemistries.above_structural_phosphorus,
         update_interval=update_interval,
     )
     woody_phosphorus = calculate_nutrient_pool_loss(
-        initial_pool_carbon=original_pools["woody"].loc[:, "C"].to_numpy(),
-        initial_pool_nutrient=original_pools["woody"].loc[:, "P"].to_numpy(),
+        initial_pool_carbon=original_pools["woody"].sel(element="C").to_numpy(),
+        initial_pool_nutrient=original_pools["woody"].sel(element="P").to_numpy(),
         carbon_loss=woody_carbon,
         input_rate_carbon=litter_inputs.woody,
         input_rate_nutrient=input_chemistries.woody_phosphorus,
         update_interval=update_interval,
     )
     below_metabolic_phosphorus = calculate_nutrient_pool_loss(
-        initial_pool_carbon=original_pools["below_metabolic"].loc[:, "C"].to_numpy(),
-        initial_pool_nutrient=original_pools["below_metabolic"].loc[:, "P"].to_numpy(),
+        initial_pool_carbon=original_pools["below_metabolic"]
+        .sel(element="C")
+        .to_numpy(),
+        initial_pool_nutrient=original_pools["below_metabolic"]
+        .sel(element="P")
+        .to_numpy(),
         carbon_loss=below_metabolic_carbon,
         input_rate_carbon=litter_inputs.below_metabolic,
         input_rate_nutrient=input_chemistries.below_metabolic_phosphorus,
         update_interval=update_interval,
     )
     below_structural_phosphorus = calculate_nutrient_pool_loss(
-        initial_pool_carbon=original_pools["below_structural"].loc[:, "C"].to_numpy(),
-        initial_pool_nutrient=original_pools["below_structural"].loc[:, "P"].to_numpy(),
+        initial_pool_carbon=original_pools["below_structural"]
+        .sel(element="C")
+        .to_numpy(),
+        initial_pool_nutrient=original_pools["below_structural"]
+        .sel(element="P")
+        .to_numpy(),
         carbon_loss=below_structural_carbon,
         input_rate_carbon=litter_inputs.below_structural,
         input_rate_nutrient=input_chemistries.below_structural_phosphorus,
@@ -209,7 +241,9 @@ def calculate_litter_losses(
 
     # Calculate the loss of lignin from the three relevant litter pools
     above_structural_lignin = calculate_lignin_pool_loss(
-        initial_pool_size=original_pools["above_structural"].loc[:, "C"].to_numpy(),
+        initial_pool_size=original_pools["above_structural"]
+        .sel(element="C")
+        .to_numpy(),
         carbon_loss=above_structural_carbon,
         input_rate=litter_inputs.above_structural,
         initial_lignin_proportion=data["lignin_above_structural"].to_numpy(),
@@ -217,7 +251,7 @@ def calculate_litter_losses(
         update_interval=update_interval,
     )
     woody_lignin = calculate_lignin_pool_loss(
-        initial_pool_size=original_pools["woody"].loc[:, "C"].to_numpy(),
+        initial_pool_size=original_pools["woody"].sel(element="C").to_numpy(),
         carbon_loss=woody_carbon,
         input_rate=litter_inputs.woody,
         initial_lignin_proportion=data["lignin_woody"].to_numpy(),
@@ -225,7 +259,9 @@ def calculate_litter_losses(
         update_interval=update_interval,
     )
     below_structural_lignin = calculate_lignin_pool_loss(
-        initial_pool_size=original_pools["below_structural"].loc[:, "C"].to_numpy(),
+        initial_pool_size=original_pools["below_structural"]
+        .sel(element="C")
+        .to_numpy(),
         carbon_loss=below_structural_carbon,
         input_rate=litter_inputs.below_structural,
         initial_lignin_proportion=data["lignin_below_structural"].to_numpy(),

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -672,10 +672,10 @@ class SoilPools:
             + necromass_decay_to_lmwc
             + fungal_fruiting_body_decay["carbon"]
             + self.to_per_volume(
-                self.data["decomposed_excrement_cnp"].loc[:, "C"].to_numpy()
+                self.data["decomposed_excrement_cnp"].sel(element="C").to_numpy()
             )
             + self.to_per_volume(
-                self.data["decomposed_carcasses_cnp"].loc[:, "C"].to_numpy()
+                self.data["decomposed_carcasses_cnp"].sel(element="C").to_numpy()
             )
             - microbial_changes.lmwc_uptake
             - lmwc_sorption_to_maom
@@ -707,7 +707,7 @@ class SoilPools:
         delta_pools_ordered["soil_cnp_pool_pom_carbon"] = (
             litter_mineralisation_flux.pom
             - enzyme_mediated.pom_to_lmwc
-            - self.data["animal_pom_consumption_cnp"].loc[:, "C"].to_numpy()
+            - self.data["animal_pom_consumption_cnp"].sel(element="C").to_numpy()
         )
         delta_pools_ordered["soil_cnp_pool_necromass_carbon"] = (
             microbial_changes.necromass_generation
@@ -748,10 +748,10 @@ class SoilPools:
             + nutrient_transfers_maom_to_lmwc["nitrogen"]
             + fungal_fruiting_body_decay["nitrogen"]
             + self.to_per_volume(
-                self.data["decomposed_excrement_cnp"].loc[:, "N"].to_numpy()
+                self.data["decomposed_excrement_cnp"].sel(element="N").to_numpy()
             )
             + self.to_per_volume(
-                self.data["decomposed_carcasses_cnp"].loc[:, "N"].to_numpy()
+                self.data["decomposed_carcasses_cnp"].sel(element="N").to_numpy()
             )
             - microbial_changes.don_uptake
             - nutrient_removal_by_water.don
@@ -759,7 +759,7 @@ class SoilPools:
         delta_pools_ordered["soil_cnp_pool_pom_nitrogen"] = (
             litter_mineralisation_flux.particulate_n
             - pom_n_mineralisation
-            - self.data["animal_pom_consumption_cnp"].loc[:, "N"].to_numpy()
+            - self.data["animal_pom_consumption_cnp"].sel(element="N").to_numpy()
         )
         delta_pools_ordered["soil_cnp_pool_necromass_nitrogen"] = (
             microbial_changes.necromass_n_flow
@@ -797,10 +797,10 @@ class SoilPools:
             + nutrient_transfers_maom_to_lmwc["phosphorus"]
             + fungal_fruiting_body_decay["phosphorus"]
             + self.to_per_volume(
-                self.data["decomposed_excrement_cnp"].loc[:, "P"].to_numpy()
+                self.data["decomposed_excrement_cnp"].sel(element="P").to_numpy()
             )
             + self.to_per_volume(
-                self.data["decomposed_carcasses_cnp"].loc[:, "P"].to_numpy()
+                self.data["decomposed_carcasses_cnp"].sel(element="P").to_numpy()
             )
             - microbial_changes.dop_uptake
             - nutrient_removal_by_water.dop
@@ -808,7 +808,7 @@ class SoilPools:
         delta_pools_ordered["soil_cnp_pool_pom_phosphorus"] = (
             litter_mineralisation_flux.particulate_p
             - pom_p_mineralisation
-            - self.data["animal_pom_consumption_cnp"].loc[:, "P"].to_numpy()
+            - self.data["animal_pom_consumption_cnp"].sel(element="P").to_numpy()
         )
         delta_pools_ordered["soil_cnp_pool_necromass_phosphorus"] = (
             microbial_changes.necromass_p_flow
@@ -1588,11 +1588,11 @@ def calculate_litter_mineralisation_fluxes(
     """
 
     flux_C_particulate, flux_C_dissolved = calculate_litter_mineralisation_split(
-        mineralisation_rate=litter_mineralisation_rates.loc[:, "C"].to_numpy(),
+        mineralisation_rate=litter_mineralisation_rates.sel(element="C").to_numpy(),
         litter_leaching_coefficient=constants.litter_leaching_fraction_carbon,
     )
     flux_N_particulate, flux_N_dissolved = calculate_litter_mineralisation_split(
-        mineralisation_rate=litter_mineralisation_rates.loc[:, "N"].to_numpy(),
+        mineralisation_rate=litter_mineralisation_rates.sel(element="N").to_numpy(),
         litter_leaching_coefficient=constants.litter_leaching_fraction_nitrogen,
     )
     flux_N_organic_dissolved = (
@@ -1602,7 +1602,7 @@ def calculate_litter_mineralisation_fluxes(
         1 - constants.organic_proportion_litter_nitrogen_leaching
     )
     flux_P_particulate, flux_P_dissolved = calculate_litter_mineralisation_split(
-        mineralisation_rate=litter_mineralisation_rates.loc[:, "P"].to_numpy(),
+        mineralisation_rate=litter_mineralisation_rates.sel(element="P").to_numpy(),
         litter_leaching_coefficient=constants.litter_leaching_fraction_phosphorus,
     )
     flux_P_organic_dissolved = (

--- a/virtual_ecosystem/models/soil/soil_model.py
+++ b/virtual_ecosystem/models/soil/soil_model.py
@@ -451,7 +451,7 @@ class SoilModel(
             (
                 np.concatenate(
                     [
-                        self.data[name].loc[:, element].to_numpy()
+                        self.data[name].sel(element=element).to_numpy()
                         for element in elements.keys()
                         for name in updated_biomass_triplets
                     ]
@@ -733,11 +733,13 @@ class SoilModel(
         )
 
         initial_ecto_n, initial_ecto_p = estimate_past_mycorrhizal_supply(
-            soil_c_pool_lmwc=self.data["soil_cnp_pool_lmwc"].loc[:, "C"].to_numpy(),
-            soil_n_pool_don=self.data["soil_cnp_pool_lmwc"].loc[:, "N"].to_numpy(),
+            soil_c_pool_lmwc=self.data["soil_cnp_pool_lmwc"]
+            .sel(element="C")
+            .to_numpy(),
+            soil_n_pool_don=self.data["soil_cnp_pool_lmwc"].sel(element="N").to_numpy(),
             soil_n_pool_ammonium=self.data["soil_n_pool_ammonium"].to_numpy(),
             soil_n_pool_nitrate=self.data["soil_n_pool_nitrate"].to_numpy(),
-            soil_p_pool_dop=self.data["soil_cnp_pool_lmwc"].loc[:, "P"].to_numpy(),
+            soil_p_pool_dop=self.data["soil_cnp_pool_lmwc"].sel(element="P").to_numpy(),
             soil_p_pool_labile=self.data["soil_p_pool_labile"].to_numpy(),
             microbe_pool_size=self.data["soil_c_pool_ectomycorrhiza"].to_numpy(),
             soil_temp=averaged_soil_temperature,
@@ -745,11 +747,13 @@ class SoilModel(
             env_factors=env_factors,
         )
         initial_arbuscular_n, initial_arbuscular_p = estimate_past_mycorrhizal_supply(
-            soil_c_pool_lmwc=self.data["soil_cnp_pool_lmwc"].loc[:, "C"].to_numpy(),
-            soil_n_pool_don=self.data["soil_cnp_pool_lmwc"].loc[:, "N"].to_numpy(),
+            soil_c_pool_lmwc=self.data["soil_cnp_pool_lmwc"]
+            .sel(element="C")
+            .to_numpy(),
+            soil_n_pool_don=self.data["soil_cnp_pool_lmwc"].sel(element="N").to_numpy(),
             soil_n_pool_ammonium=self.data["soil_n_pool_ammonium"].to_numpy(),
             soil_n_pool_nitrate=self.data["soil_n_pool_nitrate"].to_numpy(),
-            soil_p_pool_dop=self.data["soil_cnp_pool_lmwc"].loc[:, "P"].to_numpy(),
+            soil_p_pool_dop=self.data["soil_cnp_pool_lmwc"].sel(element="P").to_numpy(),
             soil_p_pool_labile=self.data["soil_p_pool_labile"].to_numpy(),
             microbe_pool_size=self.data["soil_c_pool_arbuscular_mycorrhiza"].to_numpy(),
             soil_temp=averaged_soil_temperature,


### PR DESCRIPTION
# Description

I've replaced all usages of `.loc[:, element]` notation in the litter and soil models with `.sel(element=element)` notation. I believe that this should fix the bug discussed in #1497

@hrlai I guess we only want to merge this if we have confirmed this has worked. Two options for that. I'm happy to test it on my machine if you can send over/point me to the data files that were causing the issue. Alternatively, you could pip install the most recent commit to this PR (instead of develop) and test it locally yourself. Happy to go with whatever option you prefer

Fixes #1497

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
