### PR TITLE
Stopping soil model from running with infinite inputs

### DIFF
--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -574,7 +574,7 @@ def test_integrate_with_nans(caplog, fixture_soil_model):
         (
             ERROR,
             "Soil model integration cannot proceed because the following variables "
-            "have unexpected NaN values: {'pH'}",
+            "contain invalid values (e.g. NaN or Inf): {'pH'}",
         ),
     )
 
@@ -662,7 +662,7 @@ def test_order_independance(
 
 
 @pytest.mark.parametrize(
-    argnames=["unexpected_nans", "variable_name", "input_data"],
+    argnames=["invalid_values", "variable_name", "input_data"],
     argvalues=[
         pytest.param(
             False,
@@ -676,22 +676,34 @@ def test_order_independance(
             DataArray([3.3, np.nan, 5.6, 7.9], dims=["cell_id"]),
             id="NaN",
         ),
+        pytest.param(
+            True,
+            "pH",
+            DataArray([3.3, np.inf, 5.6, 7.9], dims=["cell_id"]),
+            id="Inf",
+        ),
+        pytest.param(
+            True,
+            "pH",
+            DataArray([3.3, -np.inf, 5.6, 7.9], dims=["cell_id"]),
+            id="negative inf",
+        ),
     ],
 )
-def test_check_for_unexpected_nan_value_flat(
-    fixture_soil_model, unexpected_nans, variable_name, input_data
+def test_check_for_invalid_input_values_flat(
+    fixture_soil_model, invalid_values, variable_name, input_data
 ):
     """Test unexpected NaN checking values works for variables without layers."""
 
     fixture_soil_model.data[variable_name] = input_data
 
-    assert unexpected_nans == fixture_soil_model.check_for_unexpected_nan_values(
+    assert invalid_values == fixture_soil_model.check_for_invalid_input_values(
         var=variable_name
     )
 
 
 @pytest.mark.parametrize(
-    argnames=["unexpected_nans", "variable_name", "layer_name", "input_data"],
+    argnames=["invalid_values", "variable_name", "layer_name", "input_data"],
     argvalues=[
         pytest.param(
             False,
@@ -708,6 +720,13 @@ def test_check_for_unexpected_nan_value_flat(
             id="surface, bad",
         ),
         pytest.param(
+            True,
+            "air_temperature",
+            "index_surface",
+            np.array([3.3, np.inf, 5.6, 7.9]),
+            id="surface, inf",
+        ),
+        pytest.param(
             False,
             "soil_temperature",
             "index_all_soil",
@@ -719,14 +738,21 @@ def test_check_for_unexpected_nan_value_flat(
             "soil_temperature",
             "index_all_soil",
             np.array([[3.3, 4.3, 5.6, 7.9], [np.nan, 26.1, 24.4, 29.8]]),
-            id="soil, bad",
+            id="soil, nan",
+        ),
+        pytest.param(
+            True,
+            "soil_temperature",
+            "index_all_soil",
+            np.array([[3.3, 4.3, 5.6, 7.9], [np.inf, 26.1, 24.4, 29.8]]),
+            id="soil, inf",
         ),
     ],
 )
-def test_check_for_unexpected_nan_value_layered(
+def test_check_for_invalid_input_values_layered(
     fixture_soil_model,
     fixture_core_components,
-    unexpected_nans,
+    invalid_values,
     variable_name,
     layer_name,
     input_data,
@@ -737,7 +763,7 @@ def test_check_for_unexpected_nan_value_layered(
     fixture_soil_model.data[variable_name] = lyr_str.from_template()
     fixture_soil_model.data[variable_name][getattr(lyr_str, layer_name)] = input_data
 
-    assert unexpected_nans == fixture_soil_model.check_for_unexpected_nan_values(
+    assert invalid_values == fixture_soil_model.check_for_invalid_input_values(
         var=variable_name
     )
 

--- a/virtual_ecosystem/models/soil/soil_model.py
+++ b/virtual_ecosystem/models/soil/soil_model.py
@@ -578,7 +578,7 @@ class SoilModel(
         else:
             subset = self.data[var]
 
-        return bool( ~ np.all(np.isfinite(subset)))
+        return bool(~np.all(np.isfinite(subset)))
 
     def convert_fruiting_body_production_to_rate(
         self, total_production: DataArray

--- a/virtual_ecosystem/models/soil/soil_model.py
+++ b/virtual_ecosystem/models/soil/soil_model.py
@@ -474,18 +474,18 @@ class SoilModel(
             **{name: np.array([]) for name in self.refreshed_variables},
         }
 
-        # Check if any values used by the soil model integration have NaN values (these
-        # can stall the integration)
-        unexpected_nans = set()
+        # Check if any values used by the soil model integration have invalid values
+        # (e.g. NaN or Inf values, as these can stall the integration)
+        invalid_values = set()
 
         for var in self.vars_required_for_update:
-            if self.check_for_unexpected_nan_values(var=var):
-                unexpected_nans.add(var)
+            if self.check_for_invalid_input_values(var=var):
+                invalid_values.add(var)
 
-        if unexpected_nans:
+        if invalid_values:
             to_raise_nan = ValueError(
                 "Soil model integration cannot proceed because the following "
-                f"variables have unexpected NaN values: {unexpected_nans}"
+                f"variables contain invalid values (e.g. NaN or Inf): {invalid_values}"
             )
             LOGGER.error(to_raise_nan)
             raise to_raise_nan
@@ -555,18 +555,20 @@ class SoilModel(
 
         return new_soil_pools | triplet_pools
 
-    def check_for_unexpected_nan_values(self, var: str) -> bool:
-        """Check if there are unexpected NaN values in the data for a specific variable.
+    def check_for_invalid_input_values(self, var: str) -> bool:
+        """Check if there are any invalid values in the data for a specific variable.
 
-        The soil model needs the air_temperature variable to have non-NaN values at the
-        soil surface, and the other layer structured variables to be defined for every
-        soil layer. For these variables, this function takes the appropriate subset.
+        This function checks for NaN and infinite values.
+
+        For variables with a layer structure, only the layers relevant to the soil model
+        are checked. For the air_temperature variable this is just the soil surface
+        layer, but for the other layer-structured variable all soil layers are checked.
 
         Args:
             var: The name of the variable being checked
 
         Returns:
-            Whether the data for the variable has any unexpected NaN values.
+            Whether the data for the variable has any invalid values.
         """
 
         if var == "air_temperature":
@@ -576,7 +578,7 @@ class SoilModel(
         else:
             subset = self.data[var]
 
-        return bool(subset.isnull().any())
+        return bool((subset.isnull() | np.isinf(subset)).any())
 
     def convert_fruiting_body_production_to_rate(
         self, total_production: DataArray

--- a/virtual_ecosystem/models/soil/soil_model.py
+++ b/virtual_ecosystem/models/soil/soil_model.py
@@ -578,7 +578,7 @@ class SoilModel(
         else:
             subset = self.data[var]
 
-        return bool((subset.isnull() | np.isinf(subset)).any())
+        return bool( ~ np.all(np.isfinite(subset)))
 
     def convert_fruiting_body_production_to_rate(
         self, total_production: DataArray


### PR DESCRIPTION
# Description

This PR expands the check that runs before the soil model integration starts that checks if any input values are NaN to also catch infinities.

@kirkImperial, I've put you down as a reviewer because you raised the bug. If you would prefer that someone more familiar with the codebase reviews it let me know, and I'll track someone else down

Fixes #1522

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
