### PR TITLE
Make sure that default microbial functional groups have correct taxonomy

### DIFF
--- a/virtual_ecosystem/models/soil/model_config.py
+++ b/virtual_ecosystem/models/soil/model_config.py
@@ -452,10 +452,10 @@ class SoilConfiguration(ModelConfigurationRoot):
 
     microbial_group_definition: list[SoilMicrobialGroup] = Field(
         default=[
-            SoilMicrobialGroup(name="saprotrophic_fungi"),
-            SoilMicrobialGroup(name="ectomycorrhiza"),
-            SoilMicrobialGroup(name="arbuscular_mycorrhiza"),
-            SoilMicrobialGroup(name="bacteria"),
+            SoilMicrobialGroup(name="saprotrophic_fungi", taxonomic_group="fungi"),
+            SoilMicrobialGroup(name="ectomycorrhiza", taxonomic_group="fungi"),
+            SoilMicrobialGroup(name="arbuscular_mycorrhiza", taxonomic_group="fungi"),
+            SoilMicrobialGroup(name="bacteria", taxonomic_group="bacteria"),
         ]
     )
     """Definition of microbial groups for soil model."""


### PR DESCRIPTION
# Description

The broader issue that these default values don't mean very much still stands, but with this change we are no longer claimer that mycorrhizal fungi are bacteria.

Fixes #1536

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
