### PR TITLE
1548 vpd should not be zero to prevent division by zero

### DIFF
--- a/docs/source/virtual_ecosystem/implementation/abiotic_implementation.md
+++ b/docs/source/virtual_ecosystem/implementation/abiotic_implementation.md
@@ -471,7 +471,8 @@ make sure that water does not accumulate unrealistcally in the canopy but stays 
 to the atmosphere above. To maintain physical realism, additional redistribution steps
 are taken where necessary until all layers in the canopy are within realistic bounds.
 The resulting change in specific humidity is then used to compute the new vapour pressure
-, relative humidity, and vapour pressure deficit.
+, relative humidity, and vapour pressure deficit. Access water is allocated to
+condentation which is added to the surface precipitation in the next time step.
 
 ```{note}
 Advection of water above the canopy is currently not implemented as everything is

--- a/docs/source/virtual_ecosystem/implementation/abiotic_implementation.md
+++ b/docs/source/virtual_ecosystem/implementation/abiotic_implementation.md
@@ -472,7 +472,7 @@ to the atmosphere above. To maintain physical realism, additional redistribution
 are taken where necessary until all layers in the canopy are within realistic bounds.
 The resulting change in specific humidity is then used to compute the new vapour pressure
 , relative humidity, and vapour pressure deficit. Access water is allocated to
-condentation which is added to the surface precipitation in the next time step.
+condensation which is added to the surface precipitation in the next time step.
 
 ```{note}
 Advection of water above the canopy is currently not implemented as everything is

--- a/docs/source/virtual_ecosystem/implementation/hydrology_implementation.md
+++ b/docs/source/virtual_ecosystem/implementation/hydrology_implementation.md
@@ -253,7 +253,8 @@ daily timestep of the model, this means that we don't account for this step expl
 ### Water at the surface
 
 Precipitation that reaches the surface is defined as incoming precipitation minus canopy
-evaporation (plus leaf drainage if modelled explicitly). The water at the
+evaporation (plus leaf drainage if modelled explicitly) plus condensation (calculated in
+abiotic model). The water at the
 surface can follow different trajectories: runoff at the surface,
 remain at the surface as searchable resource for animals, return to the atmosphere via
 evaporation, or infiltrate into the soil where it can be taken up by plants or percolate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -804,6 +804,10 @@ def dummy_climate_data(fixture_core_components):
     data["stomatal_conductance"][lyr_str.index_filled_canopy] = 12.0
     data["stomatal_conductance"][lyr_str.index_surface_scalar] = 12.0
 
+    data["condensation"] = from_template()
+    data["condensation"][lyr_str.index_filled_canopy] = 1.0
+    data["condensation"][lyr_str.index_surface_scalar] = 1.0
+
     # Hydrology
     data["transpiration"] = from_template()
     data["transpiration"][lyr_str.index_filled_canopy] = 80.0
@@ -932,6 +936,11 @@ def dummy_climate_data_varying_canopy(fixture_core_components, dummy_climate_dat
         [15.0, 15.0, 15.0, np.nan],
         [15.0, 15.0, np.nan, np.nan],
         [15.0, np.nan, np.nan, np.nan],
+    ]
+    dummy_climate_data["condensation"][index_filled_canopy] = [
+        [1.0, 1.0, 1.0, np.nan],
+        [1.0, 1.0, np.nan, np.nan],
+        [1.0, np.nan, np.nan, np.nan],
     ]
 
     # Hydrology

--- a/tests/models/abiotic/test_abiotic_model.py
+++ b/tests/models/abiotic/test_abiotic_model.py
@@ -27,6 +27,7 @@ REQUIRED_INIT_VAR_CHECKS = (
     (DEBUG, "abiotic model: required var 'specific_heat_air' checked"),
     (DEBUG, "abiotic model: required var 'latent_heat_vapourisation' checked"),
     (DEBUG, "abiotic model: required var 'density_air' checked"),
+    (DEBUG, "abiotic model: required var 'condensation' checked"),
 )
 
 SETUP_MANIPULATIONS = (

--- a/tests/models/abiotic/test_energy_balance.py
+++ b/tests/models/abiotic/test_energy_balance.py
@@ -409,7 +409,7 @@ def test_update_humidity_vpd(
         & (result["relative_humidity"][~mask] < 100)
     )
 
-    # RH should be between >=0
+    # Condensation should be >=0
     assert np.all(result["condensation"][~mask] >= 0)
 
 

--- a/tests/models/abiotic/test_energy_balance.py
+++ b/tests/models/abiotic/test_energy_balance.py
@@ -2,6 +2,8 @@
 
 import numpy as np
 import pytest
+from pyrealm.constants import CoreConst as PyrealmCoreConst
+from pyrealm.core.hygro import calc_vp_sat
 
 from virtual_ecosystem.models.abiotic.abiotic_tools import (
     compute_layer_thickness_for_varying_canopy,
@@ -321,20 +323,15 @@ def test_update_humidity_vpd(
     lystr = fixture_core_components.layer_structure
     canopy_index = lystr.index_filled_canopy
     atm_index = lystr.index_filled_atmosphere
+    pyr_const = PyrealmCoreConst()
 
     above_ground_layer_thickness = compute_layer_thickness_for_varying_canopy(
         heights=data["layer_heights"][atm_index].to_numpy()
     )
 
     evapotranspiration = data["transpiration"] + data["canopy_evaporation"]
-    saturated_vapour_pressure = np.array(
-        [
-            [2.5, 2.5, 2.5, 2.5],
-            [2.5, 2.5, 2.5, np.nan],
-            [2.0, 2.0, np.nan, np.nan],
-            [1.8, np.nan, np.nan, np.nan],
-            [2.0, 2.0, 2.0, 2.0],
-        ]
+    saturated_vapour_pressure = calc_vp_sat(
+        ta=data["air_temperature"][atm_index].to_numpy(), core_const=pyr_const
     )
     specific_humidity = np.array(
         [
@@ -380,8 +377,11 @@ def test_update_humidity_vpd(
         - fixture_core_constants.molecular_weight_ratio_water_to_dry_air,
         mm_to_kg=1e-3,
         cell_area=fixture_core_components.grid.cell_area,
-        limits=(0, 60),
+        limits_specific_humidity=(0, 60),
+        limits_relative_humidity=(0.001, 99.999),
         time_interval=time_interval,
+        denominator_tolerance=1e-12,
+        minimum_vapour_pressure_deficit=0.01,
     )
 
     # Basic shape checks
@@ -390,6 +390,7 @@ def test_update_humidity_vpd(
         "vapour_pressure",
         "vapour_pressure_deficit",
         "specific_humidity",
+        "condensation",
     ]:
         assert key in result
         assert isinstance(result[key], np.ndarray)
@@ -399,14 +400,17 @@ def test_update_humidity_vpd(
     assert np.all(result["specific_humidity"][~mask] >= 0.00)
 
     # VPD should be reduced where evapotranspiration or mixing adds moisture
-    assert np.all(result["vapour_pressure_deficit"][~mask] >= 0.0)
+    assert np.all(result["vapour_pressure_deficit"][~mask] > 0.0)
     assert np.all(result["vapour_pressure"][~mask] <= saturated_vapour_pressure[~mask])
 
     # RH should be between 0 and 100
     assert np.all(
-        (result["relative_humidity"][~mask] >= 0)
-        & (result["relative_humidity"][~mask] <= 100)
+        (result["relative_humidity"][~mask] > 0)
+        & (result["relative_humidity"][~mask] < 100)
     )
+
+    # RH should be between >=0
+    assert np.all(result["condensation"][~mask] >= 0)
 
 
 def test_calculate_latent_heat_flux(

--- a/tests/models/abiotic/test_energy_balance.py
+++ b/tests/models/abiotic/test_energy_balance.py
@@ -381,7 +381,7 @@ def test_update_humidity_vpd(
         limits_relative_humidity=(0.001, 99.999),
         time_interval=time_interval,
         denominator_tolerance=1e-12,
-        minimum_vapour_pressure_deficit=0.01,
+        limits_vapour_pressure_deficit=(0.01, 50),
     )
 
     # Basic shape checks

--- a/tests/models/abiotic/test_microclimate.py
+++ b/tests/models/abiotic/test_microclimate.py
@@ -636,6 +636,7 @@ def test_update_atmospheric_humidity(
     abiotic_constants = fixture_abiotic_constants
     core_constants = fixture_core_constants
     pyrealm_core_constants = PyrealmCoreConst()
+    abiotic_bounds = AbioticSimpleBounds()
 
     vp_sat = calc_vp_sat(
         ta=state["air_temperature"],
@@ -647,6 +648,7 @@ def test_update_atmospheric_humidity(
         pyrealm_core_constants=pyrealm_core_constants,
         core_constants=core_constants,
         abiotic_constants=abiotic_constants,
+        abiotic_bounds=abiotic_bounds,
         idx=idx,
         time_interval=3600,
     )

--- a/tests/models/abiotic/test_microclimate.py
+++ b/tests/models/abiotic/test_microclimate.py
@@ -660,6 +660,7 @@ def test_update_atmospheric_humidity(
         "vapour_pressure",
         "vapour_pressure_deficit",
         "specific_humidity",
+        "condensation",
     ]:
         assert key in result
         assert isinstance(result[key], np.ndarray)
@@ -669,14 +670,17 @@ def test_update_atmospheric_humidity(
     assert np.all(result["specific_humidity"][mask] >= 0.00)
 
     # VPD should be reduced where evapotranspiration or mixing adds moisture
-    assert np.all(result["vapour_pressure_deficit"][mask] >= 0.0)
+    assert np.all(result["vapour_pressure_deficit"][mask] > 0.0)
     assert np.all(result["vapour_pressure"][mask] <= vp_sat[mask])
 
     # RH should be between 0 and 100
     assert np.all(
-        (result["relative_humidity"][mask] >= 0)
-        & (result["relative_humidity"][mask] <= 100)
+        (result["relative_humidity"][mask] > 0)
+        & (result["relative_humidity"][mask] < 100)
     )
+
+    # Condensation should be >=0
+    assert np.all(result["condensation"][mask] >= 0)
 
 
 def test_run_hour_step_orchestration(
@@ -777,6 +781,7 @@ def test_run_hour_step_orchestration(
         "vapour_pressure": (14, 4),
         "vapour_pressure_deficit": (14, 4),
         "specific_humidity": (14, 4),
+        "condensation": (14, 4),
     }
 
     for key, shape in expected_static.items():
@@ -987,6 +992,7 @@ def test_run_microclimate(
         "atmospheric_co2",
         "net_radiation",
         "diurnal_temperature_range",
+        "condensation",
     )
     time_interval = 3600
     time_index = 0

--- a/tests/models/hydrology/test_hydrology_model.py
+++ b/tests/models/hydrology/test_hydrology_model.py
@@ -23,6 +23,7 @@ MODEL_VAR_CHECK_LOG = [
     (DEBUG, "hydrology model: required var 'atmospheric_pressure_ref' checked"),
     (INFO, "Adding data array for 'soil_moisture'"),
     (INFO, "Adding data array for 'matric_potential'"),
+    (INFO, "Adding data array for 'condensation'"),
     (INFO, "Adding data array for 'groundwater_storage'"),
     (INFO, "Adding data array for 'aerodynamic_resistance_soil'"),
     (INFO, "Adding data array for 'stomatal_conductance'"),

--- a/tests/models/hydrology/test_hydrology_tools.py
+++ b/tests/models/hydrology/test_hydrology_tools.py
@@ -100,6 +100,7 @@ def test_setup_hydrology_input_current_timestep(
         "top_soil_moisture_residual",
         "groundwater_storage",
         "current_soil_moisture",
+        "condensation",
     ]
 
     assert set(result.keys()) == set(var_list)

--- a/virtual_ecosystem/data_variables.toml
+++ b/virtual_ecosystem/data_variables.toml
@@ -126,6 +126,13 @@ variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
+description = "Condensation"
+name = "condensation"
+unit = "mm"
+variable_type = "float"
+
+[[variable]]
+axis = ["spatial"]
 description = "Diabatic correction factor for heat above canopy"
 name = "diabatic_correction_heat_above"
 unit = "-"

--- a/virtual_ecosystem/data_variables.toml
+++ b/virtual_ecosystem/data_variables.toml
@@ -126,7 +126,7 @@ variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
-description = "Condensation"
+description = "Condensated water from supersaturation in the atmosphere"
 name = "condensation"
 unit = "mm"
 variable_type = "float"

--- a/virtual_ecosystem/models/abiotic/abiotic_model.py
+++ b/virtual_ecosystem/models/abiotic/abiotic_model.py
@@ -112,7 +112,7 @@ class AbioticModel(
         "vapour_pressure",
         "diurnal_temperature_range",
     ),
-    vars_populated_by_first_update=(),
+    vars_populated_by_first_update=("condensation",),
 ):
     """A class describing the abiotic model.
 

--- a/virtual_ecosystem/models/abiotic/abiotic_model.py
+++ b/virtual_ecosystem/models/abiotic/abiotic_model.py
@@ -55,6 +55,7 @@ class AbioticModel(
         "specific_heat_air",
         "latent_heat_vapourisation",
         "density_air",
+        "condensation",
     ),
     vars_updated=(
         "air_temperature",

--- a/virtual_ecosystem/models/abiotic/abiotic_model.py
+++ b/virtual_ecosystem/models/abiotic/abiotic_model.py
@@ -74,6 +74,7 @@ class AbioticModel(
         "net_radiation",
         "longwave_emission",
         "diurnal_temperature_range",
+        "condensation",
     ),
     vars_required_for_update=(
         "air_temperature_ref",
@@ -92,6 +93,7 @@ class AbioticModel(
         "soil_evaporation",
         "canopy_evaporation",
         "transpiration",
+        "condensation",
     ),
     vars_populated_by_init=(
         "soil_temperature",
@@ -112,7 +114,7 @@ class AbioticModel(
         "vapour_pressure",
         "diurnal_temperature_range",
     ),
-    vars_populated_by_first_update=("condensation",),
+    vars_populated_by_first_update=(),
 ):
     """A class describing the abiotic model.
 

--- a/virtual_ecosystem/models/abiotic/energy_balance.py
+++ b/virtual_ecosystem/models/abiotic/energy_balance.py
@@ -425,9 +425,9 @@ def update_humidity_vpd(
     cell_area: float,
     limits_specific_humidity: tuple[float, float],
     limits_relative_humidity: tuple[float, float, float],
+    limits_vapour_pressure_deficit: tuple[float, float, float],
     time_interval: float,
     denominator_tolerance: float,
-    minimum_vapour_pressure_deficit: float,
 ) -> dict[str, NDArray[np.floating]]:
     """Update specific humidity and vapour pressure deficit for a multilayer canopy.
 
@@ -451,11 +451,13 @@ def update_humidity_vpd(
         mm_to_kg: Factor to convert variable unit from millimeters to kilograms of
             water per square meter
         cell_area: Grid cell area, [m2]
-        limits_specific_humidity: Realistic bounds of specific humidity
-        limits_relative_humidity: Realistic bounds of relative humidity
+        limits_specific_humidity: Realistic bounds of specific humidity, [kg kg-1]
+        limits_relative_humidity: Realistic bounds of relative humidity, []
+        limits_vapour_pressure_deficit: Realistic bounds for vapour pressure deficit,
+            [kPa]
         time_interval: Time interval, [s]
         denominator_tolerance: Small value to prevent division by zero
-        minimum_vapour_pressure_deficit: Minimum vapour pressure deficit, [kPa]
+
 
     Returns:
       A dictionary containing arrays of updated ``relative_humidity``,
@@ -551,7 +553,7 @@ def update_humidity_vpd(
 
     # Compute new VPD (Vapour Pressure Deficit) [kPa], ensure non-zero
     vpd_updated = saturated_vapour_pressure - vapour_pressure_updated
-    vpd_updated = np.maximum(vpd_updated, minimum_vapour_pressure_deficit)
+    vpd_updated = np.maximum(vpd_updated, limits_vapour_pressure_deficit[0])
 
     # Map variable names to arrays
     raw_outputs = {

--- a/virtual_ecosystem/models/abiotic/energy_balance.py
+++ b/virtual_ecosystem/models/abiotic/energy_balance.py
@@ -546,7 +546,7 @@ def update_humidity_vpd(
     ) * 100
 
     relative_humidity_updated = np.minimum(
-        relative_humidity_updated, limits_relative_humidity[0]
+        relative_humidity_updated, limits_relative_humidity[1]
     )
 
     # Compute new VPD (Vapour Pressure Deficit) [kPa], ensure non-zero

--- a/virtual_ecosystem/models/abiotic/energy_balance.py
+++ b/virtual_ecosystem/models/abiotic/energy_balance.py
@@ -525,8 +525,8 @@ def update_humidity_vpd(
         limits_specific_humidity[0],
     )
 
-    # Convert excess to condensed water mass [kg]
-    condensation_mass = excess_specific_humidity * air_mass_per_layer
+    # Convert excess to condensed water, [mm]
+    condensation_mm = excess_specific_humidity * air_mass_per_layer / mm_to_kg
 
     # Remove excess from air
     specific_humidity_updated = np.minimum(
@@ -559,7 +559,7 @@ def update_humidity_vpd(
         "vapour_pressure": vapour_pressure_updated,
         "vapour_pressure_deficit": vpd_updated,
         "specific_humidity": specific_humidity_updated,
-        "condensation": condensation_mass,
+        "condensation": condensation_mm,
     }
 
     # Clean outputs while preserving intended NaNs

--- a/virtual_ecosystem/models/abiotic/energy_balance.py
+++ b/virtual_ecosystem/models/abiotic/energy_balance.py
@@ -423,8 +423,11 @@ def update_humidity_vpd(
     dry_air_factor: float,
     mm_to_kg: float,
     cell_area: float,
-    limits: tuple[float, float],
+    limits_specific_humidity: tuple[float, float],
+    limits_relative_humidity: tuple[float, float, float],
     time_interval: float,
+    denominator_tolerance: float,
+    minimum_vapour_pressure_deficit: float,
 ) -> dict[str, NDArray[np.floating]]:
     """Update specific humidity and vapour pressure deficit for a multilayer canopy.
 
@@ -448,8 +451,11 @@ def update_humidity_vpd(
         mm_to_kg: Factor to convert variable unit from millimeters to kilograms of
             water per square meter
         cell_area: Grid cell area, [m2]
-        limits: Realistic bounds of specific humidity
+        limits_specific_humidity: Realistic bounds of specific humidity
+        limits_relative_humidity: Realistic bounds of relative humidity
         time_interval: Time interval, [s]
+        denominator_tolerance: Small value to prevent division by zero
+        minimum_vapour_pressure_deficit: Minimum vapour pressure deficit, [kPa]
 
     Returns:
       A dictionary containing arrays of updated ``relative_humidity``,
@@ -481,15 +487,16 @@ def update_humidity_vpd(
     water_mass_in_air = specific_humidity * air_mass_per_layer
     water_mass_in_air += added_mass
 
-    # Vertical mixing
+    # Convert back to specific humidity
     specific_humidity = water_mass_in_air / air_mass_per_layer
+
+    # Vertical mixing
     specific_humidity_updated = wind.mix_and_ventilate(
         input_variable=specific_humidity,
         mixing_coefficient=mixing_coefficient,
         ventilation_rate=ventilation_rate,
-        limits=limits,
+        limits=limits_specific_humidity,
     )
-
     # NOTE Advection not implemented as everything is removed with time interval > 1h
     # and horizontal transfer is not implemented
     # specific_humidity_advected = wind.advect_water_from_toplayer(
@@ -502,25 +509,49 @@ def update_humidity_vpd(
     # )
     # specific_humidity_updated[0] = specific_humidity_advected
 
+    # Saturation constraint and condensation
+    # Saturation specific humidity
+    saturation_specific_humidity = (
+        molecular_weight_ratio_water_to_dry_air
+        * dry_air_factor
+        * saturated_vapour_pressure
+    ) / np.maximum(
+        atmospheric_pressure - saturated_vapour_pressure, denominator_tolerance
+    )
+
+    # Excess humidity goes to condensation
+    excess_specific_humidity = np.maximum(
+        specific_humidity_updated - saturation_specific_humidity,
+        limits_specific_humidity[0],
+    )
+
+    # Convert excess to condensed water mass [kg]
+    condensation_mass = excess_specific_humidity * air_mass_per_layer
+
+    # Remove excess from air
+    specific_humidity_updated = np.minimum(
+        specific_humidity_updated, saturation_specific_humidity
+    )
+
     # Vapour pressure [kPa]
     vapour_pressure_updated = (specific_humidity_updated * atmospheric_pressure) / (
         molecular_weight_ratio_water_to_dry_air * dry_air_factor
         + specific_humidity_updated
     )
 
-    # Ensure vapor pressure doesn't exceed the saturated vapor pressure
-    # TODO we need to make sure that we do not loose water here
-    vapour_pressure_updated = np.minimum(
-        vapour_pressure_updated, saturated_vapour_pressure
-    )
-
     # Compute new relative humidity (%)
     relative_humidity_updated = (
-        vapour_pressure_updated / saturated_vapour_pressure
+        vapour_pressure_updated
+        / np.maximum(saturated_vapour_pressure, denominator_tolerance)
     ) * 100
 
-    # Compute new VPD (Vapor Pressure Deficit) [kPa]
+    relative_humidity_updated = np.minimum(
+        relative_humidity_updated, limits_relative_humidity[0]
+    )
+
+    # Compute new VPD (Vapour Pressure Deficit) [kPa], ensure non-zero
     vpd_updated = saturated_vapour_pressure - vapour_pressure_updated
+    vpd_updated = np.maximum(vpd_updated, minimum_vapour_pressure_deficit)
 
     # Map variable names to arrays
     raw_outputs = {
@@ -528,6 +559,7 @@ def update_humidity_vpd(
         "vapour_pressure": vapour_pressure_updated,
         "vapour_pressure_deficit": vpd_updated,
         "specific_humidity": specific_humidity_updated,
+        "condensation": condensation_mass,
     }
 
     # Clean outputs while preserving intended NaNs

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -743,11 +743,14 @@ def update_atmospheric_humidity(
         dry_air_factor=abiotic_constants.dry_air_factor,
         mm_to_kg=core_constants.mm_to_kg,
         cell_area=static["cell_area"],
-        limits_specific_humidity=(0, max_specific_humidity[0]),  # TODO layer specific?
+        limits_specific_humidity=(
+            abiotic_constants.min_specific_humidity,
+            max_specific_humidity[0],
+        ),  # TODO layer specific?
         limits_relative_humidity=abiotic_bounds.relative_humidity,
+        limits_vapour_pressure_deficit=abiotic_bounds.vapour_pressure_deficit,
         time_interval=time_interval,
         denominator_tolerance=abiotic_constants.denominator_tolerance,
-        minimum_vapour_pressure_deficit=abiotic_bounds.vapour_pressure_deficit[0],
     )
 
     output_dict = {}

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -757,6 +757,7 @@ def update_atmospheric_humidity(
         "vapour_pressure",
         "vapour_pressure_deficit",
         "specific_humidity",
+        "condensation",
     ]:
         temp = np.full_like(specific_humidity_air, np.nan)
         temp[idx.atm] = output_vars[var]

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -679,6 +679,7 @@ def update_atmospheric_humidity(
     pyrealm_core_constants: PyrealmCoreConst,
     core_constants: CoreConstants,
     abiotic_constants: AbioticConstants,
+    abiotic_bounds: AbioticSimpleBounds,
     idx: SimpleNamespace,
     time_interval: float,
 ) -> dict[str, Any]:
@@ -690,6 +691,7 @@ def update_atmospheric_humidity(
         pyrealm_core_constants: Set of constants from pyrealm core that are used
         core_constants: Set of constants that are shared across all models
         abiotic_constants: Set of constants for abiotic model
+        abiotic_bounds: Bounds for atmospheric humidity variables
         idx: SimpleNamespace with layer indices
         time_interval: Time interval for flux calculations, [s]
 
@@ -741,8 +743,11 @@ def update_atmospheric_humidity(
         dry_air_factor=abiotic_constants.dry_air_factor,
         mm_to_kg=core_constants.mm_to_kg,
         cell_area=static["cell_area"],
-        limits=(0, max_specific_humidity[0]),  # TODO make layer specific
+        limits_specific_humidity=(0, max_specific_humidity[0]),  # TODO layer specific?
+        limits_relative_humidity=abiotic_bounds.relative_humidity,
         time_interval=time_interval,
+        denominator_tolerance=abiotic_constants.denominator_tolerance,
+        minimum_vapour_pressure_deficit=abiotic_bounds.vapour_pressure_deficit[0],
     )
 
     output_dict = {}
@@ -873,6 +878,7 @@ def run_hour_step(
         pyrealm_core_constants=pyrealm_core_constants,
         abiotic_constants=abiotic_constants,
         core_constants=core_constants,
+        abiotic_bounds=abiotic_bounds,
         idx=idx,
         time_interval=time_interval,
     )

--- a/virtual_ecosystem/models/abiotic/model_config.py
+++ b/virtual_ecosystem/models/abiotic/model_config.py
@@ -182,6 +182,9 @@ class AbioticConstants(AbioticSharedConstants):
     denominator_tolerance: float = 1e-12
     """Small value to prevent division by zero."""
 
+    min_specific_humidity: float = 0.001
+    """Minimum value for specific humidity to avoid dividion by zero, [kg kg-1]."""
+
 
 class AbioticConfiguration(ModelConfigurationRoot):
     """The abiotic model configuration."""

--- a/virtual_ecosystem/models/abiotic_simple/model_config.py
+++ b/virtual_ecosystem/models/abiotic_simple/model_config.py
@@ -49,7 +49,7 @@ class AbioticSimpleBounds(Configuration):
     leaf area index from :cite:t:`hardwick_relationship_2015`.
     """
 
-    relative_humidity: tuple[float, float, float] = (0.001, 99.999 - 1e-12, 5.4)
+    relative_humidity: tuple[float, float, float] = (0.001, 99.999, 5.4)
     """Bounds and gradient for relative humidity, dimensionless.
 
     Gradient for linear regression to calculate relative humidity as a function of

--- a/virtual_ecosystem/models/abiotic_simple/model_config.py
+++ b/virtual_ecosystem/models/abiotic_simple/model_config.py
@@ -49,14 +49,14 @@ class AbioticSimpleBounds(Configuration):
     leaf area index from :cite:t:`hardwick_relationship_2015`.
     """
 
-    relative_humidity: tuple[float, float, float] = (0.0, 100.0, 5.4)
+    relative_humidity: tuple[float, float, float] = (0.001, 99.999 - 1e-12, 5.4)
     """Bounds and gradient for relative humidity, dimensionless.
 
     Gradient for linear regression to calculate relative humidity as a function of
     leaf area index from :cite:t:`hardwick_relationship_2015`.
     """
 
-    vapour_pressure_deficit: tuple[float, float, float] = (0.0, 10.0, -252.24)
+    vapour_pressure_deficit: tuple[float, float, float] = (0.001, 10.0, -252.24)
     """Bounds and gradient for vapour pressure deficit, [kPa].
     
     Gradient for linear regression to calculate vapour pressure deficit as a function of

--- a/virtual_ecosystem/models/hydrology/hydrology_model.py
+++ b/virtual_ecosystem/models/hydrology/hydrology_model.py
@@ -563,7 +563,8 @@ class HydrologyModel(
                 :, day
             ] - np.minimum(
                 np.nansum(canopy_evaporation, axis=0),
-                hydro_input["current_precipitation"][:, day],
+                hydro_input["current_precipitation"][:, day]
+                + hydro_input["condensation"],
             )
 
             hydrology_tools.check_precipitation_surface(

--- a/virtual_ecosystem/models/hydrology/hydrology_model.py
+++ b/virtual_ecosystem/models/hydrology/hydrology_model.py
@@ -468,6 +468,7 @@ class HydrologyModel(
         * stomatal conductance, [mol m-2 s-1]
         * aerodynamic resistance canopy, [s m-1]
         * net radiation, [W m-2]
+        * condensation, [mm]
 
         and a number of parameters that as described in detail in
         :class:`~virtual_ecosystem.models.hydrology.model_config.HydrologyConstants`.

--- a/virtual_ecosystem/models/hydrology/hydrology_model.py
+++ b/virtual_ecosystem/models/hydrology/hydrology_model.py
@@ -99,6 +99,7 @@ class HydrologyModel(
         "specific_heat_air",
         "stomatal_conductance",
         "net_radiation",
+        "condensation",
     ),
     vars_populated_by_init=(
         "soil_moisture",
@@ -110,6 +111,7 @@ class HydrologyModel(
         "stomatal_conductance",
         "latent_heat_vapourisation",
         "density_air",
+        "condensation",
     ),
     vars_populated_by_first_update=(
         "interception",
@@ -289,6 +291,7 @@ class HydrologyModel(
         self.data["matric_potential"][self.layer_structure.index_all_soil] = DataArray(
             matric_potential * self.model_constants.m_to_kpa, dims=["layers", "cell_id"]
         )
+        self.data["condensation"] = self.layer_structure.from_template()
 
         # Create initial groundwater storage variable with two layers, [mm]
         # TODO think about including this in config, but we don't want to carry those

--- a/virtual_ecosystem/models/hydrology/hydrology_tools.py
+++ b/virtual_ecosystem/models/hydrology/hydrology_tools.py
@@ -146,6 +146,7 @@ def setup_hydrology_input_current_timestep(
     * top_soil_moisture_saturation
     * top_soil_moisture_residual
     * groundwater_storage
+    * condensation
 
     Args:
         data: Data object that contains inputs from the microclimate model, the plant
@@ -217,6 +218,8 @@ def setup_hydrology_input_current_timestep(
     # Get ground water level
     output["groundwater_storage"] = data["groundwater_storage"].to_numpy()
 
+    # Get condensation from abiotic model
+    output["condensation"] = np.nansum(data["condensation"].to_numpy(), axis=0) / days
     return output
 
 


### PR DESCRIPTION
This PR sets limits in place to avoid zero VPD and also introduces condensation that feeds in surface precipitation to account for the access water.

Fixes #1548

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
