### PR TITLE
Better negative value handling in the soil model

### DIFF
--- a/tests/models/soil/test_env_factors.py
+++ b/tests/models/soil/test_env_factors.py
@@ -415,6 +415,31 @@ def test_calculate_solute_removal_by_soil_water(
     assert np.allclose(expected_rate, actual_rate)
 
 
+def test_calculate_solute_removal_by_soil_water_negative_concentrations(
+    dummy_carbon_data, fixture_core_components, fixture_soil_constants
+):
+    """Check solute removal rates handle negative values correctly."""
+
+    from virtual_ecosystem.models.soil.env_factors import (
+        calculate_solute_removal_by_soil_water,
+    )
+
+    lmwc_values = np.array([0.05, -0.02, -0.1, 0.005])
+    expected_rate = [1.07473723e-6, 0.0, 0.0, 5.25567712e-5]
+    exit_flow_per_day = np.array([0.1, 0.5, 2.5, 15.9])
+
+    actual_rate = calculate_solute_removal_by_soil_water(
+        solute_density=lmwc_values,
+        exit_rate=exit_flow_per_day,
+        soil_moisture=dummy_carbon_data["soil_moisture"][
+            fixture_core_components.layer_structure.index_topsoil_scalar
+        ],
+        solubility_coefficient=fixture_soil_constants.solubility_coefficient_lmwc,
+    )
+
+    assert np.allclose(expected_rate, actual_rate)
+
+
 @pytest.mark.parametrize(
     "increased_depth,expected_soil_moisture",
     [

--- a/tests/models/soil/test_env_factors.py
+++ b/tests/models/soil/test_env_factors.py
@@ -107,21 +107,24 @@ def test_calculate_water_potential_impact_on_microbes(
     assert np.allclose(actual_factor, expected_factor)
 
 
-def test_soil_water_potential_too_high(dummy_carbon_data, fixture_soil_constants):
-    """Test that too high soil water potential results in an error."""
+def test_soil_water_potential_extreme_values(fixture_soil_constants):
+    """Test that very high and low soil water potentials are handled sensibly."""
     from virtual_ecosystem.models.soil.env_factors import (
         calculate_water_potential_impact_on_microbes,
     )
 
-    water_potentials = np.array([-2.0, -10.0, -250.0, -10000.0])
+    expected_factor = [1.0, 0.94414168, 0.62176357, 0.0]
 
-    with pytest.raises(ValueError):
-        calculate_water_potential_impact_on_microbes(
-            water_potential=water_potentials,
-            water_potential_halt=fixture_soil_constants.soil_microbe_water_potential_halt,
-            water_potential_opt=fixture_soil_constants.soil_microbe_water_potential_optimum,
-            response_curvature=fixture_soil_constants.microbial_water_response_curvature,
-        )
+    water_potentials = np.array([-2.0, -10.0, -250.0, -20000.0])
+
+    actual_factor = calculate_water_potential_impact_on_microbes(
+        water_potential=water_potentials,
+        water_potential_halt=fixture_soil_constants.soil_microbe_water_potential_halt,
+        water_potential_opt=fixture_soil_constants.soil_microbe_water_potential_optimum,
+        response_curvature=fixture_soil_constants.microbial_water_response_curvature,
+    )
+
+    assert np.allclose(actual_factor, expected_factor)
 
 
 def test_calculate_pH_suitability(fixture_soil_constants):

--- a/tests/models/soil/test_pools.py
+++ b/tests/models/soil/test_pools.py
@@ -545,15 +545,22 @@ def test_negative_nutrient_removal_by_water(
     nitrate_data[0] = -0.0024219014
     labile_p_data = dummy_carbon_data["soil_p_pool_labile"]
     labile_p_data[3] = -1.0582393e-5
+    lmwc_data = dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C")
+    lmwc_data[2] = -2.05924e-5
 
-    expected_ammonium = [1.496453109e-9, 0.0, 2.271304008e-7, 5.461249320e-6]
-    expected_nitrate = [0.0, 1.128640314e-5, 6.798727493e-6, 0.00027625126]
-    expected_labile_P = [2.274653e-11, 4.130485e-10, 6.749199e-9, 0.0]
+    expected_removal = {
+        "lmwc": [1.0747349e-6, 2.5395235e-6, 0.0, 5.2557152e-6],
+        "don": [1.22826724e-8, 1.81394352e-7, 0.0, 3.00326494e-6],
+        "dop": [1.2282071e-10, 2.90230964e-9, 0.0, 1.20130598e-7],
+        "ammonium": [1.496453109e-9, 0.0, 2.271304008e-7, 5.461249320e-6],
+        "nitrate": [0.0, 1.128640314e-5, 6.798727493e-6, 0.00027625126],
+        "labile_P": [2.274653e-11, 4.130485e-10, 6.749199e-9, 0.0],
+    }
 
     actual_removal = calculate_nutrient_removal_by_water(
-        soil_c_pool_lmwc=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C"),
-        soil_n_pool_don=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C"),
-        soil_p_pool_dop=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C"),
+        soil_c_pool_lmwc=lmwc_data,
+        soil_n_pool_don=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="N"),
+        soil_p_pool_dop=dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="P"),
         soil_n_pool_ammonium=ammonium_data,
         soil_n_pool_nitrate=nitrate_data,
         soil_p_pool_labile=labile_p_data,
@@ -565,9 +572,10 @@ def test_negative_nutrient_removal_by_water(
         constants=fixture_soil_constants,
     )
 
-    assert np.allclose(actual_removal.ammonium, expected_ammonium)
-    assert np.allclose(actual_removal.nitrate, expected_nitrate)
-    assert np.allclose(actual_removal.labile_P, expected_labile_P)
+    for attr in dir(actual_removal):
+        if not attr.startswith("_"):
+            assert attr in expected_removal.keys(), f"Attribute {attr} not tested"
+            assert np.allclose(getattr(actual_removal, attr), expected_removal[attr])
 
 
 def test_calculate_enzyme_changes(soil_pool_data, enzyme_production, enzyme_classes):

--- a/tests/models/soil/test_pools.py
+++ b/tests/models/soil/test_pools.py
@@ -825,6 +825,22 @@ def test_calculate_sorption_to_maom(
     assert np.allclose(actual_sorption, expected_sorption)
 
 
+def test_calculate_sorption_to_maom_negative_values(fixture_soil_constants):
+    """Check that sorption to mineral associated matter handles negatives correctly."""
+
+    from virtual_ecosystem.models.soil.pools import calculate_sorption_to_maom
+
+    lmwc_values = np.array([0.05, -0.02, 0.1, -0.005])
+    expected_sorption = [5.0e-5, 0.0, 0.0001, 0.0]
+
+    actual_sorption = calculate_sorption_to_maom(
+        soil_c_pool=lmwc_values,
+        sorption_rate_constant=fixture_soil_constants.lmwc_sorption_rate,
+    )
+
+    assert np.allclose(actual_sorption, expected_sorption)
+
+
 def test_calculate_necromass_breakdown(dummy_carbon_data, fixture_soil_constants):
     """Check that necromass breakdown to lmwc is calculated correctly."""
 

--- a/tests/models/soil/test_uptake.py
+++ b/tests/models/soil/test_uptake.py
@@ -358,7 +358,7 @@ def test_negative_highest_achievable_nutrient_uptake_are_impossible(
 
     labile_carbon_data = dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C")
     labile_carbon_data[1] = -0.0001
-    labile_carbon_data[3] = -3.7e-5
+    labile_carbon_data[3] = -1e3  # Larger than saturation constant
 
     expected_uptake = [0.01024359, 0.0, 0.056746414, 0.0]
 

--- a/virtual_ecosystem/models/soil/env_factors.py
+++ b/virtual_ecosystem/models/soil/env_factors.py
@@ -125,8 +125,10 @@ def calculate_water_potential_impact_on_microbes(
 ) -> NDArray[np.floating]:
     """Calculate the effect that soil water potential has on microbial rates.
 
-    This function only returns valid output for soil water potentials that are less than
-    the optimal water potential.
+    This function produces values of one (i.e. no suppression due to soil water) when
+    soil water potentials that are greater than the optimal water potential. Below the
+    water potential at which microbial activity ceases suppression is (by definition)
+    total, so values of zero are produced.
 
     Args:
         water_potential: Soil water potential [kPa]
@@ -141,20 +143,18 @@ def calculate_water_potential_impact_on_microbes(
         decomposition [unitless]
     """
 
-    # If the water potential is greater than the optimal then the function produces NaNs
-    # so the simulation should be interrupted
-    if np.any(water_potential > water_potential_opt):
-        err = ValueError("Water potential greater than minimum value")
-        LOGGER.critical(err)
-        raise err
-
     # Calculate how much moisture suppresses microbial activity
     suppression = (
         (np.log10(-water_potential) - np.log10(-water_potential_opt))
         / (np.log10(-water_potential_halt) - np.log10(-water_potential_opt))
     ) ** response_curvature
 
-    return 1 - suppression
+    # Above optimum no suppression, and below halting threshold suppression is total
+    return np.where(
+        water_potential > water_potential_opt,
+        1,
+        (np.where(water_potential < water_potential_halt, 0, 1 - suppression)),
+    )
 
 
 def calculate_pH_suitability(

--- a/virtual_ecosystem/models/soil/env_factors.py
+++ b/virtual_ecosystem/models/soil/env_factors.py
@@ -412,7 +412,11 @@ def calculate_solute_removal_by_soil_water(
         water [kg solute m^-3 day^-1]
     """
 
-    return solubility_coefficient * solute_density * exit_rate / soil_moisture
+    return np.where(
+        solute_density >= 0,
+        solubility_coefficient * solute_density * exit_rate / soil_moisture,
+        0,
+    )
 
 
 def calculate_carbon_use_efficiency(

--- a/virtual_ecosystem/models/soil/model_config.py
+++ b/virtual_ecosystem/models/soil/model_config.py
@@ -48,11 +48,11 @@ class SoilConstants(Configuration):
     [°C^-1]. Parameter estimated from a beta-logit GLMM using the data from 
     :cite:t:`Qiao2019`."""
 
-    soil_microbe_water_potential_optimum: float = -3.0
+    soil_microbe_water_potential_optimum: float = Field(default=-3.0, lt=0.0)
     """The water potential at which soil microbial rates are maximised [kPa]. Value is
     taken from :cite:t:`moyano_responses_2013`."""
 
-    soil_microbe_water_potential_halt: float = -15800.0
+    soil_microbe_water_potential_halt: float = Field(default=-15800.0, lt=0.0)
     """The water potential at which soil microbial activity stops entirely [kPa]. Value
     is taken from :cite:t:`moyano_responses_2013`."""
 
@@ -316,6 +316,20 @@ class SoilConstants(Configuration):
             < self.max_pH_microbes
         ):
             raise ValueError("Microbe pH thresholds not in increasing sequence")
+
+        return self
+
+    @model_validator(mode="after")
+    def _check_water_potential_thresholds(self) -> SoilConstants:
+        """Checks that microbial water potential response thresholds are compatible."""
+        if (
+            self.soil_microbe_water_potential_optimum
+            <= self.soil_microbe_water_potential_halt
+        ):
+            raise ValueError(
+                "Optimal water potential for microbial activity cannot be lower than "
+                "the threshold for activity halting."
+            )
 
         return self
 

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -1541,7 +1541,7 @@ def calculate_sorption_to_maom(
         The rate of sorption to MAOM [kg C m^-3 day^-1]
     """
 
-    return sorption_rate_constant * soil_c_pool
+    return np.where(soil_c_pool >= 0, sorption_rate_constant * soil_c_pool, 0)
 
 
 def calculate_necromass_breakdown(

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -1227,11 +1227,9 @@ def calculate_nutrient_removal_by_water(
         lmwc=labile_carbon_removal,
         don=don_removal,
         dop=dop_removal,
-        ammonium=np.where(ammonium_removal >= 0.0, ammonium_removal, 0.0),
-        nitrate=np.where(nitrate_removal >= 0.0, nitrate_removal, 0.0),
-        labile_P=np.where(
-            labile_phosphorus_removal >= 0.0, labile_phosphorus_removal, 0.0
-        ),
+        ammonium=ammonium_removal,
+        nitrate=nitrate_removal,
+        labile_P=labile_phosphorus_removal,
     )
 
 

--- a/virtual_ecosystem/models/soil/uptake.py
+++ b/virtual_ecosystem/models/soil/uptake.py
@@ -660,4 +660,8 @@ def calculate_highest_achievable_nutrient_uptake(
         / (labile_nutrient_pool + saturation_constant)
     )
 
-    return np.where(uptake_rate >= 0.0, uptake_rate, 0.0)
+    # Uptake rate is only valid if both the nutrient pool and the microbial pool are
+    # positive, otherwise uptake rate should be zero
+    return np.where(
+        (microbial_pool_size >= 0.0) & (labile_nutrient_pool >= 0.0), uptake_rate, 0.0
+    )


### PR DESCRIPTION
# Description

This PR fixes a function that could cause negative values within the soil model (`calculate_water_potential_impact_on_microbes`).

It also changes three functions that ran out of control when negative values emerged, so that they now should handle negative values properly. Fixing these is needed as the numerical integration solver can introduce small negative values when attempting to solve, which normally isn't an issue, but becomes a big problem if functions then start generating nonsense in response.

Fixes #1559 
Fixes #1560
Fixes #1561 
Fixes #1563 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
