### PR TITLE
Simplify logging output from base model checking of required init variables

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ def log_check(
     caplog: pytest.LogCaptureFixture,
     expected_log: tuple[tuple],
     subset: slice | None = None,
+    match_message_start: bool = False,
 ) -> None:
     """Helper function to check that the captured log is as expected.
 
@@ -32,6 +33,8 @@ def log_check(
         caplog: An instance of the caplog fixture
         expected_log: An iterable of 2-tuples containing the log level and message.
         subset: Only check a specified subset of the captured log.
+        match_message_start: Allow log matching to only match the start of the expected
+            message to allow for appended log information.
     """
 
     # caplog.records is just a list of LogRecord objects, so can use a slice to drop
@@ -46,9 +49,18 @@ def log_check(
     assert all(
         [exp[0] == rec.levelno for exp, rec in zip(expected_log, captured_records)]
     )
-    assert all(
-        [exp[1] in rec.message for exp, rec in zip(expected_log, captured_records)]
-    )
+
+    if match_message_start:
+        assert all(
+            [
+                rec.message.startswith(exp[1])
+                for exp, rec in zip(expected_log, captured_records)
+            ]
+        )
+    else:
+        assert all(
+            [exp[1] in rec.message for exp, rec in zip(expected_log, captured_records)]
+        )
 
 
 def record_found_in_log(

--- a/tests/core/test_base_model.py
+++ b/tests/core/test_base_model.py
@@ -4,7 +4,7 @@ This module tests the functionality of base_model.py
 """
 
 from contextlib import nullcontext as does_not_raise
-from logging import CRITICAL, ERROR
+from logging import CRITICAL, ERROR, INFO
 from typing import Any
 
 import pytest
@@ -440,7 +440,13 @@ def test_check_update_speed(
             core_components=core_components,
         )
 
-    log_check(caplog, expected_log)
+    log_check(
+        caplog,
+        (
+            (INFO, "timing_test model: required initial data variables checked"),
+            *expected_log,
+        ),
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/models/abiotic/test_abiotic_model.py
+++ b/tests/models/abiotic/test_abiotic_model.py
@@ -1,7 +1,7 @@
 """Test module for abiotic.abiotic_model.py."""
 
 from contextlib import nullcontext as does_not_raise
-from logging import DEBUG, ERROR, INFO
+from logging import ERROR, INFO
 from unittest.mock import patch
 
 import numpy as np
@@ -13,21 +13,7 @@ from tests.conftest import log_check
 from virtual_ecosystem.core.exceptions import ConfigurationError
 
 REQUIRED_INIT_VAR_CHECKS = (
-    (DEBUG, "abiotic model: required var 'air_temperature_ref' checked"),
-    (DEBUG, "abiotic model: required var 'atmospheric_co2_ref' checked"),
-    (DEBUG, "abiotic model: required var 'atmospheric_pressure_ref' checked"),
-    (DEBUG, "abiotic model: required var 'layer_heights' checked"),
-    (DEBUG, "abiotic model: required var 'leaf_area_index' checked"),
-    (DEBUG, "abiotic model: required var 'mean_annual_temperature' checked"),
-    (DEBUG, "abiotic model: required var 'relative_humidity_ref' checked"),
-    (DEBUG, "abiotic model: required var 'shortwave_absorption' checked"),
-    (DEBUG, "abiotic model: required var 'wind_speed_ref' checked"),
-    (DEBUG, "abiotic model: required var 'downward_longwave_radiation' checked"),
-    (DEBUG, "abiotic model: required var 'aerodynamic_resistance_canopy' checked"),
-    (DEBUG, "abiotic model: required var 'specific_heat_air' checked"),
-    (DEBUG, "abiotic model: required var 'latent_heat_vapourisation' checked"),
-    (DEBUG, "abiotic model: required var 'density_air' checked"),
-    (DEBUG, "abiotic model: required var 'condensation' checked"),
+    (INFO, "abiotic model: required initial data variables checked"),
 )
 
 SETUP_MANIPULATIONS = (
@@ -119,18 +105,17 @@ def test_abiotic_model_initialization_no_data(
         )
 
     # Final check that expected logging entries are produced
-
-    expected_var_warnings = (
-        (ERROR, f"abiotic model: init data missing required var '{var}'")
-        for var in AbioticModel.vars_required_for_init
-    )
-
     log_check(
         caplog,
         expected_log=(
-            *expected_var_warnings,
-            (ERROR, "abiotic model: error checking vars_required_for_init, see log."),
+            (
+                ERROR,
+                "abiotic model: input data is missing "
+                "required initialisation variables:",
+            ),
+            (ERROR, "abiotic model: Problems with initial model data: check log."),
         ),
+        match_message_start=True,
     )
 
 

--- a/tests/models/abiotic_simple/test_abiotic_simple_model.py
+++ b/tests/models/abiotic_simple/test_abiotic_simple_model.py
@@ -1,6 +1,6 @@
 """Test module for abiotic_simple.abiotic_simple_model.py."""
 
-from logging import DEBUG, INFO
+from logging import INFO
 
 import numpy as np
 import pytest
@@ -13,9 +13,6 @@ from tests.conftest import log_check
 @pytest.fixture
 def fixture_abiotic_simple_init_log():
     """Helper function to generate expected log messages."""
-    from virtual_ecosystem.models.abiotic_simple.abiotic_simple_model import (
-        AbioticSimpleModel,
-    )
 
     return (
         (
@@ -23,10 +20,7 @@ def fixture_abiotic_simple_init_log():
             "Information required to initialise the abiotic simple model "
             "successfully extracted.",
         ),
-        *(
-            (DEBUG, f"abiotic_simple model: required var '{v}' checked")
-            for v in AbioticSimpleModel.vars_required_for_init
-        ),
+        (INFO, "abiotic_simple model: required initial data variables checked"),
         *(
             (INFO, f"Adding data array for '{v}'")
             for v in (

--- a/tests/models/animals/test_animal_model.py
+++ b/tests/models/animals/test_animal_model.py
@@ -1,7 +1,7 @@
 """Test module for animal_model.py."""
 
 from contextlib import nullcontext as does_not_raise
-from logging import DEBUG, INFO
+from logging import INFO
 
 import numpy as np
 import pytest
@@ -87,68 +87,8 @@ class TestAnimalModel:
                             "successfully extracted.",
                         ),
                         (
-                            DEBUG,
-                            "animal model: required var 'fungal_fruiting_bodies' "
-                            "checked",
-                        ),
-                        (
-                            DEBUG,
-                            "animal model: required var 'subcanopy_vegetation_cnp' "
-                            "checked",
-                        ),
-                        (
-                            DEBUG,
-                            "animal model: required var 'subcanopy_seedbank_cnp' "
-                            "checked",
-                        ),
-                        (
-                            DEBUG,
-                            "animal model: required var 'canopy_foliage_cnp' checked",
-                        ),
-                        (
-                            DEBUG,
-                            "animal model: required var 'canopy_seed_cnp' checked",
-                        ),
-                        (
-                            DEBUG,
-                            "animal model: required var 'canopy_fruit_cnp' checked",
-                        ),
-                        (
-                            DEBUG,
-                            "animal model: required var 'foliage_turnover_cnp' checked",
-                        ),
-                        (
-                            DEBUG,
-                            "animal model: required var 'seed_turnover_cnp' checked",
-                        ),
-                        (
-                            DEBUG,
-                            "animal model: required var 'fruit_turnover_cnp' checked",
-                        ),
-                        (
-                            DEBUG,
-                            "animal model: required var "
-                            "'litter_pool_above_metabolic_cnp' checked",
-                        ),
-                        (
-                            DEBUG,
-                            "animal model: required var "
-                            "'litter_pool_above_structural_cnp' checked",
-                        ),
-                        (
-                            DEBUG,
-                            "animal model: required var "
-                            "'litter_pool_woody_cnp' checked",
-                        ),
-                        (
-                            DEBUG,
-                            "animal model: required var "
-                            "'litter_pool_below_metabolic_cnp' checked",
-                        ),
-                        (
-                            DEBUG,
-                            "animal model: required var "
-                            "'litter_pool_below_structural_cnp' checked",
+                            INFO,
+                            "animal model: required initial data variables checked",
                         ),
                         (
                             INFO,

--- a/tests/models/hydrology/test_hydrology_model.py
+++ b/tests/models/hydrology/test_hydrology_model.py
@@ -1,6 +1,6 @@
 """Test module for hydrology.hydrology_model.py."""
 
-from logging import DEBUG, INFO
+from logging import INFO
 from unittest.mock import patch
 
 import numpy as np
@@ -17,10 +17,7 @@ MODEL_VAR_CHECK_LOG = [
         "Information required to initialise the hydrology model "
         "successfully extracted.",
     ),
-    (DEBUG, "hydrology model: required var 'layer_heights' checked"),
-    (DEBUG, "hydrology model: required var 'elevation' checked"),
-    (DEBUG, "hydrology model: required var 'air_temperature_ref' checked"),
-    (DEBUG, "hydrology model: required var 'atmospheric_pressure_ref' checked"),
+    (INFO, "hydrology model: required initial data variables checked"),
     (INFO, "Adding data array for 'soil_moisture'"),
     (INFO, "Adding data array for 'matric_potential'"),
     (INFO, "Adding data array for 'condensation'"),

--- a/tests/models/litter/test_litter_model.py
+++ b/tests/models/litter/test_litter_model.py
@@ -1,6 +1,6 @@
 """Test module for litter_model.py."""
 
-from logging import DEBUG, ERROR, INFO
+from logging import ERROR, INFO
 
 import numpy as np
 import pytest
@@ -9,28 +9,15 @@ from xarray import DataArray
 from tests.conftest import log_check
 from virtual_ecosystem.core.exceptions import InitialisationError
 
-
-def litter_required_for_init():
-    """Helper function to simplify expected log messages."""
-    from virtual_ecosystem.models.litter.litter_model import LitterModel
-
-    return LitterModel.vars_required_for_init
-
-
 # Define expected init log messages for all data present and no data present
-LITTER_INIT_CHECKS = tuple(
-    (DEBUG, f"litter model: required var '{v}' checked")
-    for v in litter_required_for_init()
-)
+LITTER_INIT_CHECKS = ((INFO, "litter model: required initial data variables checked"),)
 
-LITTER_ERROR_CHECKS = tuple(
+LITTER_ERROR_CHECKS = (
     (
-        *(
-            (ERROR, f"litter model: init data missing required var '{v}'")
-            for v in litter_required_for_init()
-        ),
-        (ERROR, "litter model: error checking vars_required_for_init, see log."),
-    )
+        ERROR,
+        "litter model: input data is missing required initialisation variables:",
+    ),
+    (ERROR, "litter model: Problems with initial model data: check log."),
 )
 
 
@@ -81,8 +68,9 @@ def test_litter_model_initialization_no_data(
             model_constants=fixture_litter_constants,
         )
 
-    # Final check that expected logging entries are produced
-    log_check(caplog, expected_log=LITTER_ERROR_CHECKS)
+    # Final check that expected logging entries are produced, do not match list of
+    # missing variables.
+    log_check(caplog, expected_log=LITTER_ERROR_CHECKS, match_message_start=False)
 
 
 @pytest.mark.parametrize(

--- a/tests/models/soil/test_soil_model.py
+++ b/tests/models/soil/test_soil_model.py
@@ -1,7 +1,7 @@
 """Test module for soil_model.py."""
 
 from contextlib import nullcontext as does_not_raise
-from logging import DEBUG, ERROR, INFO
+from logging import ERROR, INFO
 
 import numpy as np
 import pytest
@@ -13,30 +13,7 @@ from virtual_ecosystem.core.exceptions import InitialisationError
 from virtual_ecosystem.models.soil.soil_model import IntegrationError
 
 # Shared log entries from model initialisation
-REQUIRED_INIT_VAR_LOG = (
-    (DEBUG, "soil model: required var 'soil_cnp_pool_maom' checked"),
-    (DEBUG, "soil model: required var 'soil_cnp_pool_lmwc' checked"),
-    (DEBUG, "soil model: required var 'soil_cnp_pool_pom' checked"),
-    (DEBUG, "soil model: required var 'soil_cnp_pool_necromass' checked"),
-    (DEBUG, "soil model: required var 'soil_c_pool_bacteria' checked"),
-    (DEBUG, "soil model: required var 'soil_c_pool_saprotrophic_fungi' checked"),
-    (DEBUG, "soil model: required var 'soil_c_pool_arbuscular_mycorrhiza' checked"),
-    (DEBUG, "soil model: required var 'soil_c_pool_ectomycorrhiza' checked"),
-    (DEBUG, "soil model: required var 'soil_enzyme_pom_bacteria' checked"),
-    (DEBUG, "soil model: required var 'soil_enzyme_maom_bacteria' checked"),
-    (DEBUG, "soil model: required var 'soil_enzyme_pom_fungi' checked"),
-    (DEBUG, "soil model: required var 'soil_enzyme_maom_fungi' checked"),
-    (DEBUG, "soil model: required var 'soil_n_pool_ammonium' checked"),
-    (DEBUG, "soil model: required var 'soil_n_pool_nitrate' checked"),
-    (DEBUG, "soil model: required var 'soil_p_pool_primary' checked"),
-    (DEBUG, "soil model: required var 'soil_p_pool_secondary' checked"),
-    (DEBUG, "soil model: required var 'soil_p_pool_labile' checked"),
-    (DEBUG, "soil model: required var 'pH' checked"),
-    (DEBUG, "soil model: required var 'clay_fraction' checked"),
-    (DEBUG, "soil model: required var 'matric_potential' checked"),
-    (DEBUG, "soil model: required var 'soil_temperature' checked"),
-    (DEBUG, "soil model: required var 'air_temperature' checked"),
-)
+REQUIRED_INIT_VAR_LOG = ((INFO, "soil model: required initial data variables checked"),)
 POST_SETUP_LOG = (
     *REQUIRED_INIT_VAR_LOG,
     (INFO, "Adding data array for 'dissolved_nitrate'"),
@@ -116,24 +93,17 @@ def test_soil_model_initialization_no_data(
             soil_moisture_residual=fixture_hydrology_constants.soil_moisture_residual,
         )
 
-    # Final check that expected logging entries are produced: modify shared
-    # REQUIRED_INIT_VAR_LOG to use shared list of variables
-    missing_log = list(
-        (
-            (
-                ERROR,
-                log_str.replace(":", ": init data missing").removesuffix(" checked"),
-            )
-            for _, log_str in REQUIRED_INIT_VAR_LOG
-        ),
-    )
-    missing_log.append(
-        (ERROR, "soil model: error checking vars_required_for_init, see log."),
-    )
-
+    # Final check that expected logging entries are produced
     log_check(
         caplog,
-        expected_log=missing_log,
+        expected_log=(
+            (
+                ERROR,
+                "soil model: input data is missing required initialisation variables:",
+            ),
+            (ERROR, "soil model: Problems with initial model data: check log."),
+        ),
+        match_message_start=True,
     )
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ defined in main.py that it calls.
 """
 
 from contextlib import nullcontext as does_not_raise
-from logging import CRITICAL, DEBUG, ERROR, INFO
+from logging import CRITICAL, ERROR, INFO
 from typing import cast
 
 import pytest
@@ -21,14 +21,7 @@ INITIALISATION_LOG = [
         INFO,
         "Information required to initialise the litter model successfully extracted.",
     ),
-    (DEBUG, "litter model: required var 'litter_pool_above_metabolic_cnp' checked"),
-    (DEBUG, "litter model: required var 'litter_pool_above_structural_cnp' checked"),
-    (DEBUG, "litter model: required var 'litter_pool_woody_cnp' checked"),
-    (DEBUG, "litter model: required var 'litter_pool_below_metabolic_cnp' checked"),
-    (DEBUG, "litter model: required var 'litter_pool_below_structural_cnp' checked"),
-    (DEBUG, "litter model: required var 'lignin_above_structural' checked"),
-    (DEBUG, "litter model: required var 'lignin_woody' checked"),
-    (DEBUG, "litter model: required var 'lignin_below_structural' checked"),
+    (INFO, "litter model: required initial data variables checked"),
 ]
 
 

--- a/virtual_ecosystem/core/base_model.py
+++ b/virtual_ecosystem/core/base_model.py
@@ -728,6 +728,7 @@ class BaseModel(ABC):
                 or if those variables do not map onto the required axes.
         """
 
+        # Canary variable for failed checks
         init_data_ok = True
 
         # Check for missing init variables
@@ -741,11 +742,11 @@ class BaseModel(ABC):
             error = ValueError(
                 f"{self.model_name} model: input data is missing required "
                 f"initialisation variables: {','.join(missing_vars)}"
-                "see log."
             )
             LOGGER.error(error)
 
-        # TODO: Check axes on provided variables.
+        # TODO: Check required axes on provided variables but this needs fixing up axis
+        #       requirements in data variables TOML file.
 
         # # Get a list of missing axes
         # bad_axes = []
@@ -772,17 +773,8 @@ class BaseModel(ABC):
             LOGGER.error(error)
             raise error
 
-        # Record variable validation in log:
-        for var in self.vars_required_for_init:
-            LOGGER.debug(f"{self.model_name} model: required var '{var}' checked")
-
-        # TODO - individual log messages is a bit much, replace with single line, but
-        # then tests need updating
-
-        # LOGGER.debug(
-        # f"{self.model_name} model required initial data checked: "
-        # f" {','.join(self.vars_required_for_init)}"
-        # )
+        # Log successful data checking
+        LOGGER.info(f"{self.model_name} model: required initial data variables checked")
 
 
 def to_camel_case(snake_str: str) -> str:

--- a/virtual_ecosystem/core/base_model.py
+++ b/virtual_ecosystem/core/base_model.py
@@ -728,47 +728,61 @@ class BaseModel(ABC):
                 or if those variables do not map onto the required axes.
         """
 
-        # Sentinel variables
-        # all_axes_ok: bool = True
-        all_vars_found: bool = True
+        init_data_ok = True
 
-        # Loop over the required  and axes
-        for var in self.vars_required_for_init:
-            # Record when a variable is missing
-            if var not in self.data:
-                LOGGER.error(
-                    f"{self.model_name} model: init data missing required var '{var}'"
-                )
-                all_vars_found = False
-                continue
+        # Check for missing init variables
+        provided_variable_names = set(self.data.data.data_vars.variables)
+        missing_vars = set(self.vars_required_for_init).difference(
+            provided_variable_names
+        )
 
-            # # Get a list of missing axes
-            # bad_axes = []
-            # # Could use try: here and let on_core_axis report errors but easier to
-            # # provide more clearly structured feedback this way
-            # for axis in axes:
-            #     if not self.data.on_core_axis(var, axis):
-            #         bad_axes.append(axis)
-
-            # Log the outcome
-            # if bad_axes:
-            #     LOGGER.error(
-            #         f"{self.model_name} model: required var '{var}' "
-            #         f"not on required axes: {','.join(bad_axes)}"
-            #     )
-            #     all_axes_ok = False
-            # else:
-
-            LOGGER.debug(f"{self.model_name} model: required var '{var}' checked")
-
-        # Raise if any problems found
-        if not (all_vars_found):
+        if missing_vars:
+            init_data_ok = False
             error = ValueError(
-                f"{self.model_name} model: error checking vars_required_for_init, "
+                f"{self.model_name} model: input data is missing required "
+                f"initialisation variables: {','.join(missing_vars)}"
                 "see log."
             )
             LOGGER.error(error)
+
+        # TODO: Check axes on provided variables.
+
+        # # Get a list of missing axes
+        # bad_axes = []
+        # # Could use try: here and let on_core_axis report errors but easier to
+        # # provide more clearly structured feedback this way
+        # for axis in axes:
+        #     if not self.data.on_core_axis(var, axis):
+        #         bad_axes.append(axis)
+
+        # Log the outcome
+        # if bad_axes:
+        #     LOGGER.error(
+        #         f"{self.model_name} model: required var '{var}' "
+        #         f"not on required axes: {','.join(bad_axes)}"
+        #     )
+        #     all_axes_ok = False
+        # else:
+
+        # Raise if any problems found
+        if not init_data_ok:
+            error = ValueError(
+                f"{self.model_name} model: Problems with initial model data: check log."
+            )
+            LOGGER.error(error)
             raise error
+
+        # Record variable validation in log:
+        for var in self.vars_required_for_init:
+            LOGGER.debug(f"{self.model_name} model: required var '{var}' checked")
+
+        # TODO - individual log messages is a bit much, replace with single line, but
+        # then tests need updating
+
+        # LOGGER.debug(
+        # f"{self.model_name} model required initial data checked: "
+        # f" {','.join(self.vars_required_for_init)}"
+        # )
 
 
 def to_camel_case(snake_str: str) -> str:


### PR DESCRIPTION
# Description

This PR:

* Removes the per variable "checked" notices when the BaseModel checks the required input variables. These were `DEBUG` level, are basically useless ("Hey everything is OK!") and are a real burden on model development and test maintenance. 
* Adds a single `INFO` level message to say the variables have all been checked.
* Collapses missing variable notifications into a single log entry with a list of missing variables (not one log entry per missing variable).
* Adds a new `match_message_start` mode to `log_check` that allows log checking to pass without having to maintain specific lists of variables at the end of log messages.

Fixes #1577 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
