### PR TITLE
canopy temperature added to abiotic_simple init

### DIFF
--- a/tests/models/abiotic_simple/test_abiotic_simple_model.py
+++ b/tests/models/abiotic_simple/test_abiotic_simple_model.py
@@ -38,6 +38,7 @@ def fixture_abiotic_simple_init_log():
                 "soil_temperature",
                 "net_radiation",
                 "canopy_temperature",
+                "diurnal_temperature_range",
             )
         ),
     )

--- a/tests/models/abiotic_simple/test_abiotic_simple_model.py
+++ b/tests/models/abiotic_simple/test_abiotic_simple_model.py
@@ -37,6 +37,7 @@ def fixture_abiotic_simple_init_log():
                 "atmospheric_co2",
                 "soil_temperature",
                 "net_radiation",
+                "canopy_temperature",
             )
         ),
     )

--- a/virtual_ecosystem/models/abiotic_simple/abiotic_simple_model.py
+++ b/virtual_ecosystem/models/abiotic_simple/abiotic_simple_model.py
@@ -81,6 +81,7 @@ class AbioticSimpleModel(
         "atmospheric_pressure",
         "atmospheric_co2",
         "wind_speed",
+        "canopy_temperature",
     ),
     vars_populated_by_first_update=tuple(),
 ):
@@ -170,6 +171,18 @@ class AbioticSimpleModel(
             pyrealm_core_constants=pyrealm_core_constants,
             bounds=self.bounds,
         )
+
+        # Initialise canopy temperature, equilibrium with surrounding air, [C]
+        air_temp = output_variables["air_temperature"].copy()
+        canopy_temperature = self.layer_structure.from_template()
+        canopy_temperature[self.layer_structure.index_filled_canopy] = air_temp[
+            self.layer_structure.index_filled_canopy
+        ]
+        canopy_temperature[self.layer_structure.index_surface_scalar] = air_temp[
+            self.layer_structure.index_surface_scalar
+        ]
+        output_variables["canopy_temperature"] = canopy_temperature
+
         self.data.add_from_dict(output_dict=output_variables)
 
     @classmethod

--- a/virtual_ecosystem/models/abiotic_simple/abiotic_simple_model.py
+++ b/virtual_ecosystem/models/abiotic_simple/abiotic_simple_model.py
@@ -82,6 +82,7 @@ class AbioticSimpleModel(
         "atmospheric_co2",
         "wind_speed",
         "canopy_temperature",
+        "diurnal_temperature_range",
     ),
     vars_populated_by_first_update=tuple(),
 ):
@@ -182,6 +183,12 @@ class AbioticSimpleModel(
             self.layer_structure.index_surface_scalar
         ]
         output_variables["canopy_temperature"] = canopy_temperature
+
+        # Add diurnal temperature range, [C]
+        diurnal_temperature_range = output_variables["air_temperature"].copy()
+        output_variables["diurnal_temperature_range"] = diurnal_temperature_range.where(
+            diurnal_temperature_range.isnull(), other=5.0
+        )
 
         self.data.add_from_dict(output_dict=output_variables)
 

--- a/virtual_ecosystem/models/abiotic_simple/abiotic_simple_model.py
+++ b/virtual_ecosystem/models/abiotic_simple/abiotic_simple_model.py
@@ -187,7 +187,8 @@ class AbioticSimpleModel(
         # Add diurnal temperature range, [C]
         diurnal_temperature_range = output_variables["air_temperature"].copy()
         output_variables["diurnal_temperature_range"] = diurnal_temperature_range.where(
-            diurnal_temperature_range.isnull(), other=5.0
+            diurnal_temperature_range.isnull(),
+            other=5.0,  # TODO add data when available
         )
 
         self.data.add_from_dict(output_dict=output_variables)


### PR DESCRIPTION
This PR adds `canopy_temperature` and `diurnal_temperature_range` to the `abiotic_simple` `init`. @TaranRallings   could you please double-check that the `canopy_temperature` is actually what you are looking for in the animal model, or if you want the air temperature surrounding the canopy.

Fixes #1585

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
