### PR TITLE
Store `LitterInputs` as CNP arrays

### DIFF
--- a/tests/models/litter/test_inputs.py
+++ b/tests/models/litter/test_inputs.py
@@ -4,6 +4,7 @@ from logging import ERROR
 
 import numpy as np
 import pytest
+from xarray import DataArray
 
 from tests.conftest import log_check
 
@@ -24,19 +25,44 @@ def test_determine_all_plant_to_litter_flows(
         "above_structural": [0.002536, 0.00029883, 0.00638456, 0.01334023],
         "below_metabolic": [0.00794333, 0.0039855, 7.5365e-5, 0.005106055],
         "below_structural": [0.00555667, 0.0065145, 7.4635e-5, 0.007343945],
-        "leaf_mass": [0.013515, 0.0012, 0.011925, 0.0156],
-        "root_mass": [0.0135, 0.0105, 0.00015, 0.01245],
-        "deadwood_mass": [0.0375, 0.0495, 0.0315, 0.0165],
         "leaf_lignin": [0.05008879, 0.10125, 0.29641509, 0.53971154],
         "root_lignin": [0.2, 0.35, 0.27, 0.4],
         "stem_lignin": [0.233, 0.545, 0.612, 0.378],
-        "leaf_nitrogen": [0.00090064935, 3.72256365e-5, 0.00030530780, 0.00032629252],
-        "root_nitrogen": [0.000445545, 0.000230263, 3.464203e-6, 0.000335580],
-        "deadwood_nitrogen": [0.00061779, 0.00085492, 0.00043092, 0.00029946],
-        "leaf_phosphorus": [3.260071e-5, 3.503399e-6, 2.319225e-5, 4.062491e-5],
-        "root_phosphorus": [2.0557332e-5, 2.3302264e-5, 3.4301395e-7, 3.3476741e-5],
-        "deadwood_phosphorus": [4.3782837e-5, 7.3289902e-5, 3.3754822e-5, 1.8564356e-5],
     }
+    # Some expected inputs are triplets so need to be stored as such
+    expected_inputs["leaf_mass"] = DataArray(
+        data=np.stack(
+            [
+                [0.013515, 0.0012, 0.011925, 0.0156],
+                [0.00090064935, 3.72256365e-5, 0.00030530780, 0.00032629252],
+                [3.260071e-5, 3.503399e-6, 2.319225e-5, 4.062491e-5],
+            ],
+            axis=1,
+        ),
+        coords={"cell_id": dummy_litter_data["cell_id"], "element": ["C", "N", "P"]},
+    )
+    expected_inputs["root_mass"] = DataArray(
+        data=np.stack(
+            [
+                [0.0135, 0.0105, 0.00015, 0.01245],
+                [0.000445545, 0.000230263, 3.464203e-6, 0.000335580],
+                [2.0557332e-5, 2.3302264e-5, 3.4301395e-7, 3.3476741e-5],
+            ],
+            axis=1,
+        ),
+        coords={"cell_id": dummy_litter_data["cell_id"], "element": ["C", "N", "P"]},
+    )
+    expected_inputs["deadwood_mass"] = DataArray(
+        data=np.stack(
+            [
+                [0.0375, 0.0495, 0.0315, 0.0165],
+                [0.00061779, 0.00085492, 0.00043092, 0.00029946],
+                [4.3782837e-5, 7.3289902e-5, 3.3754822e-5, 1.8564356e-5],
+            ],
+            axis=1,
+        ),
+        coords={"cell_id": dummy_litter_data["cell_id"], "element": ["C", "N", "P"]},
+    )
 
     litter_inputs = LitterInputs.create_from_data(
         data=dummy_litter_data, constants=fixture_litter_constants, update_interval=2.0
@@ -78,19 +104,44 @@ def test_combine_input_sources(dummy_litter_data):
     from virtual_ecosystem.models.litter.inputs import combine_input_sources
 
     expected_combined = {
-        "leaf_mass": [0.013515, 0.0012, 0.011925, 0.0156],
-        "root_mass": [0.0135, 0.0105, 0.00015, 0.01245],
-        "deadwood_mass": [0.0375, 0.0495, 0.0315, 0.0165],
         "leaf_lignin": [0.05008879, 0.10125, 0.29641509, 0.53971154],
         "root_lignin": [0.2, 0.35, 0.27, 0.4],
         "stem_lignin": [0.233, 0.545, 0.612, 0.378],
-        "leaf_nitrogen": [0.00090064935, 3.72256365e-5, 0.00030530780, 0.00032629252],
-        "root_nitrogen": [0.000445545, 0.000230263, 3.464203e-6, 0.000335580],
-        "deadwood_nitrogen": [0.00061779, 0.00085492, 0.00043092, 0.00029946],
-        "leaf_phosphorus": [3.260071e-5, 3.503399e-6, 2.319225e-5, 4.062491e-5],
-        "root_phosphorus": [2.0557332e-5, 2.3302264e-5, 3.4301395e-7, 3.3476741e-5],
-        "deadwood_phosphorus": [4.3782837e-5, 7.3289902e-5, 3.3754822e-5, 1.8564356e-5],
     }
+    # Some expected inputs are triplets so need to be stored as such
+    expected_combined["leaf_mass"] = DataArray(
+        data=np.stack(
+            [
+                [0.013515, 0.0012, 0.011925, 0.0156],
+                [0.00090064935, 3.72256365e-5, 0.00030530780, 0.00032629252],
+                [3.260071e-5, 3.503399e-6, 2.319225e-5, 4.062491e-5],
+            ],
+            axis=1,
+        ),
+        coords={"cell_id": dummy_litter_data["cell_id"], "element": ["C", "N", "P"]},
+    )
+    expected_combined["root_mass"] = DataArray(
+        data=np.stack(
+            [
+                [0.0135, 0.0105, 0.00015, 0.01245],
+                [0.000445545, 0.000230263, 3.464203e-6, 0.000335580],
+                [2.0557332e-5, 2.3302264e-5, 3.4301395e-7, 3.3476741e-5],
+            ],
+            axis=1,
+        ),
+        coords={"cell_id": dummy_litter_data["cell_id"], "element": ["C", "N", "P"]},
+    )
+    expected_combined["deadwood_mass"] = DataArray(
+        data=np.stack(
+            [
+                [0.0375, 0.0495, 0.0315, 0.0165],
+                [0.00061779, 0.00085492, 0.00043092, 0.00029946],
+                [4.3782837e-5, 7.3289902e-5, 3.3754822e-5, 1.8564356e-5],
+            ],
+            axis=1,
+        ),
+        coords={"cell_id": dummy_litter_data["cell_id"], "element": ["C", "N", "P"]},
+    )
 
     actual_combined = combine_input_sources(dummy_litter_data, update_interval=2.0)
 
@@ -163,10 +214,8 @@ def test_split_pool_into_metabolic_and_structural_litter(
     collapsed_foliage = dummy_litter_data["foliage_turnover_cnp"].sum(dim="pft")
 
     actual_split = split_pool_into_metabolic_and_structural_litter(
-        input_carbon=collapsed_foliage.sel(element="C"),
+        input_masses=collapsed_foliage,
         lignin_proportion=dummy_litter_data["senesced_leaf_lignin"],
-        input_nitrogen=collapsed_foliage.sel(element="N"),
-        input_phosphorus=collapsed_foliage.sel(element="P"),
         max_metabolic_fraction=fixture_litter_constants.max_metabolic_fraction_of_input,
         split_sensitivity_nitrogen=fixture_litter_constants.metabolic_split_nitrogen_sensitivity,
         split_sensitivity_phosphorus=fixture_litter_constants.metabolic_split_phosphorus_sensitivity,
@@ -199,10 +248,8 @@ def test_split_pool_into_metabolic_and_structural_litter_bad_data(
 
     with pytest.raises(ValueError):
         split_pool_into_metabolic_and_structural_litter(
-            input_carbon=dummy_litter_data["foliage_turnover_cnp"].sel(element="C"),
+            input_masses=dummy_litter_data["foliage_turnover_cnp"],
             lignin_proportion=lignin_proportions,
-            input_nitrogen=dummy_litter_data["foliage_turnover_cnp"].sel(element="N"),
-            input_phosphorus=dummy_litter_data["foliage_turnover_cnp"].sel(element="P"),
             max_metabolic_fraction=fixture_litter_constants.max_metabolic_fraction_of_input,
             split_sensitivity_nitrogen=fixture_litter_constants.metabolic_split_nitrogen_sensitivity,
             split_sensitivity_phosphorus=fixture_litter_constants.metabolic_split_phosphorus_sensitivity,
@@ -464,12 +511,16 @@ def test_find_nutrient_split_between_litter_pools_bad_input(
     )
 
     # One carbon input is missing
-    input_carbon_rate = np.array([218.7, 0.0, 2.43, 201.69])
+    input_carbon_rate = DataArray([218.7, 0.0, 2.43, 201.69], dims="cell_id")
     # In one case all flow is to metabolic
-    metabolic_split = np.array([0.588394858, 0.379571377, 1.0, 0.410125012])
+    metabolic_split = DataArray(
+        [0.588394858, 0.379571377, 1.0, 0.410125012], dims="cell_id"
+    )
 
-    expected_n_meta = np.array([6.331932287, 0.0, 0.0561200192, 4.22192613])
-    expected_n_struct = np.array([0.8858875316, 0.0, 0.0, 1.214462735])
+    expected_n_meta = DataArray(
+        [6.331932287, 0.0, 0.0561200192, 4.22192613], dims="cell_id"
+    )
+    expected_n_struct = DataArray([0.8858875316, 0.0, 0.0, 1.214462735], dims="cell_id")
 
     actual_n_meta, actual_n_struct = find_nutrient_split_between_litter_pools(
         input_carbon_rate=input_carbon_rate,

--- a/virtual_ecosystem/models/litter/carbon.py
+++ b/virtual_ecosystem/models/litter/carbon.py
@@ -252,7 +252,7 @@ def calculate_updated_pools(
 
     return {
         "above_metabolic": calculate_final_pool_size(
-            input_rate=litter_inputs.above_metabolic,
+            input_rate=litter_inputs.above_metabolic.to_numpy(),
             decay_rate=decay_rates["metabolic_above"],
             initial_pool=post_consumption_pools["above_metabolic"]
             .sel(element="C")
@@ -260,7 +260,7 @@ def calculate_updated_pools(
             update_interval=update_interval,
         ),
         "above_structural": calculate_final_pool_size(
-            input_rate=litter_inputs.above_structural,
+            input_rate=litter_inputs.above_structural.to_numpy(),
             decay_rate=decay_rates["structural_above"],
             initial_pool=post_consumption_pools["above_structural"]
             .sel(element="C")
@@ -268,13 +268,13 @@ def calculate_updated_pools(
             update_interval=update_interval,
         ),
         "woody": calculate_final_pool_size(
-            input_rate=litter_inputs.woody,
+            input_rate=litter_inputs.woody.to_numpy(),
             decay_rate=decay_rates["woody"],
             initial_pool=post_consumption_pools["woody"].sel(element="C").to_numpy(),
             update_interval=update_interval,
         ),
         "below_metabolic": calculate_final_pool_size(
-            input_rate=litter_inputs.below_metabolic,
+            input_rate=litter_inputs.below_metabolic.to_numpy(),
             decay_rate=decay_rates["metabolic_below"],
             initial_pool=post_consumption_pools["below_metabolic"]
             .sel(element="C")
@@ -282,7 +282,7 @@ def calculate_updated_pools(
             update_interval=update_interval,
         ),
         "below_structural": calculate_final_pool_size(
-            input_rate=litter_inputs.below_structural,
+            input_rate=litter_inputs.below_structural.to_numpy(),
             decay_rate=decay_rates["structural_below"],
             initial_pool=post_consumption_pools["below_structural"]
             .sel(element="C")

--- a/virtual_ecosystem/models/litter/chemistry.py
+++ b/virtual_ecosystem/models/litter/chemistry.py
@@ -115,19 +115,19 @@ class LitterChemistry:
             initial_carbon=original_pools["above_structural"]
             .sel(element="C")
             .to_numpy(),
-            input_carbon_rate=litter_inputs.above_structural,
+            input_carbon_rate=litter_inputs.above_structural.to_numpy(),
             carbon_loss=litter_losses.above_structural_carbon,
             initial_lignin_proportion=self.data["lignin_above_structural"].to_numpy(),
-            input_lignin_proportion=input_chemistries.above_structural_lignin,
+            input_lignin_proportion=input_chemistries.above_structural_lignin.to_numpy(),
             lignin_loss=litter_losses.above_structural_lignin,
             update_interval=update_interval,
         )
         new_lignin_proportion_woody = calculate_updated_pool_lignin_proportion(
             initial_carbon=original_pools["woody"].sel(element="C").to_numpy(),
-            input_carbon_rate=litter_inputs.woody,
+            input_carbon_rate=litter_inputs.woody.to_numpy(),
             carbon_loss=litter_losses.woody_carbon,
             initial_lignin_proportion=self.data["lignin_woody"].to_numpy(),
-            input_lignin_proportion=input_chemistries.woody_lignin,
+            input_lignin_proportion=input_chemistries.woody_lignin.to_numpy(),
             lignin_loss=litter_losses.woody_lignin,
             update_interval=update_interval,
         )
@@ -135,10 +135,10 @@ class LitterChemistry:
             initial_carbon=original_pools["below_structural"]
             .sel(element="C")
             .to_numpy(),
-            input_carbon_rate=litter_inputs.below_structural,
+            input_carbon_rate=litter_inputs.below_structural.to_numpy(),
             carbon_loss=litter_losses.below_structural_carbon,
             initial_lignin_proportion=self.data["lignin_below_structural"].to_numpy(),
-            input_lignin_proportion=input_chemistries.below_structural_lignin,
+            input_lignin_proportion=input_chemistries.below_structural_lignin.to_numpy(),
             lignin_loss=litter_losses.below_structural_lignin,
             update_interval=update_interval,
         )

--- a/virtual_ecosystem/models/litter/inputs.py
+++ b/virtual_ecosystem/models/litter/inputs.py
@@ -631,7 +631,6 @@ def find_nutrient_split_between_litter_pools(
     # Defining masks to avoid zero flow edge cases
     struct_input = carbon_input_struct != 0
     only_meta_input = (carbon_input_meta != 0) & (carbon_input_struct == 0)
-    no_input = (carbon_input_meta == 0) & (carbon_input_struct == 0)
 
     # Calculate actual split in cases where there is flow to the structural pool
     meta_nutrient, struct_nutrient = calculate_nutrient_split(
@@ -640,18 +639,17 @@ def find_nutrient_split_between_litter_pools(
         input_nutrient_rate.where(struct_input),
         meta_to_struct_nutrient_ratio,
     )
-    meta_nutrient_mass = meta_nutrient_mass.where(~struct_input, meta_nutrient)
-    struct_nutrient_mass = struct_nutrient_mass.where(~struct_input, struct_nutrient)
+
+    # Zero values get replaced if there is a flow to that pool (otherwise kept as zero)
+    meta_nutrient_mass = meta_nutrient_mass.where(~struct_input, other=meta_nutrient)
+    struct_nutrient_mass = struct_nutrient_mass.where(
+        ~struct_input, other=struct_nutrient
+    )
 
     # If all carbon goes to metabolic litter all nutrients do as well
     meta_nutrient_mass = meta_nutrient_mass.where(
         ~only_meta_input, input_nutrient_rate.where(only_meta_input)
     )
-    struct_nutrient_mass = struct_nutrient_mass.where(~only_meta_input, 0)
-
-    # No carbon input means no nutrient input
-    meta_nutrient_mass = meta_nutrient_mass.where(~no_input, 0)
-    struct_nutrient_mass = struct_nutrient_mass.where(~no_input, 0)
 
     return (meta_nutrient_mass, struct_nutrient_mass)
 

--- a/virtual_ecosystem/models/litter/inputs.py
+++ b/virtual_ecosystem/models/litter/inputs.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 
 import numpy as np
 from numpy.typing import NDArray
-from xarray import DataArray
+from xarray import DataArray, zeros_like
 
 from virtual_ecosystem.core.data import Data
 from virtual_ecosystem.core.logger import LOGGER
@@ -20,48 +20,34 @@ from virtual_ecosystem.models.litter.model_config import LitterConstants
 class LitterInputs:
     """The full set input flows to the litter model."""
 
-    leaf_mass: NDArray[np.floating]
-    """Total leaf input rate to litter in carbon terms [kg C m^-2 day^-1]"""
-    root_mass: NDArray[np.floating]
-    """Total root input rate to litter in carbon terms [kg C m^-2 day^-1]"""
-    deadwood_mass: NDArray[np.floating]
-    """Total deadwood input rate to litter in carbon terms [kg C m^-2 day^-1]"""
+    leaf_mass: DataArray
+    """Total leaf input rate to litter of each nutrient [kg m^-2 day^-1]"""
+    root_mass: DataArray
+    """Total root input rate to litter of each nutrient [kg m^-2 day^-1]"""
+    deadwood_mass: DataArray
+    """Total deadwood input rate to litter of each nutrient [kg m^-2 day^-1]"""
 
-    leaf_lignin: NDArray[np.floating]
+    leaf_lignin: DataArray
     """Lignin proportion of leaf input [kg lignin C (kg C)^-1]"""
-    root_lignin: NDArray[np.floating]
+    root_lignin: DataArray
     """Lignin proportion of root input [kg lignin C (kg C)^-1]"""
-    stem_lignin: NDArray[np.floating]
+    stem_lignin: DataArray
     """Lignin proportion of deadwood input [kg lignin C (kg C)^-1]"""
 
-    leaf_nitrogen: NDArray[np.floating]
-    """Nitrogen mass of leaf input [kg N m^-2 day^-1]"""
-    root_nitrogen: NDArray[np.floating]
-    """Nitrogen mass of root input [kg N m^-2 day^-1]"""
-    deadwood_nitrogen: NDArray[np.floating]
-    """Nitrogen mass of deadwood input [kg N m^-2 day^-1]"""
-
-    leaf_phosphorus: NDArray[np.floating]
-    """Phosphorus mass of leaf input [kg P m^-2 day^-1]"""
-    root_phosphorus: NDArray[np.floating]
-    """Phosphorus mass of root input [kg P m^-2 day^-1]"""
-    deadwood_phosphorus: NDArray[np.floating]
-    """Phosphorus mass of deadwood input [kg P m^-2 day^-1]"""
-
-    leaves_meta_split: NDArray[np.floating]
+    leaves_meta_split: DataArray
     """Fraction of leaf input that goes to metabolic litter [unitless]"""
-    roots_meta_split: NDArray[np.floating]
+    roots_meta_split: DataArray
     """Fraction of leaf input that goes to metabolic litter [unitless]"""
 
-    woody: NDArray[np.floating]
+    woody: DataArray
     """Total input rate to the woody litter pool [kg C m^-2 day^-1]"""
-    above_metabolic: NDArray[np.floating]
+    above_metabolic: DataArray
     """Total input rate to the above ground metabolic litter pool [kg C m^-2 day^-1]"""
-    above_structural: NDArray[np.floating]
+    above_structural: DataArray
     """Total input rate to the above ground structural litter pool [kg C m^-2 day^-1]"""
-    below_metabolic: NDArray[np.floating]
+    below_metabolic: DataArray
     """Total input rate to the below ground metabolic litter pool [kg C m^-2 day^-1]"""
-    below_structural: NDArray[np.floating]
+    below_structural: DataArray
     """Total input rate to the below ground structural litter pool [kg C m^-2 day^-1]"""
 
     @classmethod
@@ -125,9 +111,7 @@ def convert_to_input_masses_to_rates_per_area(
     return input_mass / (cell_area * update_interval)
 
 
-def combine_input_sources(
-    data: Data, update_interval: float
-) -> dict[str, NDArray[np.floating]]:
+def combine_input_sources(data: Data, update_interval: float) -> dict[str, DataArray]:
     """Combine the plant death and herbivory inputs into a single total input.
 
     The total input for each plant matter type (leaves, roots, deadwood) is returned,
@@ -169,40 +153,28 @@ def combine_input_sources(
     foliage_mass = data["foliage_turnover_cnp"].sel(element="C").sum(dim="pft")
 
     leaf_lignin = merge_input_lignin_proportions(
-        turnover_mass=foliage_mass.to_numpy(),
-        herbivory_waste_mass=data["herbivory_waste_leaf_cnp"]
-        .sel(element="C")
-        .to_numpy(),
-        total_mass=(
-            foliage_mass + data["herbivory_waste_leaf_cnp"].sel(element="C")
-        ).to_numpy(),
-        turnover_lignin_proportion=data["senesced_leaf_lignin"].to_numpy(),
-        herbivory_waste_lignin_proportion=data[
-            "herbivory_waste_leaf_lignin"
-        ].to_numpy(),
+        turnover_mass=foliage_mass,
+        herbivory_waste_mass=data["herbivory_waste_leaf_cnp"].sel(element="C"),
+        total_mass=(foliage_mass + data["herbivory_waste_leaf_cnp"].sel(element="C")),
+        turnover_lignin_proportion=data["senesced_leaf_lignin"],
+        herbivory_waste_lignin_proportion=data["herbivory_waste_leaf_lignin"],
     )
     root_lignin = data["root_lignin"]
     stem_lignin = data["stem_lignin"]
 
     return {
-        "leaf_mass": leaf_rates.sel(element="C").to_numpy(),
-        "deadwood_mass": deadwood_rates.sel(element="C").to_numpy(),
-        "root_mass": root_rates.sel(element="C").to_numpy(),
+        "leaf_mass": leaf_rates,
+        "deadwood_mass": deadwood_rates,
+        "root_mass": root_rates,
         "leaf_lignin": leaf_lignin,
-        "root_lignin": root_lignin.to_numpy(),
-        "stem_lignin": stem_lignin.to_numpy(),
-        "leaf_nitrogen": leaf_rates.sel(element="N").to_numpy(),
-        "root_nitrogen": root_rates.sel(element="N").to_numpy(),
-        "deadwood_nitrogen": deadwood_rates.sel(element="N").to_numpy(),
-        "leaf_phosphorus": leaf_rates.sel(element="P").to_numpy(),
-        "root_phosphorus": root_rates.sel(element="P").to_numpy(),
-        "deadwood_phosphorus": deadwood_rates.sel(element="P").to_numpy(),
+        "root_lignin": root_lignin,
+        "stem_lignin": stem_lignin,
     }
 
 
 def calculate_metabolic_proportions_of_input(
-    total_input: dict[str, NDArray[np.floating]], constants: LitterConstants
-) -> dict[str, NDArray[np.floating]]:
+    total_input: dict[str, DataArray], constants: LitterConstants
+) -> dict[str, DataArray]:
     """Calculate the proportion of each input type that flows to the metabolic pool.
 
     This function is used for roots, leaves and reproductive tissue, but not deadwood
@@ -223,20 +195,16 @@ def calculate_metabolic_proportions_of_input(
 
     # Calculate split of each input biomass type
     leaves_metabolic_split = split_pool_into_metabolic_and_structural_litter(
-        input_carbon=total_input["leaf_mass"],
+        input_masses=total_input["leaf_mass"],
         lignin_proportion=total_input["leaf_lignin"],
-        input_nitrogen=total_input["leaf_nitrogen"],
-        input_phosphorus=total_input["leaf_phosphorus"],
         max_metabolic_fraction=constants.max_metabolic_fraction_of_input,
         split_sensitivity_nitrogen=constants.metabolic_split_nitrogen_sensitivity,
         split_sensitivity_phosphorus=constants.metabolic_split_phosphorus_sensitivity,
     )
 
     roots_metabolic_split = split_pool_into_metabolic_and_structural_litter(
-        input_carbon=total_input["root_mass"],
+        input_masses=total_input["root_mass"],
         lignin_proportion=total_input["root_lignin"],
-        input_nitrogen=total_input["root_nitrogen"],
-        input_phosphorus=total_input["root_phosphorus"],
         max_metabolic_fraction=constants.max_metabolic_fraction_of_input,
         split_sensitivity_nitrogen=constants.metabolic_split_nitrogen_sensitivity,
         split_sensitivity_phosphorus=constants.metabolic_split_phosphorus_sensitivity,
@@ -249,9 +217,9 @@ def calculate_metabolic_proportions_of_input(
 
 
 def partion_plant_inputs_between_pools(
-    total_input: dict[str, NDArray[np.floating]],
-    metabolic_splits: dict[str, NDArray[np.floating]],
-):
+    total_input: dict[str, DataArray],
+    metabolic_splits: dict[str, DataArray],
+) -> dict[str, DataArray]:
     """Function to partition input biomass between the various litter pools.
 
     All deadwood is added to the woody litter pool. Leaf biomass is split between the
@@ -275,19 +243,19 @@ def partion_plant_inputs_between_pools(
     """
 
     # Calculate input to each of the five litter pools
-    woody_input = total_input["deadwood_mass"]
-    above_ground_metabolic_input = (
-        metabolic_splits["leaves_meta_split"] * total_input["leaf_mass"]
-    )
+    woody_input = total_input["deadwood_mass"].sel(element="C")
+    above_ground_metabolic_input = metabolic_splits["leaves_meta_split"] * total_input[
+        "leaf_mass"
+    ].sel(element="C")
     above_ground_strutural_input = (
         1 - metabolic_splits["leaves_meta_split"]
-    ) * total_input["leaf_mass"]
-    below_ground_metabolic_input = (
-        metabolic_splits["roots_meta_split"] * total_input["root_mass"]
-    )
+    ) * total_input["leaf_mass"].sel(element="C")
+    below_ground_metabolic_input = metabolic_splits["roots_meta_split"] * total_input[
+        "root_mass"
+    ].sel(element="C")
     below_ground_structural_input = (
         1 - metabolic_splits["roots_meta_split"]
-    ) * total_input["root_mass"]
+    ) * total_input["root_mass"].sel(element="C")
 
     return {
         "woody": woody_input,
@@ -299,25 +267,21 @@ def partion_plant_inputs_between_pools(
 
 
 def split_pool_into_metabolic_and_structural_litter(
-    input_carbon: NDArray[np.floating],
-    lignin_proportion: NDArray[np.floating],
-    input_nitrogen: NDArray[np.floating],
-    input_phosphorus: NDArray[np.floating],
+    input_masses: DataArray,
+    lignin_proportion: DataArray,
     max_metabolic_fraction: float,
     split_sensitivity_nitrogen: float,
     split_sensitivity_phosphorus: float,
-) -> NDArray[np.floating]:
+):
     """Calculate the split of input biomass between metabolic and structural pools.
 
     This division depends on the lignin, nitrogen and phosphorus contents of the input
     biomass, the functional form is taken from :cite:t:`parton_dynamics_1988`.
 
     Args:
-        input_carbon: Mass of carbon in the input biomass [kg C m^-2]
+        input_masses: Mass of each nutrient in the input biomass [kg C m^-2]
         lignin_proportion: Proportion of input biomass carbon that is lignin
             [kg lignin C (kg C)^-1]
-        input_nitrogen: Mass of nitrogen in the input biomass [kg N m^-2]
-        input_phosphorus: Mass of phosphorus in the input biomass [kg P m^-2]
         max_metabolic_fraction: Fraction of pool that becomes metabolic litter for the
             easiest to breakdown case, i.e. no lignin, ample nitrogen [unitless]
         split_sensitivity_nitrogen: Sets how rapidly the split changes in response to
@@ -339,6 +303,11 @@ def split_pool_into_metabolic_and_structural_litter(
         to_raise = ValueError("Lignin proportion not between 0 and 1 (inclusive)!")
         LOGGER.error(to_raise)
         raise to_raise
+
+    # Extract the specific nutrient masses from the summary
+    input_carbon = input_masses.sel(element="C").to_numpy()
+    input_nitrogen = input_masses.sel(element="N").to_numpy()
+    input_phosphorus = input_masses.sel(element="P").to_numpy()
 
     # Calculate carbon:nitrogen and carbon:phosphorus ratios based on the input
     # biomasses
@@ -376,12 +345,12 @@ def split_pool_into_metabolic_and_structural_litter(
 
 
 def merge_input_lignin_proportions(
-    turnover_mass: NDArray[np.floating],
-    herbivory_waste_mass: NDArray[np.floating],
-    total_mass: NDArray[np.floating],
-    turnover_lignin_proportion: NDArray[np.floating],
-    herbivory_waste_lignin_proportion: NDArray[np.floating],
-):
+    turnover_mass: DataArray,
+    herbivory_waste_mass: DataArray,
+    total_mass: DataArray,
+    turnover_lignin_proportion: DataArray,
+    herbivory_waste_lignin_proportion: DataArray,
+) -> DataArray:
     """Merge the lignin proportions of two input sources to the same litter pool.
 
     Args:
@@ -437,36 +406,36 @@ def average_nutrient_ratios(
 class InputChemistries:
     """Dataclass containing the chemistry for the input to each litter pool."""
 
-    above_metabolic_nitrogen: NDArray[np.floating]
+    above_metabolic_nitrogen: DataArray
     """Nitrogen input rate to the aboveground metabolic pool [kg N m^-2 day^-1]"""
-    above_structural_nitrogen: NDArray[np.floating]
+    above_structural_nitrogen: DataArray
     """Nitrogen input rate to the aboveground structural pool [kg N m^-2 day^-1]"""
-    woody_nitrogen: NDArray[np.floating]
+    woody_nitrogen: DataArray
     """Nitrogen input rate to the woody pool [kg N m^-2 day^-1]"""
-    below_metabolic_nitrogen: NDArray[np.floating]
+    below_metabolic_nitrogen: DataArray
     """Nitrogen input rate to the belowground metabolic pool [kg N m^-2 day^-1]"""
-    below_structural_nitrogen: NDArray[np.floating]
+    below_structural_nitrogen: DataArray
     """Nitrogen input rate to the belowground structural pool [kg N m^-2 day^-1]"""
 
-    above_metabolic_phosphorus: NDArray[np.floating]
+    above_metabolic_phosphorus: DataArray
     """Phosphorus input rate to the aboveground metabolic pool [kg P m^-2 day^-1]"""
-    above_structural_phosphorus: NDArray[np.floating]
+    above_structural_phosphorus: DataArray
     """Phosphorus input rate to the aboveground structural pool [kg P m^-2 day^-1]"""
-    woody_phosphorus: NDArray[np.floating]
+    woody_phosphorus: DataArray
     """Phosphorus input rate to the woody pool [kg P m^-2 day^-1]"""
-    below_metabolic_phosphorus: NDArray[np.floating]
+    below_metabolic_phosphorus: DataArray
     """Phosphorus input rate to the belowground metabolic pool [kg P m^-2 day^-1]"""
-    below_structural_phosphorus: NDArray[np.floating]
+    below_structural_phosphorus: DataArray
     """Phosphorus input rate to the belowground structural pool [kg P m^-2 day^-1]"""
 
-    above_structural_lignin: NDArray[np.floating]
+    above_structural_lignin: DataArray
     """Lignin proportion of input to the aboveground structural pool.
     
     Units of [kg lignin C (kg C)^-1]
     """
-    woody_lignin: NDArray[np.floating]
+    woody_lignin: DataArray
     """Lignin proportion of input to the woody pool [kg lignin C (kg C)^-1]"""
-    below_structural_lignin: NDArray[np.floating]
+    below_structural_lignin: DataArray
     """Lignin proportion of input to the belowground structural pool.
      
     Units of [kg lignin C (kg C)^-1]
@@ -514,7 +483,7 @@ def calculate_input_chemistries(
 
 def calculate_litter_input_lignin_concentrations(
     litter_inputs: LitterInputs,
-) -> dict[str, NDArray[np.floating]]:
+) -> dict[str, DataArray]:
     """Calculate the concentration of lignin for each plant biomass to litter flow.
 
     By definition the metabolic litter pools do not contain lignin, so all input
@@ -545,13 +514,13 @@ def calculate_litter_input_lignin_concentrations(
 
     lignin_proportion_below_structural = (
         litter_inputs.root_lignin
-        * litter_inputs.root_mass
+        * litter_inputs.root_mass.sel(element="C")
         / litter_inputs.below_structural
     )
 
     lignin_proportion_above_structural = (
         litter_inputs.leaf_lignin
-        * litter_inputs.leaf_mass
+        * litter_inputs.leaf_mass.sel(element="C")
         / litter_inputs.above_structural
     )
 
@@ -564,7 +533,7 @@ def calculate_litter_input_lignin_concentrations(
 
 def calculate_litter_input_nutrient_masses(
     litter_inputs: LitterInputs, meta_to_struct_nutrient_ratio: float, nutrient: str
-) -> dict[str, NDArray[np.floating]]:
+) -> dict[str, DataArray]:
     """Calculate the nutrient mass for each plant biomass to litter flow.
 
     Input to the woody litter pool just matches the nutrient masses of the
@@ -591,23 +560,26 @@ def calculate_litter_input_nutrient_masses(
         LOGGER.error(to_raise)
         raise to_raise
 
+    # TODO - This will need a more sophisticated approach if we start tracking potassium
+    element_symbol = nutrient[0].upper()
+
     # Calculate nutrient split for each (non-wood) input biomass type
     root_nutrient_meta, root_nutrient_struct = find_nutrient_split_between_litter_pools(
-        input_carbon_rate=litter_inputs.root_mass,
-        input_nutrient_rate=getattr(litter_inputs, f"root_{nutrient}"),
+        input_carbon_rate=litter_inputs.root_mass.sel(element="C"),
+        input_nutrient_rate=litter_inputs.root_mass.sel(element=element_symbol),
         metabolic_split=litter_inputs.roots_meta_split,
         meta_to_struct_nutrient_ratio=meta_to_struct_nutrient_ratio,
     )
 
     leaf_nutrient_meta, leaf_nutrient_struct = find_nutrient_split_between_litter_pools(
-        input_carbon_rate=litter_inputs.leaf_mass,
-        input_nutrient_rate=getattr(litter_inputs, f"leaf_{nutrient}"),
+        input_carbon_rate=litter_inputs.leaf_mass.sel(element="C"),
+        input_nutrient_rate=litter_inputs.leaf_mass.sel(element=element_symbol),
         metabolic_split=litter_inputs.leaves_meta_split,
         meta_to_struct_nutrient_ratio=meta_to_struct_nutrient_ratio,
     )
 
     return {
-        f"woody_{nutrient}": getattr(litter_inputs, f"deadwood_{nutrient}"),
+        f"woody_{nutrient}": litter_inputs.deadwood_mass.sel(element=element_symbol),
         f"below_metabolic_{nutrient}": root_nutrient_meta,
         f"below_structural_{nutrient}": root_nutrient_struct,
         f"above_metabolic_{nutrient}": leaf_nutrient_meta,
@@ -616,11 +588,11 @@ def calculate_litter_input_nutrient_masses(
 
 
 def find_nutrient_split_between_litter_pools(
-    input_carbon_rate: NDArray[np.floating],
-    input_nutrient_rate: NDArray[np.floating],
-    metabolic_split: NDArray[np.floating],
+    input_carbon_rate: DataArray,
+    input_nutrient_rate: DataArray,
+    metabolic_split: DataArray,
     meta_to_struct_nutrient_ratio: float,
-) -> tuple[NDArray[np.floating], NDArray[np.floating]]:
+) -> tuple[DataArray, DataArray]:
     """Function to find the split of input nutrients between litter pools.
 
     Following :cite:t:`kirschbaum_modelling_2002`, we assume that the nutrient
@@ -653,8 +625,8 @@ def find_nutrient_split_between_litter_pools(
     carbon_input_meta = input_carbon_rate * metabolic_split
     carbon_input_struct = input_carbon_rate * (1 - metabolic_split)
 
-    meta_nutrient_mass = np.empty_like(carbon_input_meta)
-    struct_nutrient_mass = np.empty_like(carbon_input_struct)
+    meta_nutrient_mass = zeros_like(carbon_input_meta)
+    struct_nutrient_mass = zeros_like(carbon_input_struct)
 
     # Defining masks to avoid zero flow edge cases
     struct_input = carbon_input_struct != 0
@@ -663,31 +635,33 @@ def find_nutrient_split_between_litter_pools(
 
     # Calculate actual split in cases where there is flow to the structural pool
     meta_nutrient, struct_nutrient = calculate_nutrient_split(
-        carbon_input_meta[struct_input],
-        carbon_input_struct[struct_input],
-        input_nutrient_rate[struct_input],
+        carbon_input_meta.where(struct_input),
+        carbon_input_struct.where(struct_input),
+        input_nutrient_rate.where(struct_input),
         meta_to_struct_nutrient_ratio,
     )
-    meta_nutrient_mass[struct_input] = meta_nutrient
-    struct_nutrient_mass[struct_input] = struct_nutrient
+    meta_nutrient_mass = meta_nutrient_mass.where(~struct_input, meta_nutrient)
+    struct_nutrient_mass = struct_nutrient_mass.where(~struct_input, struct_nutrient)
 
     # If all carbon goes to metabolic litter all nutrients do as well
-    meta_nutrient_mass[only_meta_input] = input_nutrient_rate[only_meta_input]
-    struct_nutrient_mass[only_meta_input] = 0
+    meta_nutrient_mass = meta_nutrient_mass.where(
+        ~only_meta_input, input_nutrient_rate.where(only_meta_input)
+    )
+    struct_nutrient_mass = struct_nutrient_mass.where(~only_meta_input, 0)
 
     # No carbon input means no nutrient input
-    meta_nutrient_mass[no_input] = 0
-    struct_nutrient_mass[no_input] = 0
+    meta_nutrient_mass = meta_nutrient_mass.where(~no_input, 0)
+    struct_nutrient_mass = struct_nutrient_mass.where(~no_input, 0)
 
     return (meta_nutrient_mass, struct_nutrient_mass)
 
 
 def calculate_nutrient_split(
-    carbon_input_meta: NDArray[np.floating],
-    carbon_input_struct: NDArray[np.floating],
-    input_nutrient_rate: NDArray[np.floating],
+    carbon_input_meta: DataArray,
+    carbon_input_struct: DataArray,
+    input_nutrient_rate: DataArray,
     meta_to_struct_nutrient_ratio: float,
-) -> tuple[NDArray[np.floating], NDArray[np.floating]]:
+) -> tuple[DataArray, DataArray]:
     """Calculate the split of nutrients between metabolic and structural litter pools.
 
     The calculation of this split derives from :cite:t:`kirschbaum_modelling_2002`, and

--- a/virtual_ecosystem/models/litter/losses.py
+++ b/virtual_ecosystem/models/litter/losses.py
@@ -95,31 +95,31 @@ def calculate_litter_losses(
     above_metabolic_carbon = calculate_carbon_pool_loss(
         old_pool_size=original_pools["above_metabolic"].sel(element="C").to_numpy(),
         final_pool_size=final_pools["above_metabolic"],
-        input_rate=litter_inputs.above_metabolic,
+        input_rate=litter_inputs.above_metabolic.to_numpy(),
         update_interval=update_interval,
     )
     above_structural_carbon = calculate_carbon_pool_loss(
         old_pool_size=original_pools["above_structural"].sel(element="C").to_numpy(),
         final_pool_size=final_pools["above_structural"],
-        input_rate=litter_inputs.above_structural,
+        input_rate=litter_inputs.above_structural.to_numpy(),
         update_interval=update_interval,
     )
     woody_carbon = calculate_carbon_pool_loss(
         old_pool_size=original_pools["woody"].sel(element="C").to_numpy(),
         final_pool_size=final_pools["woody"],
-        input_rate=litter_inputs.woody,
+        input_rate=litter_inputs.woody.to_numpy(),
         update_interval=update_interval,
     )
     below_metabolic_carbon = calculate_carbon_pool_loss(
         old_pool_size=original_pools["below_metabolic"].sel(element="C").to_numpy(),
         final_pool_size=final_pools["below_metabolic"],
-        input_rate=litter_inputs.below_metabolic,
+        input_rate=litter_inputs.below_metabolic.to_numpy(),
         update_interval=update_interval,
     )
     below_structural_carbon = calculate_carbon_pool_loss(
         old_pool_size=original_pools["below_structural"].sel(element="C").to_numpy(),
         final_pool_size=final_pools["below_structural"],
-        input_rate=litter_inputs.below_structural,
+        input_rate=litter_inputs.below_structural.to_numpy(),
         update_interval=update_interval,
     )
 
@@ -132,8 +132,8 @@ def calculate_litter_losses(
         .sel(element="N")
         .to_numpy(),
         carbon_loss=above_metabolic_carbon,
-        input_rate_carbon=litter_inputs.above_metabolic,
-        input_rate_nutrient=input_chemistries.above_metabolic_nitrogen,
+        input_rate_carbon=litter_inputs.above_metabolic.to_numpy(),
+        input_rate_nutrient=input_chemistries.above_metabolic_nitrogen.to_numpy(),
         update_interval=update_interval,
     )
     above_structural_nitrogen = calculate_nutrient_pool_loss(
@@ -144,16 +144,16 @@ def calculate_litter_losses(
         .sel(element="N")
         .to_numpy(),
         carbon_loss=above_structural_carbon,
-        input_rate_carbon=litter_inputs.above_structural,
-        input_rate_nutrient=input_chemistries.above_structural_nitrogen,
+        input_rate_carbon=litter_inputs.above_structural.to_numpy(),
+        input_rate_nutrient=input_chemistries.above_structural_nitrogen.to_numpy(),
         update_interval=update_interval,
     )
     woody_nitrogen = calculate_nutrient_pool_loss(
         initial_pool_carbon=original_pools["woody"].sel(element="C").to_numpy(),
         initial_pool_nutrient=original_pools["woody"].sel(element="N").to_numpy(),
         carbon_loss=woody_carbon,
-        input_rate_carbon=litter_inputs.woody,
-        input_rate_nutrient=input_chemistries.woody_nitrogen,
+        input_rate_carbon=litter_inputs.woody.to_numpy(),
+        input_rate_nutrient=input_chemistries.woody_nitrogen.to_numpy(),
         update_interval=update_interval,
     )
     below_metabolic_nitrogen = calculate_nutrient_pool_loss(
@@ -164,8 +164,8 @@ def calculate_litter_losses(
         .sel(element="N")
         .to_numpy(),
         carbon_loss=below_metabolic_carbon,
-        input_rate_carbon=litter_inputs.below_metabolic,
-        input_rate_nutrient=input_chemistries.below_metabolic_nitrogen,
+        input_rate_carbon=litter_inputs.below_metabolic.to_numpy(),
+        input_rate_nutrient=input_chemistries.below_metabolic_nitrogen.to_numpy(),
         update_interval=update_interval,
     )
     below_structural_nitrogen = calculate_nutrient_pool_loss(
@@ -176,8 +176,8 @@ def calculate_litter_losses(
         .sel(element="N")
         .to_numpy(),
         carbon_loss=below_structural_carbon,
-        input_rate_carbon=litter_inputs.below_structural,
-        input_rate_nutrient=input_chemistries.below_structural_nitrogen,
+        input_rate_carbon=litter_inputs.below_structural.to_numpy(),
+        input_rate_nutrient=input_chemistries.below_structural_nitrogen.to_numpy(),
         update_interval=update_interval,
     )
 
@@ -190,8 +190,8 @@ def calculate_litter_losses(
         .sel(element="P")
         .to_numpy(),
         carbon_loss=above_metabolic_carbon,
-        input_rate_carbon=litter_inputs.above_metabolic,
-        input_rate_nutrient=input_chemistries.above_metabolic_phosphorus,
+        input_rate_carbon=litter_inputs.above_metabolic.to_numpy(),
+        input_rate_nutrient=input_chemistries.above_metabolic_phosphorus.to_numpy(),
         update_interval=update_interval,
     )
     above_structural_phosphorus = calculate_nutrient_pool_loss(
@@ -202,16 +202,16 @@ def calculate_litter_losses(
         .sel(element="P")
         .to_numpy(),
         carbon_loss=above_structural_carbon,
-        input_rate_carbon=litter_inputs.above_structural,
-        input_rate_nutrient=input_chemistries.above_structural_phosphorus,
+        input_rate_carbon=litter_inputs.above_structural.to_numpy(),
+        input_rate_nutrient=input_chemistries.above_structural_phosphorus.to_numpy(),
         update_interval=update_interval,
     )
     woody_phosphorus = calculate_nutrient_pool_loss(
         initial_pool_carbon=original_pools["woody"].sel(element="C").to_numpy(),
         initial_pool_nutrient=original_pools["woody"].sel(element="P").to_numpy(),
         carbon_loss=woody_carbon,
-        input_rate_carbon=litter_inputs.woody,
-        input_rate_nutrient=input_chemistries.woody_phosphorus,
+        input_rate_carbon=litter_inputs.woody.to_numpy(),
+        input_rate_nutrient=input_chemistries.woody_phosphorus.to_numpy(),
         update_interval=update_interval,
     )
     below_metabolic_phosphorus = calculate_nutrient_pool_loss(
@@ -222,8 +222,8 @@ def calculate_litter_losses(
         .sel(element="P")
         .to_numpy(),
         carbon_loss=below_metabolic_carbon,
-        input_rate_carbon=litter_inputs.below_metabolic,
-        input_rate_nutrient=input_chemistries.below_metabolic_phosphorus,
+        input_rate_carbon=litter_inputs.below_metabolic.to_numpy(),
+        input_rate_nutrient=input_chemistries.below_metabolic_phosphorus.to_numpy(),
         update_interval=update_interval,
     )
     below_structural_phosphorus = calculate_nutrient_pool_loss(
@@ -234,8 +234,8 @@ def calculate_litter_losses(
         .sel(element="P")
         .to_numpy(),
         carbon_loss=below_structural_carbon,
-        input_rate_carbon=litter_inputs.below_structural,
-        input_rate_nutrient=input_chemistries.below_structural_phosphorus,
+        input_rate_carbon=litter_inputs.below_structural.to_numpy(),
+        input_rate_nutrient=input_chemistries.below_structural_phosphorus.to_numpy(),
         update_interval=update_interval,
     )
 
@@ -245,17 +245,17 @@ def calculate_litter_losses(
         .sel(element="C")
         .to_numpy(),
         carbon_loss=above_structural_carbon,
-        input_rate=litter_inputs.above_structural,
+        input_rate=litter_inputs.above_structural.to_numpy(),
         initial_lignin_proportion=data["lignin_above_structural"].to_numpy(),
-        input_lignin_proportion=input_chemistries.above_structural_lignin,
+        input_lignin_proportion=input_chemistries.above_structural_lignin.to_numpy(),
         update_interval=update_interval,
     )
     woody_lignin = calculate_lignin_pool_loss(
         initial_pool_size=original_pools["woody"].sel(element="C").to_numpy(),
         carbon_loss=woody_carbon,
-        input_rate=litter_inputs.woody,
+        input_rate=litter_inputs.woody.to_numpy(),
         initial_lignin_proportion=data["lignin_woody"].to_numpy(),
-        input_lignin_proportion=input_chemistries.woody_lignin,
+        input_lignin_proportion=input_chemistries.woody_lignin.to_numpy(),
         update_interval=update_interval,
     )
     below_structural_lignin = calculate_lignin_pool_loss(
@@ -263,9 +263,9 @@ def calculate_litter_losses(
         .sel(element="C")
         .to_numpy(),
         carbon_loss=below_structural_carbon,
-        input_rate=litter_inputs.below_structural,
+        input_rate=litter_inputs.below_structural.to_numpy(),
         initial_lignin_proportion=data["lignin_below_structural"].to_numpy(),
-        input_lignin_proportion=input_chemistries.below_structural_lignin,
+        input_lignin_proportion=input_chemistries.below_structural_lignin.to_numpy(),
         update_interval=update_interval,
     )
 


### PR DESCRIPTION
# Description

Basically just the title.

I then had to switch a significant portion of the litter model to use `DataArray` instead of `Numpy[np.floating]` in order to satisfy `mypy`, which I guess is a cleaner approach

Fixes #1556

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
