### PR TITLE
initialise diurnal range with values

### DIFF
--- a/virtual_ecosystem/models/abiotic/abiotic_model.py
+++ b/virtual_ecosystem/models/abiotic/abiotic_model.py
@@ -216,8 +216,12 @@ class AbioticModel(
             bounds=self.bounds,
         )
 
-        # Initialise diurnal temperature range
-        self.data["diurnal_temperature_range"] = self.layer_structure.from_template()
+        # Initialise diurnal temperature range, [C]
+        diurnal_temperature_range = initial_microclimate["air_temperature"].copy()
+        self.data["diurnal_temperature_range"] = diurnal_temperature_range.where(
+            diurnal_temperature_range.isnull(),
+            other=5.0,  # TODO add data when available
+        )
 
         # Generate initial profiles of canopy temperature and heat fluxes from soil and
         # canopy

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -970,28 +970,28 @@ def build_output_from_record(
         if var not in vars_set:
             continue
 
-        values = np.asarray(values)
+        values_arr = np.asarray(values)
 
         # detect time dimension
-        if values.ndim > 1:
+        if values_arr.ndim > 1:
             if var == "diurnal_temperature_range":
                 min_value = np.nanmin(data_record["air_temperature"], axis=0)
                 max_value = np.nanmax(data_record["air_temperature"], axis=0)
-                values = max_value - min_value
+                values_out = max_value - min_value
             else:
-                values = np.nanmean(values, axis=0)
+                values_out = np.nanmean(values_arr, axis=0)
 
         # assign dims
-        if values.ndim == 1:
+        if values_out.ndim == 1:
             dims = ["cell_id"]
-        elif values.ndim == 2:
+        elif values_out.ndim == 2:
             dims = ["layers", "cell_id"]
         else:
             raise ValueError(
                 f"Unsupported dimensions for variable '{var}': {values.shape}"
             )
 
-        output[var] = DataArray(values, dims=dims)
+        output[var] = DataArray(values_out, dims=dims)
 
     # check for requested variables that never appeared
     missing = vars_set - output.keys()


### PR DESCRIPTION
This PR adds values to the initialization of diurnal temperature range, this caused a warning in the past.
I also slightly renamed a variable to avoid overwriting in a loop.

Fixes #1609 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

