### PR TITLE
Added control for negative values in several soil functions

### DIFF
--- a/tests/models/soil/test_pools.py
+++ b/tests/models/soil/test_pools.py
@@ -1032,6 +1032,41 @@ def test_find_necromass_nutrient_outflows(
         assert np.allclose(expected_rates[key], actual_rates[key])
 
 
+def test_find_necromass_nutrient_outflows_negatives(
+    dummy_carbon_data, necromass_breakdown, necromass_sorption
+):
+    """Test that function to find necromass nutrient losses handles negative values."""
+    from virtual_ecosystem.models.soil.pools import find_necromass_nutrient_outflows
+
+    necromass_carbon = dummy_carbon_data["soil_cnp_pool_necromass"].sel(element="C")
+    necromass_nitrogen = dummy_carbon_data["soil_cnp_pool_necromass"].sel(element="N")
+    necromass_phosphorus = dummy_carbon_data["soil_cnp_pool_necromass"].sel(element="P")
+    # Add negative values in
+    necromass_carbon[0] = -0.98
+    necromass_nitrogen[3] = -0.33
+    necromass_phosphorus[1] = -0.01
+
+    expected_rates = {
+        "decay_nitrogen": [0.0, 0.00413222, 0.00466541, 0.0],
+        "sorption_nitrogen": [0.0, 0.01239667, 0.01399624, 0.0],
+        "decay_phosphorus": [0.0, 0.0, 1.65287877e-4, 1.03082538e-4],
+        "sorption_phosphorus": [0.0, 0.0, 4.958636e-4, 3.0924762e-4],
+    }
+
+    actual_rates = find_necromass_nutrient_outflows(
+        necromass_carbon=necromass_carbon,
+        necromass_nitrogen=necromass_nitrogen,
+        necromass_phosphorus=necromass_phosphorus,
+        necromass_decay=necromass_breakdown,
+        necromass_sorption=necromass_sorption,
+    )
+
+    assert set(expected_rates.keys()) == set(actual_rates.keys())
+
+    for key in expected_rates.keys():
+        assert np.allclose(expected_rates[key], actual_rates[key])
+
+
 def test_calculate_net_nutrient_transfers_from_maom_to_lmwc(
     dummy_carbon_data, enzyme_mediated_rates, lmwc_sorption, maom_desorption
 ):

--- a/tests/models/soil/test_pools.py
+++ b/tests/models/soil/test_pools.py
@@ -1005,6 +1005,31 @@ def test_calculate_soil_nutrient_mineralisation(
     assert np.allclose(actual_rate, expected_rate)
 
 
+def test_calculate_soil_nutrient_mineralisation_negatives(
+    dummy_carbon_data, enzyme_mediated_rates
+):
+    """Test soil nutrient mineralisation calculation handles negative values."""
+    from virtual_ecosystem.models.soil.pools import (
+        calculate_soil_nutrient_mineralisation,
+    )
+
+    pool_carbon = dummy_carbon_data["soil_cnp_pool_pom"].sel(element="C")
+    pool_nutrient = dummy_carbon_data["soil_cnp_pool_pom"].sel(element="N")
+    # Add negative values in
+    pool_carbon[2] = -1.11
+    pool_nutrient[1] = -0.99
+
+    expected_rate = [0.00013585646, 0.0, 0.0, 1.15848952e-5]
+
+    actual_rate = calculate_soil_nutrient_mineralisation(
+        pool_carbon=pool_carbon,
+        pool_nutrient=pool_nutrient,
+        breakdown_rate=enzyme_mediated_rates.pom_to_lmwc,
+    )
+
+    assert np.allclose(actual_rate, expected_rate)
+
+
 def test_calculate_nutrient_flows_to_necromass(
     functional_groups, enzyme_changes, enzyme_classes, biomass_losses
 ):

--- a/tests/models/soil/test_pools.py
+++ b/tests/models/soil/test_pools.py
@@ -884,6 +884,27 @@ def test_calculate_necromass_breakdown(dummy_carbon_data, fixture_soil_constants
     assert np.allclose(actual_breakdown, expected_breakdown)
 
 
+def test_calculate_necromass_breakdown_negative(
+    dummy_carbon_data, fixture_soil_constants
+):
+    """Check that necromass breakdown to lmwc handles negative values."""
+
+    from virtual_ecosystem.models.soil.pools import calculate_necromass_breakdown
+
+    expected_breakdown = [0.0134008455, 0.0, 0.0214875626, 0.0242601513]
+
+    # Add negative necromass value in
+    necromasses = dummy_carbon_data["soil_cnp_pool_necromass"].sel(element="C")
+    necromasses[1] = -5.5e-3
+
+    actual_breakdown = calculate_necromass_breakdown(
+        soil_c_pool_necromass=necromasses,
+        necromass_decay_rate=fixture_soil_constants.necromass_decay_rate,
+    )
+
+    assert np.allclose(actual_breakdown, expected_breakdown)
+
+
 def test_calculate_litter_mineralisation_fluxes(
     dummy_carbon_data, fixture_soil_constants
 ):

--- a/tests/models/soil/test_pools.py
+++ b/tests/models/soil/test_pools.py
@@ -1142,7 +1142,7 @@ def test_find_necromass_nutrient_outflows_negatives(
 def test_calculate_net_nutrient_transfers_from_maom_to_lmwc(
     dummy_carbon_data, enzyme_mediated_rates, lmwc_sorption, maom_desorption
 ):
-    """Test function to find net exchange of nitrogen between maom and don."""
+    """Test function to calculate net nutrient exchange between maom and lmwc."""
     from virtual_ecosystem.models.soil.pools import (
         calculate_net_nutrient_transfers_from_maom_to_lmwc,
     )
@@ -1159,6 +1159,53 @@ def test_calculate_net_nutrient_transfers_from_maom_to_lmwc(
         maom_carbon=dummy_carbon_data["soil_cnp_pool_maom"].sel(element="C"),
         maom_nitrogen=dummy_carbon_data["soil_cnp_pool_maom"].sel(element="N"),
         maom_phosphorus=dummy_carbon_data["soil_cnp_pool_maom"].sel(element="P"),
+        maom_breakdown=enzyme_mediated_rates.maom_to_lmwc,
+        maom_desorption=maom_desorption,
+        lmwc_sorption=lmwc_sorption,
+    )
+
+    assert set(expected_transfers.keys()) == set(actual_transfers.keys())
+
+    for key in expected_transfers.keys():
+        assert np.allclose(expected_transfers[key], actual_transfers[key])
+
+
+def test_calculate_net_nutrient_transfers_from_maom_to_lmwc_negatives(
+    dummy_carbon_data, enzyme_mediated_rates, lmwc_sorption, maom_desorption
+):
+    """Check net nutrient exchange between maom and lmwc handles negatives."""
+    from virtual_ecosystem.models.soil.pools import (
+        calculate_net_nutrient_transfers_from_maom_to_lmwc,
+    )
+
+    lmwc_carbon = dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="C")
+    lmwc_nitrogen = dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="N")
+    lmwc_phosphorus = dummy_carbon_data["soil_cnp_pool_lmwc"].sel(element="P")
+    maom_carbon = dummy_carbon_data["soil_cnp_pool_maom"].sel(element="C")
+    maom_nitrogen = dummy_carbon_data["soil_cnp_pool_maom"].sel(element="N")
+    maom_phosphorus = dummy_carbon_data["soil_cnp_pool_maom"].sel(element="P")
+    # Add negative values
+    lmwc_carbon[0] = -1.23
+    maom_carbon[0] = -3.45
+    lmwc_nitrogen[1] = -2.3
+    maom_nitrogen[1] = -4.6
+    lmwc_phosphorus[2] = -0.23
+    maom_phosphorus[2] = -0.46
+    lmwc_nitrogen[3] = -0.99
+    maom_phosphorus[3] = -0.11
+
+    expected_transfers = {
+        "nitrogen": [0.0, 0.0, 0.00073268, 5.76843536e-6],
+        "phosphorus": [0.0, 0.00014283379, 0.0, -1.1428568e-7],
+    }
+
+    actual_transfers = calculate_net_nutrient_transfers_from_maom_to_lmwc(
+        lmwc_carbon=lmwc_carbon,
+        lmwc_nitrogen=lmwc_nitrogen,
+        lmwc_phosphorus=lmwc_phosphorus,
+        maom_carbon=maom_carbon,
+        maom_nitrogen=maom_nitrogen,
+        maom_phosphorus=maom_phosphorus,
         maom_breakdown=enzyme_mediated_rates.maom_to_lmwc,
         maom_desorption=maom_desorption,
         lmwc_sorption=lmwc_sorption,

--- a/tests/models/soil/test_pools.py
+++ b/tests/models/soil/test_pools.py
@@ -802,6 +802,34 @@ def test_calculate_enzyme_mediated_decomposition(
     assert np.allclose(actual_decomp, expected_decomp)
 
 
+def test_calculate_enzyme_mediated_decomposition_negatives(
+    dummy_carbon_data, fixture_core_components, environmental_factors, enzyme_classes
+):
+    """Check that particulate organic matter decomposition handles negatives."""
+    from virtual_ecosystem.models.soil.pools import (
+        calculate_enzyme_mediated_decomposition,
+    )
+
+    soil_c_pool = dummy_carbon_data["soil_cnp_pool_pom"].sel(element="C")
+    soil_enzyme = dummy_carbon_data["soil_enzyme_pom_bacteria"]
+    soil_c_pool[0] = -3.45e-5
+    soil_enzyme[3] = -1.23e-3
+
+    expected_decomp = [0.0, 8.91990315e-3, 1.66740158e-2, 0.0]
+
+    actual_decomp = calculate_enzyme_mediated_decomposition(
+        soil_c_pool=dummy_carbon_data["soil_cnp_pool_pom"].sel(element="C"),
+        soil_enzyme=dummy_carbon_data["soil_enzyme_pom_bacteria"],
+        soil_temp=dummy_carbon_data["soil_temperature"][
+            fixture_core_components.layer_structure.index_topsoil_scalar
+        ],
+        env_factors=environmental_factors,
+        enzyme_class=enzyme_classes["bacteria_pom"],
+    )
+
+    assert np.allclose(actual_decomp, expected_decomp)
+
+
 def test_calculate_maom_desorption(dummy_carbon_data, fixture_soil_constants):
     """Check that mineral associated matter desorption is calculated correctly."""
 

--- a/tests/models/soil/test_pools.py
+++ b/tests/models/soil/test_pools.py
@@ -818,8 +818,8 @@ def test_calculate_enzyme_mediated_decomposition_negatives(
     expected_decomp = [0.0, 8.91990315e-3, 1.66740158e-2, 0.0]
 
     actual_decomp = calculate_enzyme_mediated_decomposition(
-        soil_c_pool=dummy_carbon_data["soil_cnp_pool_pom"].sel(element="C"),
-        soil_enzyme=dummy_carbon_data["soil_enzyme_pom_bacteria"],
+        soil_c_pool=soil_c_pool,
+        soil_enzyme=soil_enzyme,
         soil_temp=dummy_carbon_data["soil_temperature"][
             fixture_core_components.layer_structure.index_topsoil_scalar
         ],

--- a/tests/models/soil/test_pools.py
+++ b/tests/models/soil/test_pools.py
@@ -845,6 +845,25 @@ def test_calculate_maom_desorption(dummy_carbon_data, fixture_soil_constants):
     assert np.allclose(actual_desorption, expected_desorption)
 
 
+def test_calculate_maom_desorption_negatives(dummy_carbon_data, fixture_soil_constants):
+    """Check that mineral associated matter desorption handles negative values."""
+
+    from virtual_ecosystem.models.soil.pools import calculate_maom_desorption
+
+    soil_c_pool_maom = dummy_carbon_data["soil_cnp_pool_maom"].sel(element="C")
+    # Add negative value
+    soil_c_pool_maom[3] = -3.33e-3
+
+    expected_desorption = [2.5e-5, 1.7e-5, 4.5e-5, 0.0]
+
+    actual_desorption = calculate_maom_desorption(
+        soil_c_pool_maom=soil_c_pool_maom,
+        desorption_rate_constant=fixture_soil_constants.maom_desorption_rate,
+    )
+
+    assert np.allclose(actual_desorption, expected_desorption)
+
+
 @pytest.mark.parametrize(
     "pool_name,sorption_rate_constant,expected_sorption",
     [

--- a/tests/models/soil/test_pools.py
+++ b/tests/models/soil/test_pools.py
@@ -761,6 +761,24 @@ def test_calculate_enzyme_turnover(dummy_carbon_data, turnover, expected_decay):
     assert np.allclose(actual_decay, expected_decay)
 
 
+def test_calculate_enzyme_turnover_negatives(dummy_carbon_data):
+    """Check that enzyme turnover rates handle negative values."""
+    from virtual_ecosystem.models.soil.pools import calculate_enzyme_turnover
+
+    expected_decay = [0.000544296, 0.000229824, 0.0, 7.224e-5]
+
+    # Add negative enzyme pool in
+    enzyme_pool_sizes = dummy_carbon_data["soil_enzyme_pom_bacteria"]
+    enzyme_pool_sizes[2] = -3.4e-2
+
+    actual_decay = calculate_enzyme_turnover(
+        enzyme_pool=enzyme_pool_sizes,
+        turnover_rate=2.4e-2,
+    )
+
+    assert np.allclose(actual_decay, expected_decay)
+
+
 def test_calculate_enzyme_mediated_decomposition(
     dummy_carbon_data, fixture_core_components, environmental_factors, enzyme_classes
 ):

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -1843,19 +1843,32 @@ def calculate_net_nutrient_transfers_from_maom_to_lmwc(
         phosphorus [kg nutrient m^-3 day^-1]
     """
 
-    # Find carbon:nitrogen ratio of the lwmc and maom
-    c_n_ratio_lmwc = lmwc_carbon / lmwc_nitrogen
-    c_n_ratio_maom = maom_carbon / maom_nitrogen
-
-    maom_nitrogen_gain = lmwc_sorption / c_n_ratio_lmwc
-    maom_nitrogen_loss = (maom_breakdown + maom_desorption) / c_n_ratio_maom
-
-    # Find carbon:phosphorus ratio of the lwmc and maom
-    c_p_ratio_lmwc = lmwc_carbon / lmwc_phosphorus
-    c_p_ratio_maom = maom_carbon / maom_phosphorus
-
-    maom_phosphorus_gain = lmwc_sorption / c_p_ratio_lmwc
-    maom_phosphorus_loss = (maom_breakdown + maom_desorption) / c_p_ratio_maom
+    # Find gain and loss for MAOM separately (negatives have to be controlled for by
+    # setting rates to zero)
+    maom_nitrogen_gain = np.divide(
+        lmwc_sorption * lmwc_nitrogen,
+        lmwc_carbon,
+        out=np.zeros_like(lmwc_sorption, dtype=float),
+        where=(lmwc_carbon > 0) & (lmwc_nitrogen > 0),
+    )
+    maom_nitrogen_loss = np.divide(
+        (maom_breakdown + maom_desorption) * maom_nitrogen,
+        maom_carbon,
+        out=np.zeros_like(lmwc_sorption, dtype=float),
+        where=(maom_carbon > 0) & (maom_nitrogen > 0),
+    )
+    maom_phosphorus_gain = np.divide(
+        lmwc_sorption * lmwc_phosphorus,
+        lmwc_carbon,
+        out=np.zeros_like(lmwc_sorption, dtype=float),
+        where=(lmwc_carbon > 0) & (lmwc_phosphorus > 0),
+    )
+    maom_phosphorus_loss = np.divide(
+        (maom_breakdown + maom_desorption) * maom_phosphorus,
+        maom_carbon,
+        out=np.zeros_like(lmwc_sorption, dtype=float),
+        where=(maom_carbon > 0) & (maom_phosphorus > 0),
+    )
 
     return {
         "nitrogen": maom_nitrogen_loss - maom_nitrogen_gain,

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -1561,7 +1561,9 @@ def calculate_necromass_breakdown(
         The amount of necromass that breakdown to LMWC [kg C m^-3 day^-1]
     """
 
-    return necromass_decay_rate * soil_c_pool_necromass
+    return np.where(
+        soil_c_pool_necromass > 0, necromass_decay_rate * soil_c_pool_necromass, 0
+    )
 
 
 def calculate_litter_mineralisation_fluxes(

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -1517,7 +1517,9 @@ def calculate_maom_desorption(
         The rate of MAOM desorption to LMWC [kg C m^-3 day^-1]
     """
 
-    return desorption_rate_constant * soil_c_pool_maom
+    return np.where(
+        soil_c_pool_maom > 0.0, desorption_rate_constant * soil_c_pool_maom, 0.0
+    )
 
 
 def calculate_sorption_to_maom(

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -1492,8 +1492,10 @@ def calculate_enzyme_mediated_decomposition(
         * env_factors.clay_saturation
     )
 
-    return (
-        rate_constant * soil_enzyme * soil_c_pool / (saturation_constant + soil_c_pool)
+    return np.where(
+        (soil_enzyme > 0.0) & (soil_c_pool > 0.0),
+        rate_constant * soil_enzyme * soil_c_pool / (saturation_constant + soil_c_pool),
+        0.0,
     )
 
 

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -1765,15 +1765,33 @@ def find_necromass_nutrient_outflows(
         m^-3 day^-1].
     """
 
-    # Find carbon:nitrogen and carbon:phosphorus ratios of the necromass
-    c_n_ratio = necromass_carbon / necromass_nitrogen
-    c_p_ratio = necromass_carbon / necromass_phosphorus
-
+    # If either necromass carbon or the relevant nutrient is negative, this is treated
+    # as zero so there is no flow
     return {
-        "decay_nitrogen": necromass_decay / c_n_ratio,
-        "sorption_nitrogen": necromass_sorption / c_n_ratio,
-        "decay_phosphorus": necromass_decay / c_p_ratio,
-        "sorption_phosphorus": necromass_sorption / c_p_ratio,
+        "decay_nitrogen": np.divide(
+            necromass_decay * necromass_nitrogen,
+            necromass_carbon,
+            out=np.zeros_like(necromass_carbon, dtype=float),
+            where=(necromass_carbon > 0) & (necromass_nitrogen > 0),
+        ),
+        "sorption_nitrogen": np.divide(
+            necromass_sorption * necromass_nitrogen,
+            necromass_carbon,
+            out=np.zeros_like(necromass_carbon, dtype=float),
+            where=(necromass_carbon > 0) & (necromass_nitrogen > 0),
+        ),
+        "decay_phosphorus": np.divide(
+            necromass_decay * necromass_phosphorus,
+            necromass_carbon,
+            out=np.zeros_like(necromass_carbon, dtype=float),
+            where=(necromass_carbon > 0) & (necromass_phosphorus > 0),
+        ),
+        "sorption_phosphorus": np.divide(
+            necromass_sorption * necromass_phosphorus,
+            necromass_carbon,
+            out=np.zeros_like(necromass_carbon, dtype=float),
+            where=(necromass_carbon > 0) & (necromass_phosphorus > 0),
+        ),
     }
 
 

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -1437,7 +1437,7 @@ def calculate_enzyme_turnover(
         The rate at which enzymes are lost from the pool [kg C m^-3 day^-1]
     """
 
-    return turnover_rate * enzyme_pool
+    return np.where(enzyme_pool > 0, turnover_rate * enzyme_pool, 0)
 
 
 def calculate_enzyme_mediated_decomposition(

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -1678,8 +1678,13 @@ def calculate_soil_nutrient_mineralisation(
         breakdown [kg nutrient m^-3 day^-1]
     """
 
-    carbon_nutrient_ratio = pool_carbon / pool_nutrient
-    return breakdown_rate / carbon_nutrient_ratio
+    # Mineralisation should not occur if carbon or nutrient component is negative
+    return np.divide(
+        breakdown_rate * pool_nutrient,
+        pool_carbon,
+        out=np.zeros_like(breakdown_rate, dtype=float),
+        where=(pool_carbon > 0) & (pool_nutrient > 0),
+    )
 
 
 def calculate_nutrient_flows_to_necromass(


### PR DESCRIPTION
# Description

Broad aim here is to ensure that processes stop when the negative pool sizes crop up. This is (a) to handle external errors gracefully, but also (b) to make sure that the ODE solver does not spend time trying to find solutions in the negative domain.

I tried to be systematic this time and look for all functions that don't already control for negative values (previously I just focused on fix ones that caused problems).

Fixes #1615

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [NA] Relevant documentation reviewed and updated
