### PR TITLE
1626 handle canopy layer heights below surface layer

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1028,6 +1028,8 @@ def fixture_static_inputs(
         np.nansum(data["leaf_area_index"][indices.canopy].to_numpy(), axis=0)
     )
 
+    leaf_area_index = data["leaf_area_index"].copy().to_numpy()
+
     evapotranspiration = data["canopy_evaporation"] + data["transpiration"]
 
     atmospheric_pressure = abiotic_tools.update_profile_from_reference(
@@ -1049,7 +1051,7 @@ def fixture_static_inputs(
     atmospheric_layer_geometry = abiotic_tools.calculate_atmospheric_layer_geometry(
         data=data,
         idx=indices,
-        lowest_canopy_layer_correction=0.1,
+        minimum_mixing_depth=abiotic_constants.minimum_mixing_depth,
     )
 
     # Absorbed longwave radiation by canopy, [W m-2]
@@ -1079,6 +1081,7 @@ def fixture_static_inputs(
 
     return {
         "canopy_height": canopy_height,
+        "leaf_area_index": leaf_area_index,
         "lai_sum": leaf_area_index_sum,
         "evapotranspiration": evapotranspiration.to_numpy() / days,
         "atmospheric_pressure": atmospheric_pressure_true,

--- a/tests/models/abiotic/test_abiotic_tools.py
+++ b/tests/models/abiotic/test_abiotic_tools.py
@@ -397,7 +397,7 @@ def test_calculate_atmospheric_layer_geometry(
     result = calculate_atmospheric_layer_geometry(
         data=data,
         idx=idx,
-        lowest_canopy_layer_correction=0.1,
+        minimum_mixing_depth=1.5,
     )
 
     for var in ["heights", "thickness", "layer_midpoints"]:
@@ -407,7 +407,7 @@ def test_calculate_atmospheric_layer_geometry(
         [
             [32.0, 32.0, 32.0, 32.0],
             [30.0, 30.0, 30.0, np.nan],
-            [20.0, 20.0, 0.2, np.nan],
+            [20.0, 20.0, 1.5, np.nan],
             [10.0, np.nan, np.nan, np.nan],
             [0.1, 0.1, 0.1, 0.1],
         ]
@@ -420,8 +420,8 @@ def test_calculate_atmospheric_layer_geometry(
     exp_thickness = np.array(
         [
             [2.0, 2.0, 2.0, 31.9],
-            [10.0, 10.0, 29.8, np.nan],
-            [10.0, 19.9, 0.1, np.nan],
+            [10.0, 10.0, 28.5, np.nan],
+            [10.0, 19.9, 1.4, np.nan],
             [9.9, np.nan, np.nan, np.nan],
             [0.1, 0.1, 0.1, 0.1],
         ]
@@ -433,8 +433,8 @@ def test_calculate_atmospheric_layer_geometry(
     exp_midpoints = np.array(
         [
             [31.0, 31.0, 31.0, 16.05],
-            [25.0, 25.0, 15.1, np.nan],
-            [15.0, 10.05, 0.15, np.nan],
+            [25.0, 25.0, 15.75, np.nan],
+            [15.0, 10.05, 0.8, np.nan],
             [5.05, np.nan, np.nan, np.nan],
             [0.05, 0.05, 0.05, 0.05],
         ]

--- a/tests/models/abiotic/test_microclimate.py
+++ b/tests/models/abiotic/test_microclimate.py
@@ -34,6 +34,7 @@ def test_prepare_static_inputs_returns_consistent_outputs(
     # Check expected keys exist
     expected_keys = {
         "canopy_height",
+        "leaf_area_index",
         "lai_sum",
         "evapotranspiration",
         "atmospheric_pressure",
@@ -51,6 +52,7 @@ def test_prepare_static_inputs_returns_consistent_outputs(
 
     assert result["canopy_height"].shape == (n_cells,)
     assert result["lai_sum"].shape == (n_cells,)
+    assert result["leaf_area_index"].shape == (n_layers, n_cells)
     assert result["evapotranspiration"].shape == (n_layers, n_cells)
     assert result["atmospheric_pressure"].shape == (n_layers, n_cells)
     assert result["atmospheric_co2"].shape == (n_layers, n_cells)
@@ -611,6 +613,7 @@ def test_update_air_temperature(
         abiotic_bounds=abiotic_bounds,
         idx=idx,
         denominator_tolerance=1e-10,
+        min_leaf_area_index_for_mixing=0.1,
     )
 
     # Check output is correct shape and type

--- a/tests/models/abiotic/test_wind.py
+++ b/tests/models/abiotic/test_wind.py
@@ -167,6 +167,22 @@ def test_calculate_mixing_coefficients():
     assert np.all(result >= 0)
     assert_allclose(result, expected, rtol=1e-6)
 
+    # Test zero canopy height edge case
+    zero_canopy_height = np.zeros(3)
+    layer_midpoints_zero = np.array([[np.nan, np.nan, np.nan], [0.1, 0.1, 0.1]])
+    expected_zero_canopy = k * friction_velocity * layer_midpoints_zero
+
+    zero_result = calculate_mixing_coefficients_canopy(
+        layer_midpoints=layer_midpoints_zero,
+        canopy_height=zero_canopy_height,
+        friction_velocity=friction_velocity,
+        von_karman_constant=k,
+        max_mixing_coefficient=1.0,
+        denominator_tolerance=1e-10,
+    )
+
+    assert_allclose(zero_result, expected_zero_canopy)
+
 
 def test_clamp_variable_within_limits():
     """Test clamping of variable within limits."""

--- a/virtual_ecosystem/models/abiotic/abiotic_tools.py
+++ b/virtual_ecosystem/models/abiotic/abiotic_tools.py
@@ -377,16 +377,20 @@ def update_profile_from_reference(
 
 
 def calculate_atmospheric_layer_geometry(
-    data: Data, idx: SimpleNamespace, lowest_canopy_layer_correction: float
+    data: Data, idx: SimpleNamespace, minimum_mixing_depth: float
 ) -> dict[str, NDArray[np.floating]]:
     """Calculate heights, layer thickness, and midpoints for atmospheric layers.
 
     The midpoint values are distances in metres above ground for each cell.
+    For layer heights below the surface layer, a minimum mixing depth is introduced.
+    This is to prevent unrealistically low mixing depths and therefore high temperatures
+    in the lowest canopy layer when the layer height is very low. Note that this is an
+    artificial inflation of the mixing depth.
 
     Args:
         data: Data object
         idx: SimpleNamespace containing layer indices
-        lowest_canopy_layer_correction: Correction factor for lowest canopy layer
+        minimum_mixing_depth: Minimum depth for lowest canopy layer
 
     Returns:
         dict containing heights, thickness, layer_top, layer_midpoints
@@ -396,9 +400,10 @@ def calculate_atmospheric_layer_geometry(
     # surface layer height
     heights = data["layer_heights"].to_numpy().copy()
 
+    # Set minimum mixing depth
     heights[idx.canopy] = np.where(
-        heights[idx.canopy] <= heights[idx.surface],
-        heights[idx.surface] + lowest_canopy_layer_correction,
+        heights[idx.canopy] <= minimum_mixing_depth,
+        minimum_mixing_depth,
         heights[idx.canopy],
     )
     heights_corrected = np.where(

--- a/virtual_ecosystem/models/abiotic/abiotic_tools.py
+++ b/virtual_ecosystem/models/abiotic/abiotic_tools.py
@@ -390,7 +390,7 @@ def calculate_atmospheric_layer_geometry(
     Args:
         data: Data object
         idx: SimpleNamespace containing layer indices
-        minimum_mixing_depth: Minimum depth for lowest canopy layer
+        minimum_mixing_depth: Minimum depth for lowest canopy layer, [m]
 
     Returns:
         dict containing heights, thickness, layer_top, layer_midpoints

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -515,9 +515,13 @@ def calculate_vegetation_temperature(
     )
 
     # Result contains new canopy and understorey temperature
+    mask = np.isfinite(static["leaf_area_index"])
+    canopy_temperature_true = state["canopy_temperature"].copy()
+    canopy_temperature_true[~mask] = np.nan
+
     vegetation_temperature = energy_balance.secant_solve_cells_layers(
         residual_function=residual,
-        initial_guess=state["canopy_temperature"],
+        initial_guess=canopy_temperature_true,
         maxiter_secant=abiotic_constants.maxiter_secant_solver,
         convergence_tolerance=abiotic_constants.convergence_tolerance_secant_solver,
         small_perturbation_second_guess=(
@@ -525,6 +529,7 @@ def calculate_vegetation_temperature(
         ),
         denominator_tolerance=abiotic_constants.denominator_tolerance,
     )
+    vegetation_temperature[~mask] = np.nan
 
     return vegetation_temperature
 

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -54,6 +54,8 @@ def prepare_static_inputs(
         np.nansum(data["leaf_area_index"][idx.canopy].to_numpy(), axis=0)
     )
 
+    leaf_area_index = data["leaf_area_index"].copy().to_numpy()
+
     # Evapotranspiration from plant and hydrology model, [mm per time interval]
     evapotranspiration = (data["canopy_evaporation"] + data["transpiration"]).to_numpy()
 
@@ -79,7 +81,7 @@ def prepare_static_inputs(
     atmospheric_layer_geometry = abiotic_tools.calculate_atmospheric_layer_geometry(
         data=data,
         idx=idx,
-        lowest_canopy_layer_correction=abiotic_constants.lowest_canopy_layer_correction,
+        minimum_mixing_depth=abiotic_constants.minimum_mixing_depth,
     )
 
     # Absorbed longwave radiation, [W m-2]
@@ -102,6 +104,7 @@ def prepare_static_inputs(
 
     return {
         "canopy_height": canopy_height,
+        "leaf_area_index": leaf_area_index,
         "lai_sum": leaf_area_index_sum,
         "evapotranspiration": evapotranspiration,
         "atmospheric_pressure": atmospheric_pressure_true,
@@ -660,6 +663,7 @@ def update_air_temperature(
     abiotic_bounds: AbioticSimpleBounds,
     idx: SimpleNamespace,
     denominator_tolerance: float,
+    min_leaf_area_index_for_mixing: float,
 ) -> NDArray[np.floating]:
     """Update air temperature profiles based on calculated fluxes and turbulent mixing.
 
@@ -669,6 +673,8 @@ def update_air_temperature(
         abiotic_bounds: Bounds for air temperature to ensure physical realism
         idx: Indices for different layer types
         denominator_tolerance: Small value to prevent division by zero in calculations
+        min_leaf_area_index_for_mixing: Minimum leaf area index required for turbulent
+            mixing to occur.
 
     Returns:
         Updated air temperature profiles for microclimate model
@@ -691,8 +697,15 @@ def update_air_temperature(
     )
 
     # Update all air temperatures, [C]
+    # We assume here that if the canopy is very thin, it is in
+    # equilibrium with the air. This is to prevent unrealistic air temperatures when
+    # there is very little canopy.
     air_temperature = np.copy(state["air_temperature"])
-    air_temperature[idx.canopy] = canopy_air_temperature
+    air_temperature[idx.canopy] = np.where(
+        static["leaf_area_index"][idx.canopy] > min_leaf_area_index_for_mixing,
+        canopy_air_temperature,
+        state["air_temperature"][idx.canopy],
+    )
     air_temperature[idx.surface] = surface_air_temperature
 
     air_temperature = wind.mix_and_ventilate(
@@ -910,6 +923,7 @@ def run_hour_step(
         abiotic_bounds=abiotic_bounds,
         idx=idx,
         denominator_tolerance=abiotic_constants.denominator_tolerance,
+        min_leaf_area_index_for_mixing=abiotic_constants.min_leaf_area_index_for_mixing,
     )
     state["air_temperature"] = air_temperature
 

--- a/virtual_ecosystem/models/abiotic/model_config.py
+++ b/virtual_ecosystem/models/abiotic/model_config.py
@@ -200,7 +200,7 @@ class AbioticConstants(AbioticSharedConstants):
     """
 
     min_leaf_area_index_for_mixing: float = 0.5
-    """Minimum leaf area index required for turbulent mixing to occur, dimensionless."""
+    """Minimum leaf area index required for turbulent mixing to occur, [m m-1]."""
 
 
 class AbioticConfiguration(ModelConfigurationRoot):

--- a/virtual_ecosystem/models/abiotic/model_config.py
+++ b/virtual_ecosystem/models/abiotic/model_config.py
@@ -191,9 +191,16 @@ class AbioticConstants(AbioticSharedConstants):
     extinction_coefficient_longwave: float = 0.5
     """Extinction coefficient for longwave radiation, dimensionless."""
 
-    lowest_canopy_layer_correction: float = 0.1
-    """Correction factor for lowest canopy layer ensures it is not below surface layer,
-    [m]."""
+    minimum_mixing_depth: float = 1.5
+    """Minimum mixing depth for lowest canopy layer, [m].
+    
+    This is to prevent unrealistically low mixing depths and therefore high temperatures
+    in the lowest canopy layer when the layer height is very low. Note that this is an
+    artificial inflation of the mixing depth.
+    """
+
+    min_leaf_area_index_for_mixing: float = 0.5
+    """Minimum leaf area index required for turbulent mixing to occur, dimensionless."""
 
 
 class AbioticConfiguration(ModelConfigurationRoot):


### PR DESCRIPTION
This PR keep the model from crashing in the full setup (with `abiotic`) when the plants shrink. There is still an issue with the correct selection of indices - the air temperature exists in all initial canopy layers after the canopy becomes `nan` in some, but this needs some more digging and checking the order of models to make sure all layer values are provided at the right time.

Fixes # 1626

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
