### PR TITLE
Animal - Resource Pool Exporter

### DIFF
--- a/tests/models/animals/conftest.py
+++ b/tests/models/animals/conftest.py
@@ -553,12 +553,51 @@ def dummy_animal_exporter():
 
 
 @pytest.fixture
+def dummy_resource_pool_exporter():
+    """Provide a no-op exporter for resource pool data in AnimalModel tests.
+
+    Returns:
+        An object with a ``dump`` method matching the ResourcePoolDataExporter
+        interface but performing no output.
+    """
+
+    class DummyResourcePoolExporter:
+        """No-op stand-in for ResourcePoolDataExporter."""
+
+        def dump(
+            self,
+            carcass_pools,
+            excrement_pools,
+            fungal_fruiting_pools,
+            soil_pools,
+            resource_pools,
+            time,
+            time_index,
+        ):
+            """Ignore export calls in tests that do not check CSV output.
+
+            Args:
+                carcass_pools: Carcass pools keyed by cell id.
+                excrement_pools: Excrement pools keyed by cell id.
+                fungal_fruiting_pools: Fungal fruiting body pools keyed by cell id.
+                soil_pools: Soil pools keyed by cell id and pool-type string.
+                resource_pools: Flat list of ResourcePool instances.
+                time: Export timestamp.
+                time_index: Index of update.
+            """
+            return None
+
+    return DummyResourcePoolExporter()
+
+
+@pytest.fixture
 def animal_model_instance(
     dummy_animal_data,
     fixture_core_components,
     functional_group_list_instance,
     microbial_c_n_p_ratios,
     dummy_animal_exporter,
+    dummy_resource_pool_exporter,
 ):
     """Fixture for an animal model object used in tests."""
     from copy import deepcopy
@@ -572,7 +611,8 @@ def animal_model_instance(
     return AnimalModel(
         data=clean_data,
         core_components=fixture_core_components,
-        exporter=dummy_animal_exporter,
+        animal_cohort_exporter=dummy_animal_exporter,
+        resource_pool_exporter=dummy_resource_pool_exporter,
         model_constants=AnimalConstants(density_scaling_method="madingley"),
         functional_groups=functional_group_list_instance,
         microbial_c_n_p_ratios=microbial_c_n_p_ratios,
@@ -586,6 +626,7 @@ def animal_model_damuth_instance(
     functional_group_list_instance,
     microbial_c_n_p_ratios,
     dummy_animal_exporter,
+    dummy_resource_pool_exporter,
 ):
     """Fixture for an animal model object used in tests."""
     from copy import deepcopy
@@ -599,7 +640,8 @@ def animal_model_damuth_instance(
     return AnimalModel(
         data=clean_data,
         core_components=fixture_core_components,
-        exporter=dummy_animal_exporter,
+        animal_cohort_exporter=dummy_animal_exporter,
+        resource_pool_exporter=dummy_resource_pool_exporter,
         model_constants=AnimalConstants(density_scaling_method="damuth"),
         functional_groups=functional_group_list_instance,
         microbial_c_n_p_ratios=microbial_c_n_p_ratios,

--- a/tests/models/animals/test_animal_model.py
+++ b/tests/models/animals/test_animal_model.py
@@ -17,6 +17,7 @@ def prepared_animal_model_instance(
     constants_instance,
     microbial_c_n_p_ratios,
     dummy_animal_exporter,
+    dummy_resource_pool_exporter,
 ):
     """Animal model instance in which setup has already been run."""
     from virtual_ecosystem.models.animal.animal_model import AnimalModel
@@ -24,7 +25,8 @@ def prepared_animal_model_instance(
     model = AnimalModel(
         data=dummy_animal_data,
         core_components=fixture_core_components,
-        exporter=dummy_animal_exporter,
+        animal_cohort_exporter=dummy_animal_exporter,
+        resource_pool_exporter=dummy_resource_pool_exporter,
         functional_groups=functional_group_list_instance,
         model_constants=constants_instance,
         microbial_c_n_p_ratios=microbial_c_n_p_ratios,
@@ -48,6 +50,7 @@ class TestAnimalModel:
         functional_group_list_instance,
         microbial_c_n_p_ratios,
         dummy_animal_exporter,
+        dummy_resource_pool_exporter,
     ):
         """Test `AnimalModel` initialization with both scaling methods."""
         from virtual_ecosystem.core.base_model import BaseModel
@@ -58,7 +61,8 @@ class TestAnimalModel:
         model = AnimalModel(
             data=dummy_animal_data,
             core_components=fixture_core_components,
-            exporter=dummy_animal_exporter,
+            animal_cohort_exporter=dummy_animal_exporter,
+            resource_pool_exporter=dummy_resource_pool_exporter,
             functional_groups=functional_group_list_instance,
             model_constants=AnimalConstants(density_scaling_method=scaling_method),
             microbial_c_n_p_ratios=microbial_c_n_p_ratios,
@@ -81,6 +85,7 @@ class TestAnimalModel:
                 (
                     [
                         (INFO, "Animal cohort data exporter not active."),
+                        (INFO, "Resource pool data exporter not active."),
                         (
                             INFO,
                             "Information required to initialise the animal model "
@@ -465,6 +470,7 @@ class TestAnimalModel:
         constants_instance,
         microbial_c_n_p_ratios,
         dummy_animal_exporter,
+        dummy_resource_pool_exporter,
     ):
         """Test calculation of total consumption of soil by animals is correct."""
         from copy import deepcopy
@@ -479,7 +485,8 @@ class TestAnimalModel:
         model = AnimalModel(
             data=litter_soil_data_instance,
             core_components=fixture_core_components,
-            exporter=dummy_animal_exporter,
+            animal_cohort_exporter=dummy_animal_exporter,
+            resource_pool_exporter=dummy_resource_pool_exporter,
             functional_groups=functional_group_list_instance,
             model_constants=constants_instance,
             microbial_c_n_p_ratios=microbial_c_n_p_ratios,
@@ -609,6 +616,7 @@ class TestAnimalModel:
         constants_instance,
         microbial_c_n_p_ratios,
         dummy_animal_exporter,
+        dummy_resource_pool_exporter,
     ):
         """Test that the function to update fungal fruiting bodies works as expected."""
         import numpy as np
@@ -624,7 +632,8 @@ class TestAnimalModel:
         model = AnimalModel(
             data=litter_soil_data_instance,
             core_components=fixture_core_components,
-            exporter=dummy_animal_exporter,
+            animal_cohort_exporter=dummy_animal_exporter,
+            resource_pool_exporter=dummy_resource_pool_exporter,
             functional_groups=functional_group_list_instance,
             model_constants=constants_instance,
             microbial_c_n_p_ratios=microbial_c_n_p_ratios,
@@ -684,6 +693,7 @@ class TestAnimalModel:
         constants_instance,
         microbial_c_n_p_ratios,
         dummy_animal_exporter,
+        dummy_resource_pool_exporter,
     ):
         """Test that updating the data object based on FungalFruitPool changes works."""
         import numpy as np
@@ -696,7 +706,8 @@ class TestAnimalModel:
         model = AnimalModel(
             data=litter_soil_data_instance,
             core_components=fixture_core_components,
-            exporter=dummy_animal_exporter,
+            animal_cohort_exporter=dummy_animal_exporter,
+            resource_pool_exporter=dummy_resource_pool_exporter,
             functional_groups=functional_group_list_instance,
             model_constants=constants_instance,
             microbial_c_n_p_ratios=microbial_c_n_p_ratios,
@@ -716,6 +727,7 @@ class TestAnimalModel:
         constants_instance,
         microbial_c_n_p_ratios,
         dummy_animal_exporter,
+        dummy_resource_pool_exporter,
     ):
         """Test _initialize_communities."""
 
@@ -734,7 +746,8 @@ class TestAnimalModel:
         model = AnimalModel(
             data=animal_data_for_model_instance,
             core_components=fixture_core_components,
-            exporter=dummy_animal_exporter,
+            animal_cohort_exporter=dummy_animal_exporter,
+            resource_pool_exporter=dummy_resource_pool_exporter,
             functional_groups=functional_group_list_instance,
             model_constants=constants_instance,
             microbial_c_n_p_ratios=microbial_c_n_p_ratios,

--- a/tests/models/animals/test_exporter.py
+++ b/tests/models/animals/test_exporter.py
@@ -1210,7 +1210,7 @@ class TestResourcePoolDataExporter:
 
         # one row per cell
         assert len(rows) == 2
-        assert all(r["pool_type"] == "plant_array" for r in rows)
+        assert all(r["pool_type"] == "resource_array" for r in rows)
         assert all(r["pool_name"] == "subcanopy_vegetation_cnp" for r in rows)
         assert all(r["pft"] == "" for r in rows)
         assert all(r["sub_pool"] == "" for r in rows)
@@ -1306,7 +1306,7 @@ class TestResourcePoolDataExporter:
             "excrement",
             "fungal_fruiting",
             "soil",
-            "plant_array",
+            "resource_array",
         }
 
     def test_exporter_runs_inside_animal_model(

--- a/tests/models/animals/test_exporter.py
+++ b/tests/models/animals/test_exporter.py
@@ -427,6 +427,7 @@ class TestAnimalCohortDataExporter:
         fixture_core_components,
         functional_group_list_instance,
         microbial_c_n_p_ratios,
+        dummy_resource_pool_exporter,
     ):
         """Test that the exporter runs correctly inside an AnimalModel.
 
@@ -436,6 +437,7 @@ class TestAnimalCohortDataExporter:
             fixture_core_components: CoreComponents fixture.
             functional_group_list_instance: List of animal functional groups.
             microbial_c_n_p_ratios: Microbial stoichiometry ratios.
+            dummy_resource_pool_exporter: No-op exporter for resource pools.
         """
         from copy import deepcopy
         from pathlib import Path
@@ -470,7 +472,8 @@ class TestAnimalCohortDataExporter:
             model_constants=AnimalConstants(density_scaling_method="madingley"),
             functional_groups=functional_group_list_instance,
             microbial_c_n_p_ratios=microbial_c_n_p_ratios,
-            exporter=exporter,
+            animal_cohort_exporter=exporter,
+            resource_pool_exporter=dummy_resource_pool_exporter,
         )
 
         out_path = output_dir / "animal_cohort_data.csv"
@@ -742,3 +745,627 @@ class TestAnimalCohortDataExporter:
 
         assert exporter._trophic_output_mode == "a"
         assert exporter._write_trophic_header is False
+
+
+class TestResourcePoolDataExporter:
+    """Tests for ResourcePoolDataExporter."""
+
+    def test_from_config_disabled_creates_inactive_exporter(self, tmp_path):
+        """Test that a disabled config creates an inactive exporter.
+
+        Args:
+            tmp_path: Temporary directory provided by pytest.
+        """
+        import numpy as np
+
+        from virtual_ecosystem.models.animal.exporter import ResourcePoolDataExporter
+        from virtual_ecosystem.models.animal.model_config import (
+            ResourcePoolExportConfig,
+        )
+
+        config = ResourcePoolExportConfig(enabled=False, float_format="%0.3f")
+
+        exporter = ResourcePoolDataExporter.from_config(
+            output_directory=tmp_path,
+            config=config,
+        )
+
+        assert exporter._active is False
+        assert exporter._pool_path is None
+        assert exporter.float_format == "%0.3f"
+
+        exporter.dump(
+            carcass_pools={},
+            excrement_pools={},
+            fungal_fruiting_pools={},
+            soil_pools={},
+            resource_pools=[],
+            time=np.datetime64("2000-01-01"),
+            time_index=0,
+        )
+
+        assert (tmp_path / "resource_pool_data.csv").exists() is False
+
+    def test_from_config_enabled_sets_path(self, tmp_path):
+        """Test that an enabled config sets the output path correctly.
+
+        Args:
+            tmp_path: Temporary directory provided by pytest.
+        """
+        from virtual_ecosystem.models.animal.exporter import ResourcePoolDataExporter
+        from virtual_ecosystem.models.animal.model_config import (
+            ResourcePoolExportConfig,
+        )
+
+        config = ResourcePoolExportConfig(enabled=True, float_format="%0.4f")
+
+        exporter = ResourcePoolDataExporter.from_config(
+            output_directory=tmp_path,
+            config=config,
+        )
+
+        assert exporter._active is True
+        assert exporter._pool_path == tmp_path / "resource_pool_data.csv"
+        assert exporter.float_format == "%0.4f"
+
+    def test_from_config_raises_if_output_file_exists(self, tmp_path):
+        """Test that an existing output file raises a ConfigurationError.
+
+        Args:
+            tmp_path: Temporary directory provided by pytest.
+        """
+        from virtual_ecosystem.core.exceptions import ConfigurationError
+        from virtual_ecosystem.models.animal.exporter import ResourcePoolDataExporter
+        from virtual_ecosystem.models.animal.model_config import (
+            ResourcePoolExportConfig,
+        )
+
+        (tmp_path / "resource_pool_data.csv").touch()
+
+        config = ResourcePoolExportConfig(enabled=True)
+
+        with pytest.raises(ConfigurationError):
+            ResourcePoolDataExporter.from_config(
+                output_directory=tmp_path,
+                config=config,
+            )
+
+    def test_from_config_raises_if_output_directory_missing(self, tmp_path):
+        """Test that a missing output directory raises a ConfigurationError.
+
+        Args:
+            tmp_path: Temporary directory provided by pytest.
+        """
+        from virtual_ecosystem.core.exceptions import ConfigurationError
+        from virtual_ecosystem.models.animal.exporter import ResourcePoolDataExporter
+        from virtual_ecosystem.models.animal.model_config import (
+            ResourcePoolExportConfig,
+        )
+
+        config = ResourcePoolExportConfig(enabled=True)
+
+        with pytest.raises(ConfigurationError):
+            ResourcePoolDataExporter.from_config(
+                output_directory=tmp_path / "does_not_exist",
+                config=config,
+            )
+
+    def test_check_and_set_paths_sets_pool_path(self, tmp_path):
+        """Test _check_and_set_paths sets the pool output path.
+
+        Args:
+            tmp_path: Temporary directory provided by pytest.
+        """
+        from virtual_ecosystem.models.animal.exporter import ResourcePoolDataExporter
+
+        exporter = ResourcePoolDataExporter.__new__(ResourcePoolDataExporter)
+        exporter.output_directory = tmp_path
+        exporter._pool_path = None
+
+        exporter._check_and_set_paths()
+
+        assert exporter._pool_path == tmp_path / "resource_pool_data.csv"
+
+    def test_mode_and_header_toggling(self, tmp_path, mocker):
+        """Test that mode and header flags switch from write to append after first dump.
+
+        Args:
+            tmp_path: Temporary directory provided by pytest.
+            mocker: Pytest mocker fixture.
+        """
+        import numpy as np
+        import pandas as pd
+
+        from virtual_ecosystem.models.animal.exporter import ResourcePoolDataExporter
+        from virtual_ecosystem.models.animal.model_config import (
+            ResourcePoolExportConfig,
+        )
+
+        exporter = ResourcePoolDataExporter.from_config(
+            output_directory=tmp_path,
+            config=ResourcePoolExportConfig(enabled=True),
+        )
+
+        assert exporter._output_mode == "w"
+        assert exporter._write_header is True
+
+        carcass_pool = mocker.Mock()
+        carcass_pool.scavengeable_cnp = mocker.Mock(C=1.0, N=0.1, P=0.01)
+        carcass_pool.decomposed_cnp = mocker.Mock(C=0.0, N=0.0, P=0.0)
+
+        t1 = np.datetime64("2001-01-01")
+        t2 = np.datetime64("2001-01-02")
+
+        exporter.dump(
+            carcass_pools={0: [carcass_pool]},
+            excrement_pools={},
+            fungal_fruiting_pools={},
+            soil_pools={},
+            resource_pools=[],
+            time=t1,
+            time_index=0,
+        )
+
+        assert exporter._output_mode == "a"
+        assert exporter._write_header is False
+
+        exporter.dump(
+            carcass_pools={0: [carcass_pool]},
+            excrement_pools={},
+            fungal_fruiting_pools={},
+            soil_pools={},
+            resource_pools=[],
+            time=t2,
+            time_index=1,
+        )
+
+        df = pd.read_csv(tmp_path / "resource_pool_data.csv")
+        # two sub-pools (scavengeable + decomposed) x two time steps
+        assert len(df) == 4
+
+    def test_dump_creates_file_with_expected_columns(self, tmp_path, mocker):
+        """Test that dump creates the CSV with the expected column schema.
+
+        Args:
+            tmp_path: Temporary directory provided by pytest.
+            mocker: Pytest mocker fixture.
+        """
+        import numpy as np
+        import pandas as pd
+
+        from virtual_ecosystem.models.animal.exporter import ResourcePoolDataExporter
+        from virtual_ecosystem.models.animal.model_config import (
+            ResourcePoolExportConfig,
+        )
+
+        exporter = ResourcePoolDataExporter.from_config(
+            output_directory=tmp_path,
+            config=ResourcePoolExportConfig(enabled=True),
+        )
+
+        carcass_pool = mocker.Mock()
+        carcass_pool.scavengeable_cnp = mocker.Mock(C=1.0, N=0.1, P=0.01)
+        carcass_pool.decomposed_cnp = mocker.Mock(C=0.5, N=0.05, P=0.005)
+
+        exporter.dump(
+            carcass_pools={0: [carcass_pool]},
+            excrement_pools={},
+            fungal_fruiting_pools={},
+            soil_pools={},
+            resource_pools=[],
+            time=np.datetime64("2001-01-01"),
+            time_index=0,
+        )
+
+        df = pd.read_csv(tmp_path / "resource_pool_data.csv")
+        assert set(df.columns) == {
+            "time",
+            "time_index",
+            "pool_type",
+            "pool_name",
+            "sub_pool",
+            "pft",
+            "cell_id",
+            "C",
+            "N",
+            "P",
+        }
+
+    def test_dump_no_op_when_inactive(self, tmp_path, mocker):
+        """Test that dump does nothing when the exporter is inactive.
+
+        Args:
+            tmp_path: Temporary directory provided by pytest.
+            mocker: Pytest mocker fixture.
+        """
+        import numpy as np
+
+        from virtual_ecosystem.models.animal.exporter import ResourcePoolDataExporter
+        from virtual_ecosystem.models.animal.model_config import (
+            ResourcePoolExportConfig,
+        )
+
+        exporter = ResourcePoolDataExporter.from_config(
+            output_directory=tmp_path,
+            config=ResourcePoolExportConfig(enabled=False),
+        )
+
+        exporter.dump(
+            carcass_pools={0: [mocker.Mock()]},
+            excrement_pools={},
+            fungal_fruiting_pools={},
+            soil_pools={},
+            resource_pools=[],
+            time=np.datetime64("2001-01-01"),
+            time_index=0,
+        )
+
+        assert (tmp_path / "resource_pool_data.csv").exists() is False
+
+    def test_build_carcass_rows_emits_two_rows_per_pool(self, mocker):
+        """Test _build_carcass_rows emits one scavengeable and one decomposed row.
+
+        Args:
+            mocker: Pytest mocker fixture.
+        """
+        import numpy as np
+
+        from virtual_ecosystem.models.animal.exporter import ResourcePoolDataExporter
+
+        exporter = ResourcePoolDataExporter.__new__(ResourcePoolDataExporter)
+
+        pool = mocker.Mock()
+        pool.scavengeable_cnp = mocker.Mock(C=10.0, N=2.0, P=0.5)
+        pool.decomposed_cnp = mocker.Mock(C=3.0, N=0.6, P=0.1)
+
+        t = np.datetime64("2001-06-01")
+        rows = exporter._build_carcass_rows(
+            carcass_pools={5: [pool]},
+            time=t,
+            time_index=3,
+        )
+
+        assert len(rows) == 2
+
+        scav = next(r for r in rows if r["sub_pool"] == "scavengeable")
+        assert scav["pool_type"] == "carcass"
+        assert scav["cell_id"] == 5
+        assert scav["C"] == 10.0
+        assert scav["N"] == 2.0
+        assert scav["P"] == 0.5
+        assert scav["pft"] == ""
+        assert scav["time"] == t
+        assert scav["time_index"] == 3
+
+        decomp = next(r for r in rows if r["sub_pool"] == "decomposed")
+        assert decomp["C"] == 3.0
+        assert decomp["N"] == 0.6
+        assert decomp["P"] == 0.1
+
+    def test_build_carcass_rows_multiple_cells_and_pools(self, mocker):
+        """Test _build_carcass_rows handles multiple cells with multiple pools each.
+
+        Args:
+            mocker: Pytest mocker fixture.
+        """
+        import numpy as np
+
+        from virtual_ecosystem.models.animal.exporter import ResourcePoolDataExporter
+
+        exporter = ResourcePoolDataExporter.__new__(ResourcePoolDataExporter)
+
+        def make_pool():
+            p = mocker.Mock()
+            p.scavengeable_cnp = mocker.Mock(C=1.0, N=0.1, P=0.01)
+            p.decomposed_cnp = mocker.Mock(C=0.0, N=0.0, P=0.0)
+            return p
+
+        pools = {0: [make_pool(), make_pool()], 1: [make_pool()]}
+
+        rows = exporter._build_carcass_rows(
+            carcass_pools=pools,
+            time=np.datetime64("2001-01-01"),
+            time_index=0,
+        )
+
+        # 3 pool instances x 2 sub-pools each
+        assert len(rows) == 6
+        assert all(r["pool_type"] == "carcass" for r in rows)
+
+    def test_build_excrement_rows_emits_two_rows_per_pool(self, mocker):
+        """Test _build_excrement_rows emits one scavengeable and one decomposed row.
+
+        Args:
+            mocker: Pytest mocker fixture.
+        """
+        import numpy as np
+
+        from virtual_ecosystem.models.animal.exporter import ResourcePoolDataExporter
+
+        exporter = ResourcePoolDataExporter.__new__(ResourcePoolDataExporter)
+
+        pool = mocker.Mock()
+        pool.scavengeable_cnp = mocker.Mock(C=8.0, N=1.6, P=0.4)
+        pool.decomposed_cnp = mocker.Mock(C=2.0, N=0.4, P=0.08)
+
+        t = np.datetime64("2002-03-15")
+        rows = exporter._build_excrement_rows(
+            excrement_pools={2: [pool]},
+            time=t,
+            time_index=1,
+        )
+
+        assert len(rows) == 2
+        assert all(r["pool_type"] == "excrement" for r in rows)
+        assert all(r["cell_id"] == 2 for r in rows)
+        assert all(r["pft"] == "" for r in rows)
+
+        scav = next(r for r in rows if r["sub_pool"] == "scavengeable")
+        assert scav["C"] == 8.0
+
+        decomp = next(r for r in rows if r["sub_pool"] == "decomposed")
+        assert decomp["C"] == 2.0
+
+    def test_build_fungal_rows_emits_one_row_per_cell(self, mocker):
+        """Test _build_fungal_rows emits one row per FungalFruitPool.
+
+        Args:
+            mocker: Pytest mocker fixture.
+        """
+        import numpy as np
+
+        from virtual_ecosystem.models.animal.exporter import ResourcePoolDataExporter
+
+        exporter = ResourcePoolDataExporter.__new__(ResourcePoolDataExporter)
+
+        pool_0 = mocker.Mock()
+        pool_0.mass_cnp = mocker.Mock(C=5.0, N=0.2, P=0.05)
+
+        pool_1 = mocker.Mock()
+        pool_1.mass_cnp = mocker.Mock(C=3.0, N=0.12, P=0.03)
+
+        t = np.datetime64("2003-07-01")
+        rows = exporter._build_fungal_rows(
+            fungal_fruiting_pools={0: pool_0, 1: pool_1},
+            time=t,
+            time_index=2,
+        )
+
+        assert len(rows) == 2
+        assert all(r["pool_type"] == "fungal_fruiting" for r in rows)
+        assert all(r["sub_pool"] == "" for r in rows)
+        assert all(r["pft"] == "" for r in rows)
+
+        row_0 = next(r for r in rows if r["cell_id"] == 0)
+        assert row_0["C"] == 5.0
+        assert row_0["N"] == 0.2
+        assert row_0["P"] == 0.05
+
+    def test_build_soil_rows_emits_one_row_per_pool_type_per_cell(self, mocker):
+        """Test _build_soil_rows emits one row per (cell, pool-type) combination.
+
+        Args:
+            mocker: Pytest mocker fixture.
+        """
+        import numpy as np
+
+        from virtual_ecosystem.models.animal.exporter import ResourcePoolDataExporter
+
+        exporter = ResourcePoolDataExporter.__new__(ResourcePoolDataExporter)
+
+        bacteria = mocker.Mock()
+        bacteria.mass_cnp = mocker.Mock(C=4.0, N=0.8, P=0.13)
+
+        pom = mocker.Mock()
+        pom.mass_cnp = mocker.Mock(C=7.0, N=0.35, P=0.07)
+
+        t = np.datetime64("2004-01-01")
+        rows = exporter._build_soil_rows(
+            soil_pools={0: {"bacteria": bacteria, "pom": pom}},
+            time=t,
+            time_index=0,
+        )
+
+        assert len(rows) == 2
+        assert all(r["pool_type"] == "soil" for r in rows)
+        assert all(r["sub_pool"] == "" for r in rows)
+        assert all(r["pft"] == "" for r in rows)
+        assert all(r["cell_id"] == 0 for r in rows)
+
+        bac_row = next(r for r in rows if r["pool_name"] == "bacteria")
+        assert bac_row["C"] == 4.0
+        assert bac_row["N"] == 0.8
+
+        pom_row = next(r for r in rows if r["pool_name"] == "pom")
+        assert pom_row["C"] == 7.0
+
+    def test_build_resource_pool_rows_no_pft(self, mocker):
+        """Test _build_resource_pool_rows handles pools without PFT partitioning.
+
+        Args:
+            mocker: Pytest mocker fixture.
+        """
+        import numpy as np
+
+        from virtual_ecosystem.models.animal.exporter import ResourcePoolDataExporter
+
+        exporter = ResourcePoolDataExporter.__new__(ResourcePoolDataExporter)
+
+        pool = mocker.Mock()
+        pool.resource.pool_array = "subcanopy_vegetation_cnp"
+        pool.pft = None
+        pool.elemental_masses = np.array(
+            [
+                [20.0, 2.0, 1.0],
+                [15.0, 1.5, 0.75],
+            ]
+        )
+
+        t = np.datetime64("2005-04-01")
+        rows = exporter._build_resource_pool_rows(
+            resource_pools=[pool],
+            time=t,
+            time_index=4,
+        )
+
+        # one row per cell
+        assert len(rows) == 2
+        assert all(r["pool_type"] == "plant_array" for r in rows)
+        assert all(r["pool_name"] == "subcanopy_vegetation_cnp" for r in rows)
+        assert all(r["pft"] == "" for r in rows)
+        assert all(r["sub_pool"] == "" for r in rows)
+
+        row_0 = next(r for r in rows if r["cell_id"] == 0)
+        assert row_0["C"] == 20.0
+        assert row_0["N"] == 2.0
+        assert row_0["P"] == 1.0
+
+        row_1 = next(r for r in rows if r["cell_id"] == 1)
+        assert row_1["C"] == 15.0
+
+    def test_build_resource_pool_rows_with_pft(self, mocker):
+        """Test _build_resource_pool_rows records PFT identity in the pft column.
+
+        Args:
+            mocker: Pytest mocker fixture.
+        """
+        import numpy as np
+
+        from virtual_ecosystem.models.animal.exporter import ResourcePoolDataExporter
+
+        exporter = ResourcePoolDataExporter.__new__(ResourcePoolDataExporter)
+
+        pool = mocker.Mock()
+        pool.resource.pool_array = "canopy_foliage_cnp"
+        pool.pft = "broadleaf"
+        pool.elemental_masses = np.array([[10.0, 1.0, 0.5]])
+
+        rows = exporter._build_resource_pool_rows(
+            resource_pools=[pool],
+            time=np.datetime64("2006-01-01"),
+            time_index=0,
+        )
+
+        assert len(rows) == 1
+        assert rows[0]["pft"] == "broadleaf"
+        assert rows[0]["pool_name"] == "canopy_foliage_cnp"
+        assert rows[0]["C"] == 10.0
+
+    def test_dump_all_pool_types_appear_in_output(self, tmp_path, mocker):
+        """Test that dump writes rows for all five pool types in a single call.
+
+        Args:
+            tmp_path: Temporary directory provided by pytest.
+            mocker: Pytest mocker fixture.
+        """
+        import numpy as np
+        import pandas as pd
+
+        from virtual_ecosystem.models.animal.exporter import ResourcePoolDataExporter
+        from virtual_ecosystem.models.animal.model_config import (
+            ResourcePoolExportConfig,
+        )
+
+        exporter = ResourcePoolDataExporter.from_config(
+            output_directory=tmp_path,
+            config=ResourcePoolExportConfig(enabled=True),
+        )
+
+        carcass = mocker.Mock()
+        carcass.scavengeable_cnp = mocker.Mock(C=1.0, N=0.1, P=0.01)
+        carcass.decomposed_cnp = mocker.Mock(C=0.0, N=0.0, P=0.0)
+
+        excrement = mocker.Mock()
+        excrement.scavengeable_cnp = mocker.Mock(C=2.0, N=0.2, P=0.02)
+        excrement.decomposed_cnp = mocker.Mock(C=0.0, N=0.0, P=0.0)
+
+        fungal = mocker.Mock()
+        fungal.mass_cnp = mocker.Mock(C=3.0, N=0.12, P=0.03)
+
+        soil = mocker.Mock()
+        soil.mass_cnp = mocker.Mock(C=4.0, N=0.8, P=0.13)
+
+        resource_pool = mocker.Mock()
+        resource_pool.resource.pool_array = "litter_pool_above_metabolic_cnp"
+        resource_pool.pft = None
+        resource_pool.elemental_masses = np.array([[5.0, 0.5, 0.05]])
+
+        exporter.dump(
+            carcass_pools={0: [carcass]},
+            excrement_pools={0: [excrement]},
+            fungal_fruiting_pools={0: fungal},
+            soil_pools={0: {"bacteria": soil}},
+            resource_pools=[resource_pool],
+            time=np.datetime64("2001-01-01"),
+            time_index=0,
+        )
+
+        df = pd.read_csv(tmp_path / "resource_pool_data.csv")
+        assert set(df["pool_type"].unique()) == {
+            "carcass",
+            "excrement",
+            "fungal_fruiting",
+            "soil",
+            "plant_array",
+        }
+
+    def test_exporter_runs_inside_animal_model(
+        self,
+        tmp_path,
+        dummy_animal_data,
+        fixture_core_components,
+        functional_group_list_instance,
+        microbial_c_n_p_ratios,
+        dummy_animal_exporter,
+    ):
+        """Test that the resource pool exporter runs correctly inside an AnimalModel.
+
+        Args:
+            tmp_path: Temporary directory provided by pytest.
+            dummy_animal_data: Data fixture for the animal model.
+            fixture_core_components: CoreComponents fixture.
+            functional_group_list_instance: List of animal functional groups.
+            microbial_c_n_p_ratios: Microbial stoichiometry ratios.
+            dummy_animal_exporter: No-op cohort exporter.
+        """
+        from copy import deepcopy
+
+        import pandas as pd
+
+        from virtual_ecosystem.models.animal.animal_model import AnimalModel
+        from virtual_ecosystem.models.animal.exporter import ResourcePoolDataExporter
+        from virtual_ecosystem.models.animal.model_config import (
+            AnimalConstants,
+            ResourcePoolExportConfig,
+        )
+
+        resource_pool_exporter = ResourcePoolDataExporter.from_config(
+            output_directory=tmp_path,
+            config=ResourcePoolExportConfig(enabled=True),
+        )
+
+        model = AnimalModel(
+            data=deepcopy(dummy_animal_data),
+            core_components=fixture_core_components,
+            model_constants=AnimalConstants(density_scaling_method="madingley"),
+            functional_groups=functional_group_list_instance,
+            microbial_c_n_p_ratios=microbial_c_n_p_ratios,
+            animal_cohort_exporter=dummy_animal_exporter,
+            resource_pool_exporter=resource_pool_exporter,
+        )
+
+        out_path = tmp_path / "resource_pool_data.csv"
+        assert out_path.exists()
+
+        assert resource_pool_exporter._output_mode == "a"
+        assert resource_pool_exporter._write_header is False
+
+        df_initial = pd.read_csv(out_path)
+        initial_rows = len(df_initial)
+        assert initial_rows > 0
+        assert set(df_initial["pool_type"].unique()) >= {"carcass", "excrement"}
+
+        model.update(time_index=0)
+
+        df_updated = pd.read_csv(out_path)
+        assert len(df_updated) > initial_rows

--- a/virtual_ecosystem/example_data/config/animal_config.toml
+++ b/virtual_ecosystem/example_data/config/animal_config.toml
@@ -34,3 +34,8 @@ cohort_attributes = [
 ]
 
 float_format = "%0.5f"
+
+
+[animal.resource_pool_export]
+enabled = true
+float_format = "%0.5f"

--- a/virtual_ecosystem/models/animal/animal_model.py
+++ b/virtual_ecosystem/models/animal/animal_model.py
@@ -67,7 +67,10 @@ from virtual_ecosystem.models.animal.decay import (
     HerbivoryWaste,
     SoilPool,
 )
-from virtual_ecosystem.models.animal.exporter import AnimalCohortDataExporter
+from virtual_ecosystem.models.animal.exporter import (
+    AnimalCohortDataExporter,
+    ResourcePoolDataExporter,
+)
 from virtual_ecosystem.models.animal.functional_group import (
     FunctionalGroup,
     get_functional_group_by_name,
@@ -188,7 +191,8 @@ class AnimalModel(
     Args:
         data: The data object to be used in the model.
         core_components: The core components used across models.
-        exporter: The export system for animal cohort data.
+        animal_cohort_exporter: The export system for animal cohort data.
+        resource_pool_exporter: The export system for resource pools.
         density_scaling_method: Which density scaling equation to use in initialization.
         functional_groups: The list of animal functional groups present in the
             simulation.
@@ -205,7 +209,8 @@ class AnimalModel(
         self,
         data: Data,
         core_components: CoreComponents,
-        exporter: AnimalCohortDataExporter,
+        animal_cohort_exporter: AnimalCohortDataExporter,
+        resource_pool_exporter: ResourcePoolDataExporter,
         functional_groups: list[FunctionalGroup],
         microbial_c_n_p_ratios: dict[str, dict[str, float]],
         model_constants: AnimalConstants = AnimalConstants(),
@@ -257,8 +262,10 @@ class AnimalModel(
         """The pools of fungal fruiting bodies with associated grid cell ids."""
 
         # Set the exporter - this is always set _regardless_ of the static mode.
-        self.exporter: AnimalCohortDataExporter = exporter
+        self.animal_cohort_exporter: AnimalCohortDataExporter = animal_cohort_exporter
         """Exporter for animal cohort data."""
+        self.resource_pool_exporter: ResourcePoolDataExporter = resource_pool_exporter
+        """Exporter for resource pools."""
 
         # Run the setup if the model is not in deep static mode
         if self._run_setup:
@@ -371,8 +378,18 @@ class AnimalModel(
         """Create the dictionary of animal communities and populate each community with
         animal cohorts."""
 
-        self.exporter.dump(
+        self.animal_cohort_exporter.dump(
             cohorts=self.active_cohorts.values(),
+            time=self.model_timing.start_time,
+            time_index=0,
+        )
+
+        self.resource_pool_exporter.dump(
+            carcass_pools=self.carcass_pools,
+            excrement_pools=self.excrement_pools,
+            fungal_fruiting_pools=self.fungal_fruiting_bodies,
+            soil_pools=self.soil_pools,
+            resource_pools=self.array_resource_pools,
             time=self.model_timing.start_time,
             time_index=0,
         )
@@ -455,9 +472,14 @@ class AnimalModel(
         # Find microbial stoichiometries based on the config
         microbial_c_n_p_ratios = find_microbial_stoichiometries(config=configuration)
 
-        exporter = AnimalCohortDataExporter.from_config(
+        animal_cohort_exporter = AnimalCohortDataExporter.from_config(
             output_directory=core_configuration.data_output_options.out_path,
             config=model_configuration.cohort_data_export,
+        )
+
+        resource_pool_exporter = ResourcePoolDataExporter.from_config(
+            output_directory=core_configuration.data_output_options.out_path,
+            config=model_configuration.resource_pool_export,
         )
 
         LOGGER.info(
@@ -472,7 +494,8 @@ class AnimalModel(
             functional_groups=functional_groups,
             model_constants=model_configuration.constants,
             microbial_c_n_p_ratios=microbial_c_n_p_ratios,
-            exporter=exporter,
+            animal_cohort_exporter=animal_cohort_exporter,
+            resource_pool_exporter=resource_pool_exporter,
         )
 
     def spinup(self) -> None:
@@ -544,8 +567,18 @@ class AnimalModel(
         self.update_population_densities()
 
         # Dump the cohort data to CSV
-        self.exporter.dump(
+        self.animal_cohort_exporter.dump(
             cohorts=self.active_cohorts.values(),
+            time=self.model_timing.update_datestamps[time_index],
+            time_index=time_index,
+        )
+
+        self.resource_pool_exporter.dump(
+            carcass_pools=self.carcass_pools,
+            excrement_pools=self.excrement_pools,
+            fungal_fruiting_pools=self.fungal_fruiting_bodies,
+            soil_pools=self.soil_pools,
+            resource_pools=self.array_resource_pools,
             time=self.model_timing.update_datestamps[time_index],
             time_index=time_index,
         )

--- a/virtual_ecosystem/models/animal/exporter.py
+++ b/virtual_ecosystem/models/animal/exporter.py
@@ -19,7 +19,17 @@ import pandas as pd
 from virtual_ecosystem.core.exceptions import ConfigurationError
 from virtual_ecosystem.core.logger import LOGGER
 from virtual_ecosystem.models.animal.animal_cohorts import AnimalCohort
-from virtual_ecosystem.models.animal.model_config import AnimalExportConfig
+from virtual_ecosystem.models.animal.array_resources import ResourcePool
+from virtual_ecosystem.models.animal.decay import (
+    CarcassPool,
+    ExcrementPool,
+    FungalFruitPool,
+    SoilPool,
+)
+from virtual_ecosystem.models.animal.model_config import (
+    AnimalExportConfig,
+    ResourcePoolExportConfig,
+)
 
 
 class AnimalCohortDataExporter:
@@ -432,4 +442,375 @@ class AnimalCohortDataExporter:
                 }
             )
 
+        return rows
+
+
+class ResourcePoolDataExporter:
+    """Exporter for resource pool state data.
+
+    Writes one CSV file containing a row for every resource pool sub-pool at
+    every time step. The file is opened in write mode on the first call to
+    ``dump`` (including the header) and subsequently appended to.
+
+    The exporter covers all animal-model resource pools: carcass, excrement,
+    fungal fruiting body, soil, and plant/litter array pools. Each row
+    identifies the pool by ``pool_type``, ``pool_name``, ``sub_pool``, ``pft``,
+    and ``cell_id``, and records the carbon, nitrogen, and phosphorus masses at
+    the time of the snapshot.
+
+    For plant and litter array pools the snapshot reflects the pre-foraging
+    available masses, because ``ResourcePool.elemental_masses`` is populated by
+    ``set_resources`` at the start of each update step and is not modified
+    in-place during foraging.
+
+    Args:
+        output_directory: Directory where the CSV file will be created.
+        float_format: Float format string used when writing numeric data.
+    """
+
+    _outputs: ClassVar[dict[str, tuple[str, str]]] = {
+        "resource_pools": ("resource_pool_data.csv", "_pool_path"),
+    }
+    """Mapping from output key to (filename, path-attribute-name)."""
+
+    def __init__(
+        self,
+        output_directory: Path,
+        float_format: str = "%0.5f",
+    ) -> None:
+        self.output_directory: Path = output_directory
+        """The directory in which to save resource pool data."""
+        self.float_format: str = float_format
+        """The float format for data export."""
+
+        self._output_mode: str = "w"
+        """Switches the exporter between write and append mode."""
+        self._write_header: bool = True
+        """Stops headers being duplicated in append mode."""
+        self._active: bool = True
+        """Whether any data export has been requested."""
+        self._pool_path: Path | None = None
+        """Sets the output path for the resource pool csv."""
+
+        self._check_and_set_paths()
+
+    @classmethod
+    def from_config(
+        cls,
+        output_directory: Path,
+        config: ResourcePoolExportConfig,
+    ) -> ResourcePoolDataExporter:
+        """Create an exporter from a ResourcePoolExportConfig instance.
+
+        If the config has ``enabled=False``, returns an inactive exporter that
+        silently no-ops on all ``dump`` calls.
+
+        Args:
+            output_directory: Directory where the CSV file will be created.
+            config: Configuration section controlling resource pool export.
+
+        Returns:
+            Initialised ResourcePoolDataExporter instance.
+        """
+        if not config.enabled:
+            LOGGER.info("Resource pool data exporter not active.")
+            exporter = cls.__new__(cls)
+            exporter.output_directory = output_directory
+            exporter.float_format = config.float_format
+            exporter._output_mode = "w"
+            exporter._write_header = True
+            exporter._active = False
+            exporter._pool_path = None
+            return exporter
+
+        return cls(
+            output_directory=output_directory,
+            float_format=config.float_format,
+        )
+
+    def _check_and_set_paths(self) -> None:
+        """Check and set the output paths to be used by the exporter.
+
+        Raises:
+            ConfigurationError: If the directory does not exist or is not a
+                directory, or if any output file already exists.
+        """
+        if not (self.output_directory.exists() and self.output_directory.is_dir()):
+            msg = (
+                "The resource pool data output directory does not exist or is not "
+                f"a directory: {self.output_directory}"
+            )
+            LOGGER.error(msg)
+            raise ConfigurationError(msg)
+
+        for output_key, (fname, attr_name) in self._outputs.items():
+            data_path = self.output_directory / fname
+
+            if data_path.exists():
+                msg = (
+                    "An output file for resource pool export already exists: "
+                    f"{output_key} -> {fname}"
+                )
+                LOGGER.error(msg)
+                raise ConfigurationError(msg)
+
+            setattr(self, attr_name, data_path)
+
+    def dump(
+        self,
+        carcass_pools: dict[int, list[CarcassPool]],
+        excrement_pools: dict[int, list[ExcrementPool]],
+        fungal_fruiting_pools: dict[int, FungalFruitPool],
+        soil_pools: dict[int, dict[str, SoilPool]],
+        resource_pools: list[ResourcePool],
+        time: np.datetime64,
+        time_index: int,
+    ) -> None:
+        """Write resource pool state data to CSV.
+
+        This method is a no-op if the exporter is inactive.
+
+        Args:
+            carcass_pools: Carcass pools keyed by cell id, each containing one
+                or more CarcassPool instances.
+            excrement_pools: Excrement pools keyed by cell id, each containing
+                one or more ExcrementPool instances.
+            fungal_fruiting_pools: Fungal fruiting body pools keyed by cell id.
+            soil_pools: Soil pools keyed by cell id and then by pool-type string
+                (e.g. ``"bacteria"``, ``"saprotrophic_fungi"``).
+            resource_pools: Flat list of plant and litter ResourcePool
+                instances. Each pool's ``elemental_masses`` array holds
+                pre-foraging available masses set by the most recent
+                ``set_resources`` call.
+            time: Timestamp to associate with this snapshot.
+            time_index: The index of the datetime within the model updates.
+        """
+        if not self._active:
+            return
+
+        if self._pool_path is None:
+            LOGGER.debug("Resource pool exporter called with no output path.")
+            return
+
+        rows: list[dict[str, object]] = []
+        rows.extend(self._build_carcass_rows(carcass_pools, time, time_index))
+        rows.extend(self._build_excrement_rows(excrement_pools, time, time_index))
+        rows.extend(self._build_fungal_rows(fungal_fruiting_pools, time, time_index))
+        rows.extend(self._build_soil_rows(soil_pools, time, time_index))
+        rows.extend(self._build_resource_pool_rows(resource_pools, time, time_index))
+
+        if not rows:
+            LOGGER.info("Resource pool exporter called with no pool data present.")
+            return
+
+        pd.DataFrame(rows).to_csv(
+            self._pool_path,
+            mode=self._output_mode,
+            header=self._write_header,
+            index=False,
+            float_format=self.float_format,
+        )
+
+        LOGGER.info("Resource pool data dumped at time: %s", time)
+
+        self._output_mode = "a"
+        self._write_header = False
+
+    def _build_carcass_rows(
+        self,
+        carcass_pools: dict[int, list[CarcassPool]],
+        time: np.datetime64,
+        time_index: int,
+    ) -> list[dict[str, object]]:
+        """Build output rows for all carcass pools.
+
+        Emits two rows per pool instance: one for the scavengeable fraction and
+        one for the decomposed fraction.
+
+        Args:
+            carcass_pools: Carcass pools keyed by cell id.
+            time: Timestamp for this snapshot.
+            time_index: The index of the datetime within the model updates.
+
+        Returns:
+            List of row dictionaries, two per CarcassPool instance.
+        """
+        rows = []
+        for cell_id, pools in carcass_pools.items():
+            for pool in pools:
+                for sub_pool, cnp in (
+                    ("scavengeable", pool.scavengeable_cnp),
+                    ("decomposed", pool.decomposed_cnp),
+                ):
+                    rows.append(
+                        {
+                            "time": time,
+                            "time_index": time_index,
+                            "pool_type": "carcass",
+                            "pool_name": "",
+                            "sub_pool": sub_pool,
+                            "pft": "",
+                            "cell_id": cell_id,
+                            "C": cnp.C,
+                            "N": cnp.N,
+                            "P": cnp.P,
+                        }
+                    )
+        return rows
+
+    def _build_excrement_rows(
+        self,
+        excrement_pools: dict[int, list[ExcrementPool]],
+        time: np.datetime64,
+        time_index: int,
+    ) -> list[dict[str, object]]:
+        """Build output rows for all excrement pools.
+
+        Emits two rows per pool instance: one for the scavengeable fraction and
+        one for the decomposed fraction.
+
+        Args:
+            excrement_pools: Excrement pools keyed by cell id.
+            time: Timestamp for this snapshot.
+            time_index: The index of the datetime within the model updates.
+
+        Returns:
+            List of row dictionaries, two per ExcrementPool instance.
+        """
+        rows = []
+        for cell_id, pools in excrement_pools.items():
+            for pool in pools:
+                for sub_pool, cnp in (
+                    ("scavengeable", pool.scavengeable_cnp),
+                    ("decomposed", pool.decomposed_cnp),
+                ):
+                    rows.append(
+                        {
+                            "time": time,
+                            "time_index": time_index,
+                            "pool_type": "excrement",
+                            "pool_name": "",
+                            "sub_pool": sub_pool,
+                            "pft": "",
+                            "cell_id": cell_id,
+                            "C": cnp.C,
+                            "N": cnp.N,
+                            "P": cnp.P,
+                        }
+                    )
+        return rows
+
+    def _build_fungal_rows(
+        self,
+        fungal_fruiting_pools: dict[int, FungalFruitPool],
+        time: np.datetime64,
+        time_index: int,
+    ) -> list[dict[str, object]]:
+        """Build output rows for all fungal fruiting body pools.
+
+        Emits one row per pool instance.
+
+        Args:
+            fungal_fruiting_pools: Fungal fruiting body pools keyed by cell id.
+            time: Timestamp for this snapshot.
+            time_index: The index of the datetime within the model updates.
+
+        Returns:
+            List of row dictionaries, one per FungalFruitPool instance.
+        """
+        rows = []
+        for cell_id, pool in fungal_fruiting_pools.items():
+            rows.append(
+                {
+                    "time": time,
+                    "time_index": time_index,
+                    "pool_type": "fungal_fruiting",
+                    "pool_name": "",
+                    "sub_pool": "",
+                    "pft": "",
+                    "cell_id": cell_id,
+                    "C": pool.mass_cnp.C,
+                    "N": pool.mass_cnp.N,
+                    "P": pool.mass_cnp.P,
+                }
+            )
+        return rows
+
+    def _build_soil_rows(
+        self,
+        soil_pools: dict[int, dict[str, SoilPool]],
+        time: np.datetime64,
+        time_index: int,
+    ) -> list[dict[str, object]]:
+        """Build output rows for all soil pools.
+
+        Emits one row per (cell, pool-type) combination.
+
+        Args:
+            soil_pools: Soil pools keyed by cell id and pool-type string (e.g.
+                ``"bacteria"``, ``"saprotrophic_fungi"``).
+            time: Timestamp for this snapshot.
+            time_index: The index of the datetime within the model updates.
+
+        Returns:
+            List of row dictionaries, one per SoilPool instance.
+        """
+        rows = []
+        for cell_id, pools_by_type in soil_pools.items():
+            for pool_name, pool in pools_by_type.items():
+                rows.append(
+                    {
+                        "time": time,
+                        "time_index": time_index,
+                        "pool_type": "soil",
+                        "pool_name": pool_name,
+                        "sub_pool": "",
+                        "pft": "",
+                        "cell_id": cell_id,
+                        "C": pool.mass_cnp.C,
+                        "N": pool.mass_cnp.N,
+                        "P": pool.mass_cnp.P,
+                    }
+                )
+        return rows
+
+    def _build_resource_pool_rows(
+        self,
+        resource_pools: list[ResourcePool],
+        time: np.datetime64,
+        time_index: int,
+    ) -> list[dict[str, object]]:
+        """Build output rows for all plant and litter array resource pools.
+
+        Emits one row per (pool, cell) combination. The C, N, and P masses are
+        taken from ``ResourcePool.elemental_masses``, which holds pre-foraging
+        available masses populated by the most recent ``set_resources`` call.
+
+        Args:
+            resource_pools: Flat list of ResourcePool instances.
+            time: Timestamp for this snapshot.
+            time_index: The index of the datetime within the model updates.
+
+        Returns:
+            List of row dictionaries, one per (ResourcePool, cell) pair.
+        """
+        rows = []
+        for pool in resource_pools:
+            pool_name = pool.resource.pool_array
+            pft = pool.pft or ""
+            for cell_id, (C, N, P) in enumerate(pool.elemental_masses):
+                rows.append(
+                    {
+                        "time": time,
+                        "time_index": time_index,
+                        "pool_type": "plant_array",
+                        "pool_name": pool_name,
+                        "sub_pool": "",
+                        "pft": pft,
+                        "cell_id": cell_id,
+                        "C": C,
+                        "N": N,
+                        "P": P,
+                    }
+                )
         return rows

--- a/virtual_ecosystem/models/animal/exporter.py
+++ b/virtual_ecosystem/models/animal/exporter.py
@@ -803,7 +803,7 @@ class ResourcePoolDataExporter:
                     {
                         "time": time,
                         "time_index": time_index,
-                        "pool_type": "plant_array",
+                        "pool_type": "resource_array",
                         "pool_name": pool_name,
                         "sub_pool": "",
                         "pft": pft,

--- a/virtual_ecosystem/models/animal/model_config.py
+++ b/virtual_ecosystem/models/animal/model_config.py
@@ -467,6 +467,18 @@ class AnimalExportConfig(Configuration):
     float_format: str = "%0.5f"
 
 
+class ResourcePoolExportConfig(Configuration):
+    """Configuration for resource pool data export.
+
+    Attributes:
+        enabled: Whether resource pool export is active.
+        float_format: Float format string used when writing numeric data.
+    """
+
+    enabled: bool = False
+    float_format: str = "%0.5f"
+
+
 class AnimalConfiguration(ModelConfigurationRoot):
     """Root configuration class for the animal model."""
 
@@ -479,4 +491,8 @@ class AnimalConfiguration(ModelConfigurationRoot):
     cohort_data_export: AnimalExportConfig = Field(
         default_factory=AnimalExportConfig,
         description="Export settings for animal cohort CSV output.",
+    )
+    resource_pool_export: ResourcePoolExportConfig = Field(
+        default_factory=ResourcePoolExportConfig,
+        description="Export settings for resource pool CSV output.",
     )


### PR DESCRIPTION
# Description

This PR introduces an exporter for the resource pool objects that are found inside the animal model. The structure of the exporter closely follows the existing exporter for animal cohort data. 

New things:
- the `ResourcePoolDataExporter` class
- the `ResourcePoolExportConfig` class
- a new on/off config option for the animal model

Things that are true:
- structurally, a bunch of this is redundant and could (LATER) be collapsed into a single reusable structure both in terms of exporting specific classes and with the other cohort data exporter
- a bunch of the exported data is also exported in some fashion as part of the continuous data
- we discussed it and this is a workable solution to the animal data team's needs right now

Fixes #1627

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
