### PR TITLE
1623 parsing data variable units to include or exclude element

### DIFF
--- a/virtual_ecosystem/data_variables.toml
+++ b/virtual_ecosystem/data_variables.toml
@@ -616,7 +616,7 @@ variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
-description = "Soil low molecular weight carbon pool. Carbon, nitrogen and phosphorous content"
+description = "Soil low molecular weight organic pool. Carbon, nitrogen and phosphorous content"
 name = "soil_cnp_pool_lmwc"
 unit = "kg m^-3"
 variable_type = "float"
@@ -632,28 +632,28 @@ variable_type = "float"
 axis = ["spatial"]
 description = "Soil bacterial biomass (carbon) pool"
 name = "soil_c_pool_bacteria"
-unit = "kg C m^-3"
+unit = "kg{C} m^-3"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Soil saprotrophic fungal biomass (carbon) pool"
 name = "soil_c_pool_saprotrophic_fungi"
-unit = "kg C m^-3"
+unit = "kg{C} m^-3"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Soil arbuscular mycorrhizal fungal biomass (carbon) pool"
 name = "soil_c_pool_arbuscular_mycorrhiza"
-unit = "kg C m^-3"
+unit = "kg{C} m^-3"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Soil ectomycorrhizal fungal biomass (carbon) pool"
 name = "soil_c_pool_ectomycorrhiza"
-unit = "kg C m^-3"
+unit = "kg{C} m^-3"
 variable_type = "float"
 
 [[variable]]
@@ -674,35 +674,35 @@ variable_type = "float"
 axis = ["spatial"]
 description = "Amount of nitrogen contained in the soil ammonium (NH4+) pool"
 name = "soil_n_pool_ammonium"
-unit = "kg N m^-3"
+unit = "kg{N} m^-3"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Amount of nitrogen contained in the soil nitrate (NO3-) pool"
 name = "soil_n_pool_nitrate"
-unit = "kg N m^-3"
+unit = "kg{N} m^-3"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Amount of phosphorus in a primary mineral form"
 name = "soil_p_pool_primary"
-unit = "kg P m^-3"
+unit = "kg{P} m^-3"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Amount of inorganic phosphorus that is associated with secondary minerals"
 name = "soil_p_pool_secondary"
-unit = "kg P m^-3"
+unit = "kg{P} m^-3"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Amount of inorganic phosphorus that is in a labile form"
 name = "soil_p_pool_labile"
-unit = "kg P m^-3"
+unit = "kg{P} m^-3"
 variable_type = "float"
 
 [[variable]]
@@ -1010,49 +1010,49 @@ variable_type = "float"
 axis = ["spatial"]
 description = "Concentration of dissolved nitrate in the topsoil layer"
 name = "dissolved_nitrate"
-unit = "kg N m^-3"
+unit = "kg{N} m^-3"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Concentration of dissolved ammonium in the topsoil layer"
 name = "dissolved_ammonium"
-unit = "kg N m^-3"
+unit = "kg{N} m^-3"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Concentration of dissolved labile inorganic phosphorus in the topsoil layer"
 name = "dissolved_phosphorus"
-unit = "kg P m^-3"
+unit = "kg{P} m^-3"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Amount of nitrogen provided by arbuscular mycorrhizal fungi to their plant partners"
 name = "arbuscular_mycorrhizal_n_supply"
-unit = "kg N"
+unit = "kg{N}"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Amount of phosphorous provided by arbuscular mycorrhizal fungi to their plant partners"
 name = "arbuscular_mycorrhizal_p_supply"
-unit = "kg P"
+unit = "kg{P}"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Amount of nitrogen provided by ectomycorrhizal fungi to their plant partners"
 name = "ectomycorrhizal_n_supply"
-unit = "kg N"
+unit = "kg{N}"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Amount of phosphorous provided by ectomycorrhizal fungi to their plant partners"
 name = "ectomycorrhizal_p_supply"
-unit = "kg P"
+unit = "kg{P}"
 variable_type = "float"
 
 [[variable]]
@@ -1101,28 +1101,28 @@ variable_type = "float"
 axis = ["spatial"]
 description = "Amount of bacterial enzyme class which breaks down particulate organic matter"
 name = "soil_enzyme_pom_bacteria"
-unit = "kg C m^-3"
+unit = "kg{C} m^-3"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Amount of bacterial enzyme class which breaks down mineral associated organic matter"
 name = "soil_enzyme_maom_bacteria"
-unit = "kg C m^-3"
+unit = "kg{C} m^-3"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Amount of fungal enzyme class which breaks down particulate organic matter"
 name = "soil_enzyme_pom_fungi"
-unit = "kg C m^-3"
+unit = "kg{C} m^-3"
 variable_type = "float"
 
 [[variable]]
 axis = ["spatial"]
 description = "Amount of fungal enzyme class which breaks down mineral associated organic matter"
 name = "soil_enzyme_maom_fungi"
-unit = "kg C m^-3"
+unit = "kg{C} m^-3"
 variable_type = "float"
 
 [[variable]]

--- a/virtual_ecosystem/models/litter/carbon.py
+++ b/virtual_ecosystem/models/litter/carbon.py
@@ -98,13 +98,13 @@ def calculate_decay_rates(
 
     Args:
         lignin_above_structural: Proportion of above ground structural pool which is
-            lignin [kg lignin C (kg C)^-1]
+            lignin [kg{lignin C} kg{C}^-1]
         lignin_woody: Proportion of dead wood pool which is lignin
-            [kg lignin C (kg C)^-1]
+            [kg{lignin C} kg{C}^-1]
         lignin_below_structural: Proportion of below ground structural pool which is
-            lignin [kg lignin C (kg C)^-1]
-        air_temperatures: Air temperatures, for all above ground layers [C]
-        soil_temperatures: Soil temperatures, for all soil layers [C]
+            lignin [kg{lignin C} kg{C}^-1]
+        air_temperatures: Air temperatures, for all above ground layers [Celsius]
+        soil_temperatures: Soil temperatures, for all soil layers [Celsius]
         water_potentials: Water potentials, for all soil layers [kPa]
         layer_structure: The LayerStructure instance for the simulation.
         constants: Set of constants for the litter model
@@ -181,7 +181,7 @@ def calculate_total_C_mineralised(
         update_interval: Interval that the litter pools are being updated for [days]
 
     Returns:
-        Rate of carbon mineralisation from litter into soil [kg C m^-3 day^-1].
+        Rate of carbon mineralisation from litter into soil [kg{C} m^-3 day^-1].
     """
 
     # Calculate mineralisation from each pool
@@ -234,9 +234,9 @@ def calculate_updated_pools(
 
     Args:
         post_consumption_pools: The five litter pools after animal consumption has been
-            subtracted [kg C m^-2]
+            subtracted [kg{C} m^-2]
         decay_rates: Dictionary containing the rates of decay for all 5 litter pools
-            [kg C m^-2 day^-1]
+            [kg{C} m^-2 day^-1]
         litter_inputs: An LitterInputs instance containing the total input of each plant
             biomass type, the proportion of the input that goes to the relevant
             metabolic pool for each input type (expect deadwood) and the total input
@@ -247,7 +247,7 @@ def calculate_updated_pools(
     Returns:
         Dictionary containing the updated pool densities for all 5 litter pools (above
         ground metabolic, above ground structural, dead wood, below ground metabolic,
-        and below ground structural) [kg C m^-2]
+        and below ground structural) [kg{C} m^-2]
     """
 
     return {
@@ -307,15 +307,15 @@ def calculate_final_pool_size(
     size with at the litter decay rate.
 
     Args:
-        input_rate: The rate of input of carbon to the new pool [kg C m^-2 day^-1]
-        decay_rate: The rate at which the pool decays (in carbon terms) [kg C m^-2
+        input_rate: The rate of input of carbon to the new pool [kg{C} m^-2 day^-1]
+        decay_rate: The rate at which the pool decays (in carbon terms) [kg{C} m^-2
             day^-1]
-        initial_pool: The size of the pool at the start of the update interval [kg C
-            m^-2]
+        initial_pool: The size of the pool at the start of the update interva
+            [kg{C} m^-2]
         update_interval: Interval that the litter pools are being updated for [days]
 
     Returns:
-        The size of the pool at the end of the time step [kg C m^-2]
+        The size of the pool at the end of the time step [kg{C} m^-2]
     """
 
     equilibrium_pool = input_rate / decay_rate
@@ -340,7 +340,7 @@ def calculate_litter_decay_metabolic_above(
             litter pool [day^-1]
 
     Returns:
-        Rate of decay of the above ground metabolic litter pool [kg C m^-2 day^-1]
+        Rate of decay of the above ground metabolic litter pool [kg{C} m^-2 day^-1]
     """
 
     return litter_decay_coefficient * temperature_factor
@@ -360,14 +360,14 @@ def calculate_litter_decay_structural_above(
         temperature_factor: A multiplicative factor capturing the impact of temperature
             on litter decomposition [unitless]
         lignin_proportion: The proportion of the above ground structural pool which is
-            lignin [kg lignin C (kg C)^-1]
+            lignin [kg{lignin C} kg{C}^-1]
         litter_decay_coefficient: The decay coefficient for the above ground structural
             litter pool [day^-1]
         lignin_inhibition_factor: An exponential factor expressing the extent to which
             lignin inhibits the breakdown of litter [unitless]
 
     Returns:
-        Rate of decay of the above ground structural litter pool [kg C m^-2 day^-1]
+        Rate of decay of the above ground structural litter pool [kg{C} m^-2 day^-1]
     """
 
     litter_chemistry_factor = calculate_litter_chemistry_factor(
@@ -391,14 +391,14 @@ def calculate_litter_decay_woody(
         temperature_factor: A multiplicative factor capturing the impact of temperature
             on litter decomposition [unitless]
         lignin_proportion: The proportion of the woody litter pool which is lignin
-            [kg lignin C (kg C)^-1]
+            [kg{lignin C} kg{C}^-1]
         litter_decay_coefficient: The decay coefficient for the woody litter pool
             [day^-1]
         lignin_inhibition_factor: An exponential factor expressing the extent to which
             lignin inhibits the breakdown of litter [unitless]
 
     Returns:
-        Rate of decay of the woody litter pool [kg C m^-2 day^-1]
+        Rate of decay of the woody litter pool [kg{C} m^-2 day^-1]
     """
 
     litter_chemistry_factor = calculate_litter_chemistry_factor(
@@ -426,7 +426,7 @@ def calculate_litter_decay_metabolic_below(
             litter pool [day^-1]
 
     Returns:
-        Rate of decay of the below ground metabolic litter pool [kg C m^-2 day^-1]
+        Rate of decay of the below ground metabolic litter pool [kg{C} m^-2 day^-1]
     """
 
     return litter_decay_coefficient * temperature_factor * moisture_factor
@@ -449,14 +449,14 @@ def calculate_litter_decay_structural_below(
         moisture_factor: A multiplicative factor capturing the impact of soil moisture
             on litter decomposition [unitless]
         lignin_proportion: The proportion of the below ground structural pool which is
-            lignin [kg lignin C (kg C)^-1]
+            lignin [kg{lignin C} kg{C}^-1]
         litter_decay_coefficient: The decay coefficient for the below ground structural
             litter pool [day^-1]
         lignin_inhibition_factor: An exponential factor expressing the extent to which
             lignin inhibits the breakdown of litter [unitless]
 
     Returns:
-        Rate of decay of the below ground structural litter pool [kg C m^-2 day^-1]
+        Rate of decay of the below ground structural litter pool [kg{C} m^-2 day^-1]
     """
 
     litter_chemistry_factor = calculate_litter_chemistry_factor(
@@ -480,11 +480,11 @@ def calculate_carbon_mineralised(
     to track that.
 
     Args:
-        carbon_loss: Total amount of carbon lost from the litter pool [kg C m^-2]
+        carbon_loss: Total amount of carbon lost from the litter pool [kg{C} m^-2]
         carbon_use_efficiency: Carbon use efficiency of litter pool [unitless]
 
     Returns:
-        Rate at which carbon is mineralised from the litter pool [kg C m^-2]
+        Rate at which carbon is mineralised from the litter pool [kg{C} m^-2]
     """
 
     return carbon_use_efficiency * carbon_loss

--- a/virtual_ecosystem/models/litter/chemistry.py
+++ b/virtual_ecosystem/models/litter/chemistry.py
@@ -57,7 +57,7 @@ class LitterChemistry:
             input_chemistries: An InputChemistries instance containing the chemical
                 compositions of the input to each litter pool
             original_pools: The size of each litter pool after animal consumption, but
-                before litter inputs and decay [kg C m^-2].
+                before litter inputs and decay [kg{C} m^-2].
             update_interval: The update interval for the litter model [days]
         """
 
@@ -102,13 +102,13 @@ class LitterChemistry:
             litter_losses: An LitterInputs instance containing the total loss of carbon,
                 nitrogen, phosphorus and lignin from each litter pool.
             original_pools: The size of each litter pool after animal consumption, but
-                before litter inputs and decay [kg C m^-2].
+                before litter inputs and decay [kg{C} m^-2].
             update_interval: The update interval for the litter model [days]
 
         Returns:
             Dictionary containing the updated lignin proportions for the 3 relevant
             litter pools (above ground structural, dead wood, and below ground
-            structural) [kg lignin C (kg C)^-1]
+            structural) [kg{lignin C} kg{C}^-1]
         """
 
         new_lignin_proportion_above_struct = calculate_updated_pool_lignin_proportion(
@@ -167,7 +167,7 @@ def calculate_updated_nutrient_pools(
         litter_losses: An LitterInputs instance containing the total loss of carbon,
             nitrogen and phosphorus from each litter pool.
         original_pools: The size of each litter pool after animal consumption, but
-            before litter inputs and decay [kg C m^-2]
+            before litter inputs and decay [kg{C} m^-2]
         update_interval: The update interval for the litter model [days]
 
     Returns:
@@ -206,7 +206,7 @@ def calculate_litter_chemistry_factor(
 
     Args:
         lignin_proportion: The proportion of litter pool carbon that is held in the form
-            of lignin (or similar polymers) [kg lignin C (kg C)^-1]
+            of lignin (or similar polymers) [kg{lignin C} kg{C}^-1]
         lignin_inhibition_factor: An exponential factor expressing the extent to which
             lignin inhibits the breakdown of litter [unitless]
 
@@ -234,21 +234,21 @@ def calculate_updated_pool_lignin_proportion(
 
     Args:
         initial_carbon: The total carbon mass of the litter pool before inputs and decay
-            [kg C m^-2]
+            [kg{C} m^-2]
         input_carbon_rate: The rate of carbon input to the litter pool
-            [kg C m^-2 day^-1]
-        carbon_loss: Total loss of carbon from the litter pool due to decay [kg C m^-2]
+            [kg{C} m^-2 day^-1]
+        carbon_loss: Total loss of carbon from the litter pool due to decay [kg{C} m^-2]
         initial_lignin_proportion: The lignin proportion of the litter pool at the
-            start of the update interval [kg lignin C (kg C)^-1]
+            start of the update interval [kg{lignin C} kg{C}^-1]
         input_lignin_proportion: The lignin proportion of the input biomass
-            [kg lignin C (kg C)^-1]
+            [kg{lignin C} kg{C}^-1]
         lignin_loss: Total loss of lignin from the litter pool due to decay
-            [kg lignin C m^-2]
+            [kg{lignin C} m^-2]
         update_interval: The update interval for the litter model [days]
 
     Returns:
         The new lignin proportion at the end of the update interval
-        [kg lignin C (kg C)^-1]
+        [kg{lignin C} kg{C}^-1]
     """
 
     input_carbon_total = input_carbon_rate * update_interval

--- a/virtual_ecosystem/models/litter/env_factors.py
+++ b/virtual_ecosystem/models/litter/env_factors.py
@@ -37,8 +37,8 @@ def calculate_environmental_factors(
     other models.
 
     Args:
-        air_temperatures: Air temperatures, for all above ground layers [C]
-        soil_temperatures: Soil temperatures, for all soil layers [C]
+        air_temperatures: Air temperatures, for all above ground layers [Celsius]
+        soil_temperatures: Soil temperatures, for all soil layers [Celsius]
         water_potentials: Water potentials, for all soil layers [kPa]
         layer_structure: The LayerStructure instance for the simulation.
         constants: Set of constants for the litter model
@@ -103,10 +103,10 @@ def calculate_temperature_effect_on_litter_decomp(
     This function is taken from :cite:t:`kirschbaum_modelling_2002`.
 
     Args:
-        temperature: The temperature of the litter layer [C]
+        temperature: The temperature of the litter layer [Celsius]
         reference_temp: The reference temperature for changes in litter decomposition
-            rates with temperature [C]
-        offset_temp: Temperature offset [C]
+            rates with temperature [Celsius]
+        offset_temp: Temperature offset [Celsius]
         temp_response: Factor controlling response strength to changing temperature
             [unitless]
 
@@ -168,13 +168,13 @@ def average_temperature_over_microbially_active_layers(
     depth lies within each layer.
 
     Args:
-        soil_temperatures: Soil temperatures to be averaged [C]
-        surface_temperature: Air temperature just above the soil surface [C]
+        soil_temperatures: Soil temperatures to be averaged [Celsius]
+        surface_temperature: Air temperature just above the soil surface [Celsius]
         layer_structure: The LayerStructure instance for the simulation.
 
     Returns:
         The average temperature across the soil depth considered to be microbially
-        active [C]
+        active [Celsius]
     """
 
     # Find weighting for each layer in the average by dividing the microbially active

--- a/virtual_ecosystem/models/litter/inputs.py
+++ b/virtual_ecosystem/models/litter/inputs.py
@@ -28,11 +28,11 @@ class LitterInputs:
     """Total deadwood input rate to litter of each nutrient [kg m^-2 day^-1]"""
 
     leaf_lignin: DataArray
-    """Lignin proportion of leaf input [kg lignin C (kg C)^-1]"""
+    """Lignin proportion of leaf input [kg{lignin C} kg{C}^-1]"""
     root_lignin: DataArray
-    """Lignin proportion of root input [kg lignin C (kg C)^-1]"""
+    """Lignin proportion of root input [kg{lignin C} kg{C}^-1]"""
     stem_lignin: DataArray
-    """Lignin proportion of deadwood input [kg lignin C (kg C)^-1]"""
+    """Lignin proportion of deadwood input [kg{lignin C} kg{C}^-1]"""
 
     leaves_meta_split: DataArray
     """Fraction of leaf input that goes to metabolic litter [unitless]"""
@@ -40,15 +40,15 @@ class LitterInputs:
     """Fraction of leaf input that goes to metabolic litter [unitless]"""
 
     woody: DataArray
-    """Total input rate to the woody litter pool [kg C m^-2 day^-1]"""
+    """Total input rate to the woody litter pool [kg{C} m^-2 day^-1]"""
     above_metabolic: DataArray
-    """Total input rate to the above ground metabolic litter pool [kg C m^-2 day^-1]"""
+    """Total input rate to the above ground metabolic litter pool [kg{C} m^-2 day^-1]"""
     above_structural: DataArray
-    """Total input rate to the above ground structural litter pool [kg C m^-2 day^-1]"""
+    """Total input rate to the above ground structural litter pool [kg{C} m^-2 day^-1]"""
     below_metabolic: DataArray
-    """Total input rate to the below ground metabolic litter pool [kg C m^-2 day^-1]"""
+    """Total input rate to the below ground metabolic litter pool [kg{C} m^-2 day^-1]"""
     below_structural: DataArray
-    """Total input rate to the below ground structural litter pool [kg C m^-2 day^-1]"""
+    """Total input rate to the below ground structural litter pool [kg{C} m^-2 day^-1]"""
 
     @classmethod
     def create_from_data(
@@ -127,8 +127,8 @@ def combine_input_sources(data: Data, update_interval: float) -> dict[str, DataA
 
     Returns:
         A dictionary containing the combined rate at which each input pools is added to
-        [kg C m^-2 day^-1], as well as the carbon to nitrogen ratios [unitless], carbon
-        to phosphorus ratios [unitless] and lignin proportions [kg lignin C (kg C)^-1]
+        [kg{C} m^-2 day^-1], as well as the carbon to nitrogen ratios [unitless], carbon
+        to phosphorus ratios [unitless] and lignin proportions [kg{lignin C} kg{C}^-1]
         of each of these pools.
     """
 
@@ -182,9 +182,9 @@ def calculate_metabolic_proportions_of_input(
     inputs either as they all flow into just the metabolic pool.
 
     Args:
-        total_input: The total amount of carbon in each input pools [kg C m^-3], as
-            well as the nitrogen content [kg N m^-3], phosphorus content [kg P m^-3] and
-            lignin proportions [kg lignin C (kg C)^-1] of each of these pools.
+        total_input: The total amount of carbon in each input pools [kg{C} m^-3], as
+            well as the nitrogen content [kg{N} m^-3], phosphorus content [kg{P} m^-3]
+            and lignin proportions [kg{lignin C} kg{C}^-1] of each of these pools.
         constants: Set of constants for the litter model.
 
     Returns:
@@ -228,9 +228,9 @@ def partion_plant_inputs_between_pools(
     structural pools based on lignin concentration and carbon nitrogen ratios.
 
     Args:
-        total_input: The the total pool size for each input pools [kg C m^-3], as
+        total_input: The the total pool size for each input pools [kg{C} m^-3], as
             well as the carbon to nitrogen ratios [unitless], carbon to phosphorus
-            ratios [unitless] and lignin proportions [kg lignin C (kg C)^-1] of each of
+            ratios [unitless] and lignin proportions [kg{lignin C} kg{C}^-1] of each of
             these pools.
         metabolic_splits: Dictionary containing the proportion of each input that
             goes to the relevant metabolic pool. This is for three input types:
@@ -239,7 +239,7 @@ def partion_plant_inputs_between_pools(
     Returns:
         A dictionary containing the rate of biomass flow into each of the five litter
         pools (woody, above ground metabolic, above ground structural, below ground
-        metabolic and below ground structural) [kg C m^-2 day^-1]
+        metabolic and below ground structural) [kg{C} m^-2 day^-1]
     """
 
     # Calculate input to each of the five litter pools
@@ -279,9 +279,9 @@ def split_pool_into_metabolic_and_structural_litter(
     biomass, the functional form is taken from :cite:t:`parton_dynamics_1988`.
 
     Args:
-        input_masses: Mass of each nutrient in the input biomass [kg C m^-2]
+        input_masses: Mass of each nutrient in the input biomass [kg{C} m^-2]
         lignin_proportion: Proportion of input biomass carbon that is lignin
-            [kg lignin C (kg C)^-1]
+            [kg{lignin C} kg{C}^-1]
         max_metabolic_fraction: Fraction of pool that becomes metabolic litter for the
             easiest to breakdown case, i.e. no lignin, ample nitrogen [unitless]
         split_sensitivity_nitrogen: Sets how rapidly the split changes in response to
@@ -355,10 +355,10 @@ def merge_input_lignin_proportions(
 
     Args:
         turnover_mass: Input mass coming from the natural turnover of plant tissue
-            [kg C]
+            [kg{C}]
         herbivory_waste_mass: Input mass coming from the mechanical inefficiencies of
-            herbivory [kg C]
-        total_mass: The combined mass of the two input sources [kg C]
+            herbivory [kg{C}]
+        total_mass: The combined mass of the two input sources [kg{C}]
         turnover_lignin_proportion: Proportion of lignin in the input mass from
             natural plant turnover [unitless]
         herbivory_waste_lignin_proportion: Proportion of lignin in the input mass from
@@ -366,7 +366,7 @@ def merge_input_lignin_proportions(
 
     Returns:
         The proportion of carbon that is lignin carbon in the total mass of the new
-        combined input stream [kg lignin C (kg C)^-1]
+        combined input stream [kg{lignin C} kg{C}^-1]
     """
 
     return (
@@ -385,9 +385,9 @@ def average_nutrient_ratios(
 
     Args:
         mass_1: Total carbon mass of the first pool/input stream
-            [kg C m^-2 or kg C m^-2]
+            [kg{C} m^-2 or kg{C} m^-2]
         mass_2: Total carbon mass of the second pool/input stream
-            [kg C m^-2 or kg C m^-2]
+            [kg{C} m^-2 or kg{C} m^-2]
         nutrient_ratio_1: Carbon to nutrient ratio of the first pool/input stream
             [unitless]
         nutrient_ratio_2: Carbon to nutrient ratio of the second pool/input stream
@@ -407,38 +407,38 @@ class InputChemistries:
     """Dataclass containing the chemistry for the input to each litter pool."""
 
     above_metabolic_nitrogen: DataArray
-    """Nitrogen input rate to the aboveground metabolic pool [kg N m^-2 day^-1]"""
+    """Nitrogen input rate to the aboveground metabolic pool [kg{N} m^-2 day^-1]"""
     above_structural_nitrogen: DataArray
-    """Nitrogen input rate to the aboveground structural pool [kg N m^-2 day^-1]"""
+    """Nitrogen input rate to the aboveground structural pool [kg{N} m^-2 day^-1]"""
     woody_nitrogen: DataArray
-    """Nitrogen input rate to the woody pool [kg N m^-2 day^-1]"""
+    """Nitrogen input rate to the woody pool [kg{N} m^-2 day^-1]"""
     below_metabolic_nitrogen: DataArray
-    """Nitrogen input rate to the belowground metabolic pool [kg N m^-2 day^-1]"""
+    """Nitrogen input rate to the belowground metabolic pool [kg{N} m^-2 day^-1]"""
     below_structural_nitrogen: DataArray
-    """Nitrogen input rate to the belowground structural pool [kg N m^-2 day^-1]"""
+    """Nitrogen input rate to the belowground structural pool [kg{N} m^-2 day^-1]"""
 
     above_metabolic_phosphorus: DataArray
-    """Phosphorus input rate to the aboveground metabolic pool [kg P m^-2 day^-1]"""
+    """Phosphorus input rate to the aboveground metabolic pool [kg{P} m^-2 day^-1]"""
     above_structural_phosphorus: DataArray
-    """Phosphorus input rate to the aboveground structural pool [kg P m^-2 day^-1]"""
+    """Phosphorus input rate to the aboveground structural pool [kg{P} m^-2 day^-1]"""
     woody_phosphorus: DataArray
-    """Phosphorus input rate to the woody pool [kg P m^-2 day^-1]"""
+    """Phosphorus input rate to the woody pool [kg{P} m^-2 day^-1]"""
     below_metabolic_phosphorus: DataArray
-    """Phosphorus input rate to the belowground metabolic pool [kg P m^-2 day^-1]"""
+    """Phosphorus input rate to the belowground metabolic pool [kg{P} m^-2 day^-1]"""
     below_structural_phosphorus: DataArray
-    """Phosphorus input rate to the belowground structural pool [kg P m^-2 day^-1]"""
+    """Phosphorus input rate to the belowground structural pool [kg{P} m^-2 day^-1]"""
 
     above_structural_lignin: DataArray
     """Lignin proportion of input to the aboveground structural pool.
     
-    Units of [kg lignin C (kg C)^-1]
+    Units of [kg{lignin C} kg{C}^-1]
     """
     woody_lignin: DataArray
-    """Lignin proportion of input to the woody pool [kg lignin C (kg C)^-1]"""
+    """Lignin proportion of input to the woody pool [kg{lignin C} kg{C}^-1]"""
     below_structural_lignin: DataArray
     """Lignin proportion of input to the belowground structural pool.
      
-    Units of [kg lignin C (kg C)^-1]
+    Units of [kg{lignin C} kg{C}^-1]
     """
 
 
@@ -507,7 +507,7 @@ def calculate_litter_input_lignin_concentrations(
     Returns:
         Dictionary containing the lignin concentration of the input to each of the
         three lignin containing litter pools (woody, above and below ground
-        structural) [kg lignin C (kg C)^-1]
+        structural) [kg{lignin C} kg{C}^-1]
     """
 
     lignin_proportion_woody = litter_inputs.stem_lignin
@@ -552,7 +552,7 @@ def calculate_litter_input_nutrient_masses(
 
     Returns:
         Dictionary containing input rates of the nutrients (nitrogen or phosphorus) into
-        each of the pools [kg nut m^-2 day^-1]
+        each of the pools [kg{nutrient} m^-2 day^-1]
     """
 
     if nutrient not in {"nitrogen", "phosphorus"}:
@@ -608,8 +608,8 @@ def find_nutrient_split_between_litter_pools(
     If there isn't, then there is no nutrient flow to either pool.
 
     Args:
-        input_carbon_rate: Rate of carbon input [kg C m^-2 day^-1]
-        input_nutrient_rate: Rate of nutrient input [kg nut m^-2 day^-1]
+        input_carbon_rate: Rate of carbon input [kg{C} m^-2 day^-1]
+        input_nutrient_rate: Rate of nutrient input [kg{nutrient} m^-2 day^-1]
         metabolic_split: Proportion of organic matter input that flows to the metabolic
             litter pool [unitless]
         meta_to_struct_nutrient_ratio: Ratio of the nutrient concentrations (relative to
@@ -618,7 +618,7 @@ def find_nutrient_split_between_litter_pools(
 
     Returns:
         A tuple containing the nutrient input rate to the metabolic and structural
-        litter pools [kg nut m^-2 day^-1], in that order.
+        litter pools [kg{nutrient} m^-2 day^-1], in that order.
     """
 
     # Calculate rate of carbon input to each pool
@@ -667,17 +667,18 @@ def calculate_nutrient_split(
     litter pools are in a fixed proportion.
 
     Args:
-        carbon_input_meta: Rate of carbon input to the metabolic pool [kg C m^-2 day^-1]
-        carbon_input_struct: Rate of carbon input to the structural pool [kg C m^-2
-            day^-1]
-        input_nutrient_rate: Total rate of nutrient input [kg nut m^-2 day^-1]
+        carbon_input_meta: Rate of carbon input to the metabolic pool
+            [kg{C} m^-2 day^-1]
+        carbon_input_struct: Rate of carbon input to the structural pool
+            [kg{C} m^-2 day^-1]
+        input_nutrient_rate: Total rate of nutrient input [kg{nutrient} m^-2 day^-1]
         meta_to_struct_nutrient_ratio: Ratio of the nutrient concentrations (relative to
             carbon mass) for the inputs to the metabolic and structural litter pools
             [unitless]
 
     Returns:
         A tuple containing the rate of nutrient flow to the metabolic and structural
-        litter pools, respectively [kg nut m^-2 day^-1]
+        litter pools, respectively [kg{nutrient} m^-2 day^-1]
     """
 
     # Find ratio of the carbon contents of the two pools

--- a/virtual_ecosystem/models/litter/inputs.py
+++ b/virtual_ecosystem/models/litter/inputs.py
@@ -44,11 +44,13 @@ class LitterInputs:
     above_metabolic: DataArray
     """Total input rate to the above ground metabolic litter pool [kg{C} m^-2 day^-1]"""
     above_structural: DataArray
-    """Total input rate to the above ground structural litter pool [kg{C} m^-2 day^-1]"""
+    """Total input rate to the above ground structural litter pool [kg{C} m^-2 day^-1]
+    """
     below_metabolic: DataArray
     """Total input rate to the below ground metabolic litter pool [kg{C} m^-2 day^-1]"""
     below_structural: DataArray
-    """Total input rate to the below ground structural litter pool [kg{C} m^-2 day^-1]"""
+    """Total input rate to the below ground structural litter pool [kg{C} m^-2 day^-1]
+    """
 
     @classmethod
     def create_from_data(

--- a/virtual_ecosystem/models/litter/losses.py
+++ b/virtual_ecosystem/models/litter/losses.py
@@ -18,49 +18,49 @@ class LitterLosses:
     """The full set losses for the litter pools, as well as the mineralisation rates."""
 
     above_metabolic_carbon: NDArray[np.floating]
-    """Carbon loss from the aboveground metabolic pool [kg C m^-2]"""
+    """Carbon loss from the aboveground metabolic pool [kg{C} m^-2]"""
     above_structural_carbon: NDArray[np.floating]
-    """Carbon loss from the aboveground structural pool [kg C m^-2]"""
+    """Carbon loss from the aboveground structural pool [kg{C} m^-2]"""
     woody_carbon: NDArray[np.floating]
-    """Carbon loss from the woody pool [kg C m^-2]"""
+    """Carbon loss from the woody pool [kg{C} m^-2]"""
     below_metabolic_carbon: NDArray[np.floating]
-    """Carbon loss from the belowground metabolic pool [kg C m^-2]"""
+    """Carbon loss from the belowground metabolic pool [kg{C} m^-2]"""
     below_structural_carbon: NDArray[np.floating]
-    """Carbon loss from the belowground structural pool [kg C m^-2]"""
+    """Carbon loss from the belowground structural pool [kg{C} m^-2]"""
 
     above_metabolic_nitrogen: NDArray[np.floating]
-    """Nitrogen loss from the aboveground metabolic pool [kg N m^-2]"""
+    """Nitrogen loss from the aboveground metabolic pool [kg{N} m^-2]"""
     above_structural_nitrogen: NDArray[np.floating]
-    """Nitrogen loss from the aboveground structural pool [kg N m^-2]"""
+    """Nitrogen loss from the aboveground structural pool [kg{N} m^-2]"""
     woody_nitrogen: NDArray[np.floating]
-    """Nitrogen loss from the woody pool [kg N m^-2]"""
+    """Nitrogen loss from the woody pool [kg{N} m^-2]"""
     below_metabolic_nitrogen: NDArray[np.floating]
-    """Nitrogen loss from the belowground metabolic pool [kg N m^-2]"""
+    """Nitrogen loss from the belowground metabolic pool [kg{N} m^-2]"""
     below_structural_nitrogen: NDArray[np.floating]
-    """Nitrogen loss from the belowground structural pool [kg N m^-2]"""
+    """Nitrogen loss from the belowground structural pool [kg{N} m^-2]"""
 
     above_metabolic_phosphorus: NDArray[np.floating]
-    """Phosphorus loss from the aboveground metabolic pool [kg P m^-2]"""
+    """Phosphorus loss from the aboveground metabolic pool [kg{P} m^-2]"""
     above_structural_phosphorus: NDArray[np.floating]
-    """Phosphorus loss from the aboveground structural pool [kg P m^-2]"""
+    """Phosphorus loss from the aboveground structural pool [kg{P} m^-2]"""
     woody_phosphorus: NDArray[np.floating]
-    """Phosphorus loss from the woody pool [kg P m^-2]"""
+    """Phosphorus loss from the woody pool [kg{P} m^-2]"""
     below_metabolic_phosphorus: NDArray[np.floating]
-    """Phosphorus loss from the belowground metabolic pool [kg P m^-2]"""
+    """Phosphorus loss from the belowground metabolic pool [kg{P} m^-2]"""
     below_structural_phosphorus: NDArray[np.floating]
-    """Phosphorus loss from the belowground structural pool [kg P m^-2]"""
+    """Phosphorus loss from the belowground structural pool [kg{P} m^-2]"""
 
     above_structural_lignin: NDArray[np.floating]
-    """Lignin loss from the aboveground structural pool [kg lignin C m^-2]"""
+    """Lignin loss from the aboveground structural pool [kg{lignin C} m^-2]"""
     woody_lignin: NDArray[np.floating]
-    """Lignin loss from the woody pool [kg lignin C m^-2]"""
+    """Lignin loss from the woody pool [kg{lignin C} m^-2]"""
     below_structural_lignin: NDArray[np.floating]
-    """Lignin loss from the belowground structural pool [kg lignin C m^-2]"""
+    """Lignin loss from the belowground structural pool [kg{lignin C} m^-2]"""
 
     N_mineralisation_rate: NDArray[np.floating]
-    """Total nitrogen mineralisation rate from all litter pools [kg N m^-3 day^-1]"""
+    """Total nitrogen mineralisation rate from all litter pools [kg{N} m^-3 day^-1]"""
     P_mineralisation_rate: NDArray[np.floating]
-    """Total phosphorus mineralisation rate from all litter pools [kg P m^-3 day^-1]"""
+    """Total phosphorus mineralisation rate from all litter pools [kg{P} m^-3 day^-1]"""
 
 
 def calculate_litter_losses(
@@ -78,9 +78,9 @@ def calculate_litter_losses(
 
     Args:
         data: A :class:`~virtual_ecosystem.core.data.Data` instance.
-        original_pools: Pool sizes before any litter input and decay [kg C m^-2].
-        final_pools: Pool sizes after litter input and decay [kg C m^-2].
-        litter_inputs: The inputs to each litter pool [kg C m^-2 day^-1].
+        original_pools: Pool sizes before any litter input and decay [kg{C} m^-2].
+        final_pools: Pool sizes after litter input and decay [kg{C} m^-2].
+        litter_inputs: The inputs to each litter pool [kg{C} m^-2 day^-1].
         input_chemistries: The chemical compositions of the inputs to each litter pool.
         update_interval: The time period over which the litter pools are updated [days].
         active_microbe_depth: The depth at which microbial activity is assumed to cease
@@ -321,13 +321,13 @@ def calculate_carbon_pool_loss(
     calculation of the loss.
 
     Args:
-        old_pool_size: The size of the litter pool before the update [kg C m^-2].
-        final_pool_size: The size of the litter pool after the update [kg C m^-2].
-        input_rate: The rate of carbon input to the litter pool [kg C m^-2 day^-1].
+        old_pool_size: The size of the litter pool before the update [kg{C} m^-2].
+        final_pool_size: The size of the litter pool after the update [kg{C} m^-2].
+        input_rate: The rate of carbon input to the litter pool [kg{C} m^-2 day^-1].
         update_interval: The time period over which the litter pools are updated [days].
 
     Returns:
-        The total loss of carbon from the pool due to decay [kg C m^-2]
+        The total loss of carbon from the pool due to decay [kg{C} m^-2]
     """
 
     return old_pool_size + (input_rate * update_interval) - final_pool_size
@@ -354,20 +354,20 @@ def calculate_nutrient_pool_loss(
     split.
 
     Args:
-        initial_pool_carbon: Amount of carbon in the litter pool before the update [kg C
-            m^-2]
+        initial_pool_carbon: Amount of carbon in the litter pool before the update
+            [kg{C} m^-2]
         initial_pool_nutrient: Amount of nutrient in the litter pool before the update
-            [kg nut m^-2]
+            [kg{nutrient} m^-2]
         carbon_loss: The total loss of carbon from the pool over the decay period
-            [kg C m^-2]
-        input_rate_carbon: The rate of carbon input to the litter pool [kg C m^-2
-            day^-1]
-        input_rate_nutrient: The rate of nutrient input to the litter pool [kg nut m^-2
-            day^-1]
+            [kg{C} m^-2]
+        input_rate_carbon: The rate of carbon input to the litter pool
+            [kg{C} m^-2 day^-1]
+        input_rate_nutrient: The rate of nutrient input to the litter pool
+            [kg{nutrient} m^-2 day^-1]
         update_interval: The time period over which the litter pools are updated [days].
 
     Returns:
-        The total loss of nutrient from the pool due to decay [kg nutrient m^-2]
+        The total loss of nutrient from the pool due to decay [kg{nutrient} m^-2]
     """
 
     # Find the fraction of the initial pool that has decayed, and the fraction of input
@@ -412,18 +412,18 @@ def calculate_lignin_pool_loss(
     based on this assumed split.
 
     Args:
-        initial_pool_size: The size of the litter pool before the update [kg C m^-2].
+        initial_pool_size: The size of the litter pool before the update [kg{C} m^-2].
         carbon_loss: The total loss of carbon from the pool over the decay period
-            [kg C m^-2].
-        input_rate: The rate of carbon input to the litter pool [kg C m^-2 day^-1].
+            [kg{C} m^-2].
+        input_rate: The rate of carbon input to the litter pool [kg{C} m^-2 day^-1].
         initial_lignin_proportion: The lignin proportion of the litter pool before the
-            update [kg lignin C (kg C)^-1]
+            update [kg{lignin C} kg{C}^-1]
         input_lignin_proportion: The lignin proportion of the input to the litter
-            pool [kg lignin C (kg C)^-1]
+            pool [kg{lignin C} kg{C}^-1]
         update_interval: The time period over which the litter pools are updated [days].
 
     Returns:
-        The total loss of lignin from the pool due to decay [kg lignin C m^-2]
+        The total loss of lignin from the pool due to decay [kg{lignin C} m^-2]
     """
 
     # Find the fraction of the initial pool that has decayed, and the fraction of input

--- a/virtual_ecosystem/models/litter/model_config.py
+++ b/virtual_ecosystem/models/litter/model_config.py
@@ -9,13 +9,13 @@ class LitterConstants(Configuration):
     """Dataclass to store all constants for the `litter` model."""
 
     litter_decomp_reference_temp: float = 40.0
-    """Reference temperature for litter decomposition [C].
+    """Reference temperature for litter decomposition [Celsius].
 
     Value is taken from :cite:t:`kirschbaum_modelling_2002`.
     """
 
     litter_decomp_offset_temp: float = 31.79
-    """Offset temperature for litter decomposition [C].
+    """Offset temperature for litter decomposition [Celsius].
 
     Value is taken from :cite:t:`kirschbaum_modelling_2002`.
     """

--- a/virtual_ecosystem/models/soil/env_factors.py
+++ b/virtual_ecosystem/models/soil/env_factors.py
@@ -97,7 +97,8 @@ def calculate_temperature_effect_on_microbes(
     Args:
         soil_temperature: The temperature of the soil [Celsius]
         activation_energy: Energy of activation [J mol^-1]
-        reference_temperature: The reference temperature of the Arrhenius equation [Celsius]
+        reference_temperature: The reference temperature of the Arrhenius equation
+            [Celsius]
 
     Returns:
         A multiplicative factor capturing the effect of temperature on microbial rates
@@ -314,8 +315,10 @@ def calculate_denitrification_temperature_factor(
         soil_temp: Temperature of the relevant segment of soil [Celsius]
         factor_at_infinity: Value of temperature factor at infinite temperature
             [unitless]
-        minimum_temp: Minimum temperature at which denitrification can still happen [Kelvin]
-        thermal_sensitivity: Sensitivity of the factor to changes in temperature [Kelvin]
+        minimum_temp: Minimum temperature at which denitrification can still happen
+            [Kelvin]
+        thermal_sensitivity: Sensitivity of the factor to changes in temperature
+            [Kelvin]
 
     Returns:
         A factor capturing the impact of soil temperature on the denitrification rate

--- a/virtual_ecosystem/models/soil/env_factors.py
+++ b/virtual_ecosystem/models/soil/env_factors.py
@@ -95,9 +95,9 @@ def calculate_temperature_effect_on_microbes(
     handle these conversions in general.
 
     Args:
-        soil_temperature: The temperature of the soil [C]
+        soil_temperature: The temperature of the soil [Celsius]
         activation_energy: Energy of activation [J mol^-1]
-        reference_temperature: The reference temperature of the Arrhenius equation [C]
+        reference_temperature: The reference temperature of the Arrhenius equation [Celsius]
 
     Returns:
         A multiplicative factor capturing the effect of temperature on microbial rates
@@ -255,10 +255,10 @@ def calculate_nitrification_temperature_factor(
     Form of this function is taken from :cite:t:`xu-ri_terrestrial_2008`.
 
     Args:
-        soil_temp: Temperature of the relevant segment of soil [C]
-        optimum_temp: Temperature at which nitrification is maximised [K]
+        soil_temp: Temperature of the relevant segment of soil [Celsius]
+        optimum_temp: Temperature at which nitrification is maximised [Kelvin]
         max_temp: Maximum temperature for which this expression still gives a meaningful
-            result [K]
+            result [Kelvin]
         thermal_sensitivity: Sensitivity of the factor to changes in temperature
             [unitless]
 
@@ -311,11 +311,11 @@ def calculate_denitrification_temperature_factor(
     :cite:t:`xu-ri_terrestrial_2008`.
 
     Args:
-        soil_temp: Temperature of the relevant segment of soil [C]
+        soil_temp: Temperature of the relevant segment of soil [Celsius]
         factor_at_infinity: Value of temperature factor at infinite temperature
             [unitless]
-        minimum_temp: Minimum temperature at which denitrification can still happen [K]
-        thermal_sensitivity: Sensitivity of the factor to changes in temperature [K]
+        minimum_temp: Minimum temperature at which denitrification can still happen [Kelvin]
+        thermal_sensitivity: Sensitivity of the factor to changes in temperature [Kelvin]
 
     Returns:
         A factor capturing the impact of soil temperature on the denitrification rate
@@ -353,19 +353,20 @@ def calculate_symbiotic_nitrogen_fixation_carbon_cost(
     Kelvin units so this is the only function in the soil model to use Celsius units.
 
     Args:
-        soil_temp: Temperature of the relevant soil zone [C]
-        cost_at_zero_celsius: The cost nitrogen fixation at zero Celsius [kg C kg N^-1]
+        soil_temp: Temperature of the relevant soil zone [Celsius]
+        cost_at_zero_celsius: The cost nitrogen fixation at zero Celsius
+            [kg{C} kg{N}^-1]
         infinite_temp_cost_offset: The difference between the nitrogen fixation cost at
             zero Celsius and the cost that it tends towards at very high temperatures
-            [kg C kg N^-1]
+            [kg{C} kg{N}^-1]
         thermal_sensitivity: Sensitivity of nitrogen fixation cost to changes in
-            temperature [C^-1]
+            temperature [Celsius^-1]
         cost_equality_temp: Temperature (positive) at which the nitrogen fixation cost
-            is the same as it is at zero Celsius [C]
+            is the same as it is at zero Celsius [Celsius]
 
     Returns:
         The carbon cost that plants have to pay their microbial symbionts to fix per
-        unit of nitrogen fixed [kg C kg N^-1]
+        unit of nitrogen fixed [kg{C} kg{N}^-1]
     """
 
     return np.where(
@@ -400,7 +401,7 @@ def calculate_solute_removal_by_soil_water(
     to soil moisture in mm.
 
     Args:
-        solute_density: The density of the solute in the soil [kg solute m^-3]
+        solute_density: The density of the solute in the soil [kg{solute} m^-3]
         exit_rate: Rate at which water exits the microbially active portion of the soil
             [mm day^-1]
         soil_moisture: Volume of water contained in topsoil layer [mm]
@@ -409,7 +410,7 @@ def calculate_solute_removal_by_soil_water(
 
     Returns:
         The rate at which the solute in question is removed from the soil by the flow of
-        water [kg solute m^-3 day^-1]
+        water [kg{solute} m^-3 day^-1]
     """
 
     return np.where(
@@ -433,12 +434,12 @@ def calculate_carbon_use_efficiency(
     TODO - This should be adapted to use an Arrhenius function at some point.
 
     Args:
-        soil_temp: soil temperature for each soil grid cell [degrees C]
+        soil_temp: soil temperature for each soil grid cell [Celsius]
         reference_cue_logit: Logit of the carbon use efficiency at reference temp
             [unitless]
-        cue_reference_temp: Reference temperature [degrees C]
+        cue_reference_temp: Reference temperature [Celsius]
         logit_cue_with_temp: Rate of change in the logit of carbon use efficiency with
-            increasing temperature [degree C^-1]
+            increasing temperature [Celsius^-1]
 
     Returns:
         The carbon use efficiency (CUE) of the microbial community

--- a/virtual_ecosystem/models/soil/microbial_groups.py
+++ b/virtual_ecosystem/models/soil/microbial_groups.py
@@ -33,41 +33,42 @@ class MicrobialGroupConstants:
     """Maximum rate at the reference temperature of labile carbon uptake [day^-1]."""
 
     activation_energy_uptake_rate: float
-    """Activation energy for nutrient uptake [J K^-1]."""
+    """Activation energy for nutrient uptake [J Kelvin^-1]."""
 
     half_sat_labile_C_uptake: float
-    """Half saturation constant for uptake of labile carbon (LMWC) [kg C m^-3]."""
+    """Half saturation constant for uptake of labile carbon (LMWC) [kg{C} m^-3]."""
 
     activation_energy_uptake_saturation: float
-    """Activation energy for nutrient uptake saturation constants [J K^-1]."""
+    """Activation energy for nutrient uptake saturation constants [J Kelvin^-1]."""
 
     max_uptake_rate_ammonium: float
     """Maximum possible rate for ammonium uptake [day^-1]."""
 
     half_sat_ammonium_uptake: float
-    """Half saturation constant for uptake of ammonium [kg N m^-3]."""
+    """Half saturation constant for uptake of ammonium [kg{N} m^-3]."""
 
     max_uptake_rate_nitrate: float
     """Maximum possible rate for nitrate uptake [day^-1]."""
 
     half_sat_nitrate_uptake: float
-    """Half saturation constant for uptake of nitrate [kg N m^-3]."""
+    """Half saturation constant for uptake of nitrate [kg{N} m^-3]."""
 
     max_uptake_rate_labile_p: float
     """Maximum possible rate for labile inorganic phosphorus uptake [day^-1]."""
 
     half_sat_labile_p_uptake: float
-    """Half saturation constant for uptake of labile inorganic phosphorus [kg P m^-3].
+    """Half saturation constant for uptake of labile inorganic phosphorus [kg{P} m^-3].
     """
 
     turnover_rate: float
     """Microbial maintenance turnover rate at reference temperature [day^-1]."""
 
     activation_energy_turnover: float
-    """Activation energy for microbial maintenance turnover rate [J K^-1]."""
+    """Activation energy for microbial maintenance turnover rate [J Kelvin^-1]."""
 
     reference_temperature: float
-    """The reference temperature that turnover and uptake rates were measured at [C].
+    """The reference temperature that turnover and uptake rates were measured at
+    [Celsius].
     """
 
     c_n_ratio: float
@@ -81,7 +82,7 @@ class MicrobialGroupConstants:
     
     The keys are the substrates for which enzymes are produced, and the values are the
     allocation to enzyme production. This allocation is expressed as a fraction of the
-    (gross) cellular biomass growth.
+    (gross) cellular biomass growth [unitless].
     """
 
     reproductive_allocation: float
@@ -93,19 +94,21 @@ class MicrobialGroupConstants:
     """
 
     symbiote_nitrogen_uptake_fraction: float
-    """Fraction of nitrogen uptake that is supplied to symbiotic (plant) partners.
+    """Fraction of nitrogen uptake that is supplied to symbiotic (plant) partners.    
+    [unitless]. 
     
-    [unitless]. This should only have a non-zero value for mycorrhizal fungi.
+    This should only have a non-zero value for mycorrhizal fungi.
     """
 
     symbiote_phosphorus_uptake_fraction: float
-    """Fraction of phosphorus uptake that is supplied to symbiotic (plant) partners.
+    """Fraction of phosphorus uptake that is supplied to symbiotic (plant) partners.    
+    [unitless]. 
     
-    [unitless]. This should only have a non-zero value for mycorrhizal fungi.
+    This should only have a non-zero value for mycorrhizal fungi.
     """
 
     synthesis_nutrient_ratios: dict[str, float]
-    """Average carbon to nutrient ratios for the total synthesised biomass.
+    """Average carbon to nutrient ratios for the total synthesised biomass [unitless].
     
     Microbes have to synthesis both cellular biomass and extracellular enzymes. We
     assume that this occurs in fixed unvarying proportion. This attribute stores the
@@ -247,13 +250,13 @@ class CarbonSupply:
     """Rate of carbon supply to each of the plant symbiotic microbial groups."""
 
     nitrogen_fixers: NDArray[np.floating]
-    """Carbon supply to the nitrogen fixing bacteria [kg C m^-3 day^-1]."""
+    """Carbon supply to the nitrogen fixing bacteria [kg{C} m^-3 day^-1]."""
 
     ectomycorrhiza: NDArray[np.floating]
-    """Carbon supply to ectomycorrhizal fungi [kg C m^-3 day^-1]."""
+    """Carbon supply to ectomycorrhizal fungi [kg{C} m^-3 day^-1]."""
 
     arbuscular_mycorrhiza: NDArray[np.floating]
-    """Carbon supply to arbuscular mycorrhizal fungi [kg C m^-3 day^-1]."""
+    """Carbon supply to arbuscular mycorrhizal fungi [kg{C} m^-3 day^-1]."""
 
 
 def calculate_symbiotic_carbon_supply(
@@ -268,14 +271,14 @@ def calculate_symbiotic_carbon_supply(
 
     Args:
         total_plant_supply: Total supply of carbon from the plant to symbiotic microbial
-            partners [kg C m^-3 day^-1]
+            partners [kg{C} m^-3 day^-1]
         nitrogen_fixer_fraction: Fraction of carbon supplied by plants to symbiotes that
             goes to nitrogen fixers [unitless]
         ectomycorrhiza_fraction: Fraction of plant carbon supply to mycorrhizal fungi
             that goes to ectomycorrhiza [unitless]
 
     Returns:
-        The carbon supply to each symbiotic microbial partner [kg C m^-3 day^-1]
+        The carbon supply to each symbiotic microbial partner [kg{C} m^-3 day^-1]
     """
 
     n_fixer_supply = total_plant_supply * nitrogen_fixer_fraction

--- a/virtual_ecosystem/models/soil/model_config.py
+++ b/virtual_ecosystem/models/soil/model_config.py
@@ -40,12 +40,12 @@ class SoilConstants(Configuration):
     :cite:t:`Qiao2019`."""
 
     cue_reference_temp: float = 20.0
-    """Reference temperature for carbon use efficiency [°C]. Default value taken from
-    :cite:t:`Qiao2019`."""
+    """Reference temperature for carbon use efficiency [Celsius]. Default value taken
+    from :cite:t:`Qiao2019`."""
 
     logit_cue_with_temperature: float = -0.039
     """Change in the logit of carbon use efficiency with unit increase in temperature
-    [°C^-1]. Parameter estimated from a beta-logit GLMM using the data from 
+    [Celsius^-1]. Parameter estimated from a beta-logit GLMM using the data from 
     :cite:t:`Qiao2019`."""
 
     soil_microbe_water_potential_optimum: float = Field(default=-3.0, lt=0.0)
@@ -178,7 +178,7 @@ class SoilConstants(Configuration):
     particularly clear."""
 
     tectonic_uplift_rate_phosphorus: float = 0.0
-    """Rate at which tectonic uplift exposes new primary phosphorus [kg P m^-3 day^-1].
+    """Rate at which tectonic uplift exposes new primary phosphorus [kg{P} m^-3 day^-1].
     This rate is essentially zero for decadal simulations. We have only included to
     give the flexibility to run longer term test scenarios."""
 
@@ -198,13 +198,13 @@ class SoilConstants(Configuration):
     default value from there."""
 
     nitrification_optimum_temperature: float = 311.15
-    """Soil temperature at which nitrification is maximised [K]. Value taken from
+    """Soil temperature at which nitrification is maximised [Kelvin]. Value taken from
     :cite:t:`xu-ri_terrestrial_2008`. This value should not be varied independently of
     :attr:`SoilConstants.nitrification_maximum_temperature` and
     :attr:`SoilConstants.nitrification_thermal_sensitivity`!"""
 
     nitrification_maximum_temperature: float = 343.15
-    """Temperature at which our empirical nitrification model stops working [K].
+    """Temperature at which our empirical nitrification model stops working [Kelvin].
     This is well outside field values so this should be too much of a problem. Value
     taken from :cite:t:`xu-ri_terrestrial_2008`. This value should not be varied
     independently of :attr:`SoilConstants.nitrification_optimum_temperature` and
@@ -224,29 +224,29 @@ class SoilConstants(Configuration):
     :attr:`SoilConstants.denitrification_thermal_sensitivity`!"""
 
     denitrification_minimum_temperature: float = 273.15 - 46.02
-    """Temperature at which denitrification stops entirely [K]. Value is obtained from
-    :cite:t:`xu-ri_terrestrial_2008`, and converted to Kelvin. The expression we are
-    using does not function below this temperature, but this is not a major problem as
-    it is a very low temperature. This value should not be varied independently of
+    """Temperature at which denitrification stops entirely [Kelvin]. Value is obtained
+    from :cite:t:`xu-ri_terrestrial_2008`, and converted to Kelvin. The expression we
+    are using does not function below this temperature, but this is not a major problem
+    as it is a very low temperature. This value should not be varied independently of
     :attr:`SoilConstants.denitrification_infinite_temperature_factor` and
     :attr:`SoilConstants.denitrification_thermal_sensitivity`!"""
 
     denitrification_thermal_sensitivity: float = 308.56
-    """Sensitivity of denitrification rate to changes in temperature [K]. Value is
+    """Sensitivity of denitrification rate to changes in temperature [Kelvin]. Value is
     obtained from :cite:t:`xu-ri_terrestrial_2008`. This value should not be varied
     independently of :attr:`SoilConstants.denitrification_infinite_temperature_factor`
     and :attr:`SoilConstants.denitrification_minimum_temperature`!"""
 
     nitrogen_fixation_cost_zero_celcius: float = 59.19651970522086
-    """Cost (in carbon) that plants pay to their symbiotic partners at zero Celsius [kg
-    C kg N^-1]. This is cost per unit of nitrogen received, and will be higher than the
-    symbiotic partners actually spend to fix the nitrogen. Value is obtained from
-    :cite:t:`brzostek_modeling_2014`. 
+    """Cost (in carbon) that plants pay to their symbiotic partners at zero Celsius
+    [kg{C} kg{N}^-1]. This is cost per unit of nitrogen received, and will be higher 
+    than the symbiotic partners actually spend to fix the nitrogen. Value is obtained 
+    from :cite:t:`brzostek_modeling_2014`. 
     """
 
     nitrogen_fixation_cost_infinite_temp_offset: float = -0.8034802947791453
     """Difference in nitrogen fixation cost between zero Celsius and infinite limit.
-    Units of [kg C kg N^-1]. This limit of infinite temperature is not biologically
+    Units of [kg{C} kg{N}^-1]. This limit of infinite temperature is not biologically
     meaningful and is instead just a way of characterising the form of the empirical
     function. A negative value means that the cost in the infinite temperature limit is
     higher than at zero Celsius. Value is obtained from
@@ -254,22 +254,22 @@ class SoilConstants(Configuration):
 
     nitrogen_fixation_cost_thermal_sensitivity: float = 0.27
     """Sensitivity of symbiotic nitrogen fixation cost to changes in temperature
-    [°C^-1]. Value is obtained from :cite:t:`brzostek_modeling_2014`."""
+    [Celsius^-1]. Value is obtained from :cite:t:`brzostek_modeling_2014`."""
 
     nitrogen_fixation_cost_equality_temperature: float = 50.28
     """Positive temperature at which nitrogen fixation cost is the same at zero Celsius.
-    [°C]. Value is obtained from :cite:t:`brzostek_modeling_2014`."""
+    [Celsius]. Value is obtained from :cite:t:`brzostek_modeling_2014`."""
 
     free_living_N_fixation_reference_rate: float = 15.0 * 1e-4 / 365.25
     """Rate at which free living microbes fix nitrogen (at the reference temperature).
-    Units of [kg N m^-2 day^-1]. Value specific to tropical forests, and is taken from
+    Units of [kg{N} m^-2 day^-1]. Value specific to tropical forests, and is taken from
     :cite:t:`lin_modelling_2000` (with the units adjusted). Should not be changed
     independently from :attr:`SoilConstants.free_living_N_fixation_reference_temp`."""
 
     free_living_N_fixation_reference_temp: float = 293.15
-    """Temperature reference rate of free-living nitrogen fixation was measured at [K].
-    Value taken from :cite:t:`lin_modelling_2000`. Should not be changed independently
-    from :attr:`SoilConstants.free_living_N_fixation_reference_rate`.
+    """Temperature reference rate of free-living nitrogen fixation was measured at
+    [Kelvin]. Value taken from :cite:t:`lin_modelling_2000`. Should not be changed
+    independently from :attr:`SoilConstants.free_living_N_fixation_reference_rate`.
     """
 
     free_living_N_fixation_q10_coefficent: float = 3.0
@@ -289,12 +289,12 @@ class SoilConstants(Configuration):
     [day^-1]. Default value taken from :cite:t:`parton_dynamics_1988`. """
 
     ammonium_deposition_rate: float = 1.5e-4 / 365.25
-    """Rate at which ammonium is deposited into the system [kg N m^-2 day^-1]. We are
+    """Rate at which ammonium is deposited into the system [kg{N} m^-2 day^-1]. We are
     assuming that deposition rates won't vary substantially over the area the 
     simulation encompasses. Value taken from :cite:t:`vet_global_2014`."""
 
     phosphorus_deposition_rate: float = 5e-6 / 365.25
-    """Rate at which phosphorus is deposited into the system [kg P m^-2 day^-1].
+    """Rate at which phosphorus is deposited into the system [kg{P} m^-2 day^-1].
     We are assuming that deposition rates won't vary substantially over the area the
     simulation encompasses. Value taken from :cite:t:`Mahowald2008`."""
 
@@ -345,14 +345,14 @@ class SoilEnzymeClass(Configuration):
     """The maximum rate of the enzyme at the reference temperature [day^-1]."""
     half_saturation_constant: float = Field(default=70.0)
     """The half saturation constant for the enzyme at the reference temperature. Units
-    of [kg C m^-3]."""
+    of [kg{C} m^-3]."""
     activation_energy_rate: float = Field(default=37000)
-    """Activation energy for enzyme rate with temperature [J K^-1]."""
+    """Activation energy for enzyme rate with temperature [J Kelvin^-1]."""
     activation_energy_saturation: float = Field(default=30000)
-    """Activation energy for enzyme saturation with temperature [J K^-1]."""
+    """Activation energy for enzyme saturation with temperature [J Kelvin^-1]."""
     # TODO - This should change to Kelvin when we change the default units to Kelvin
     reference_temperature: float = Field(default=12.0)
-    """The temperature that enzyme rate and saturation were measured at [°C]."""
+    """The temperature that enzyme rate and saturation were measured at [Celsius]."""
     turnover_rate: float = Field(default=0.024)
     """The turnover rate of the enzyme [day^-1]."""
     c_n_ratio: float = Field(default=5.2)
@@ -371,30 +371,30 @@ class SoilMicrobialGroup(Configuration):
     max_uptake_rate_labile_C: float = Field(default=0.04)
     """Maximum rate at the reference temperature of labile carbon uptake [day^-1]."""
     activation_energy_uptake_rate: float = Field(default=47000)
-    """Activation energy for nutrient uptake [J K^-1]."""
+    """Activation energy for nutrient uptake [J Kelvin^-1]."""
     half_sat_labile_C_uptake: float = Field(default=0.364)
-    """Half saturation constant for uptake of labile carbon (LMWC) [kg C m^-3]."""
+    """Half saturation constant for uptake of labile carbon (LMWC) [kg{C} m^-3]."""
     activation_energy_uptake_saturation: float = Field(default=30000)
-    """Activation energy for nutrient uptake saturation constants [J K^-1]."""
+    """Activation energy for nutrient uptake saturation constants [J Kelvin^-1]."""
     max_uptake_rate_ammonium: float = Field(default=0.005)
     """Maximum possible rate for ammonium uptake [day^-1]."""
     half_sat_ammonium_uptake: float = Field(default=0.02275)
-    """Half saturation constant for uptake of ammonium [kg N m^-3]."""
+    """Half saturation constant for uptake of ammonium [kg{N} m^-3]."""
     max_uptake_rate_nitrate: float = Field(default=0.0005)
     """Maximum possible rate for nitrate uptake [day^-1]."""
     half_sat_nitrate_uptake: float = Field(default=0.02275)
-    """Half saturation constant for uptake of nitrate [kg N m^-3]."""
+    """Half saturation constant for uptake of nitrate [kg{N} m^-3]."""
     max_uptake_rate_labile_p: float = Field(default=0.0025)
     """Maximum possible rate for labile inorganic phosphorus uptake [day^-1]."""
     half_sat_labile_p_uptake: float = Field(default=0.02275)
-    """Half saturation constant for uptake of labile inorganic phosphorus [kg P m^-3].
+    """Half saturation constant for uptake of labile inorganic phosphorus [kg{P} m^-3].
     """
     turnover_rate: float = Field(default=0.005)
     """Microbial maintenance turnover rate at reference temperature [day^-1]."""
     activation_energy_turnover: float = Field(default=20000)
-    """Activation energy for microbial maintenance turnover rate [J K^-1]."""
+    """Activation energy for microbial maintenance turnover rate [J Kelvin^-1]."""
     reference_temperature: float = Field(default=12.0)
-    """The temperature that turnover and uptake rates were measured at [°C]."""
+    """The temperature that turnover and uptake rates were measured at [Celsius]."""
     c_n_ratio: float = Field(default=5.2)
     """Ratio of carbon to nitrogen in biomass [unitless]."""
     c_p_ratio: float = Field(default=16)

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -51,21 +51,21 @@ class MicrobialChanges:
     lmwc_uptake: NDArray[np.floating]
     """Total rate of microbial uptake of low molecular weight carbon.
     
-    Units of [kg C m^-3 day^-1]."""
+    Units of [kg{C} m^-3 day^-1]."""
 
     don_uptake: NDArray[np.floating]
     """Total rate of microbial uptake of dissolved organic nitrogen.
     
-    Units of [kg N m^-3 day^-1]."""
+    Units of [kg{N} m^-3 day^-1]."""
 
     ammonium_change: NDArray[np.floating]
-    """Total change in the ammonium pool due to microbial activity [kg N m^-3 day^-1].
+    """Total change in the ammonium pool due to microbial activity [kg{N} m^-3 day^-1].
     
     This change arises from the balance of immobilisation and mineralisation of
     ammonium. A positive value indicates a net immobilisation (uptake) of ammonium."""
 
     nitrate_change: NDArray[np.floating]
-    """Total change in the nitrate pool due to microbial activity [kg N m^-3 day^-1].
+    """Total change in the nitrate pool due to microbial activity [kg{N} m^-3 day^-1].
 
     This change arises from the balance of immobilisation and mineralisation of
     nitrate. A positive value indicates a net immobilisation (uptake) of nitrate."""
@@ -73,76 +73,76 @@ class MicrobialChanges:
     dop_uptake: NDArray[np.floating]
     """Total rate of microbial uptake of dissolved organic phosphorus.
     
-    Units of [kg P m^-3 day^-1]."""
+    Units of [kg{P} m^-3 day^-1]."""
 
     labile_p_change: NDArray[np.floating]
     """Total change in the labile inorganic phosphorus pool due to microbial activity.
     
-    Units of [kg P m^-3 day^-1]. This change arises from the balance of immobilisation
+    Units of [kg{P} m^-3 day^-1]. This change arises from the balance of immobilisation
     and mineralisation of labile P. A positive value indicates a net immobilisation
     (uptake) of P. """
 
     bacteria_change: NDArray[np.floating]
-    """Rate of change of bacterial biomass pool [kg C m^-3 day^-1]."""
+    """Rate of change of bacterial biomass pool [kg{C} m^-3 day^-1]."""
 
     saprotrophic_fungi_change: NDArray[np.floating]
-    """Rate of change of saprotrophic fungal biomass pool [kg C m^-3 day^-1]."""
+    """Rate of change of saprotrophic fungal biomass pool [kg{C} m^-3 day^-1]."""
 
     arbuscular_mycorrhiza_change: NDArray[np.floating]
-    """Rate of change of arbuscular mycorrhizal fungi biomass pool [kg C m^-3 day^-1].
+    """Rate of change of arbuscular mycorrhizal fungi biomass pool [kg{C} m^-3 day^-1].
     """
 
     ectomycorrhiza_change: NDArray[np.floating]
-    """Rate of change of ectomycorrhizal fungi biomass pool [kg C m^-3 day^-1]."""
+    """Rate of change of ectomycorrhizal fungi biomass pool [kg{C} m^-3 day^-1]."""
 
     pom_enzyme_bacteria_change: NDArray[np.floating]
     """Rate of change for the bacterially produced :term:`POM` degrading enzymes.
 
-    Units of [kg C m^-3 day^-1].
+    Units of [kg{C} m^-3 day^-1].
     """
 
     maom_enzyme_bacteria_change: NDArray[np.floating]
     """Rate of change for the bacterially produced :term:`MAOM` degrading enzymes.
     
-    Units of [kg C m^-3 day^-1].
+    Units of [kg{C} m^-3 day^-1].
     """
 
     pom_enzyme_fungi_change: NDArray[np.floating]
     """Rate of change for the fungally produced :term:`POM` degrading enzymes.
 
-    Units of [kg C m^-3 day^-1].
+    Units of [kg{C} m^-3 day^-1].
     """
 
     maom_enzyme_fungi_change: NDArray[np.floating]
     """Rate of change for the fungally produced :term:`MAOM` degrading enzymes.
     
-    Units of [kg C m^-3 day^-1].
+    Units of [kg{C} m^-3 day^-1].
     """
 
     necromass_generation: NDArray[np.floating]
-    """Rate at which necromass is being produced [kg C m^-3 day^-1]."""
+    """Rate at which necromass is being produced [kg{C} m^-3 day^-1]."""
 
     necromass_n_flow: NDArray[np.floating]
-    """Nitrogen flow associated with necromass generation [kg N m^-3 day^-1]."""
+    """Nitrogen flow associated with necromass generation [kg{N} m^-3 day^-1]."""
 
     necromass_p_flow: NDArray[np.floating]
-    """Phosphorus flow associated with necromass generation [kg P m^-3 day^-1]."""
+    """Phosphorus flow associated with necromass generation [kg{P} m^-3 day^-1]."""
 
     fruiting_body_production: NDArray[np.floating]
-    """Rate at which fungal fruiting bodies are being produced [kg C m^-3 day^-1]."""
+    """Rate at which fungal fruiting bodies are being produced [kg{C} m^-3 day^-1]."""
 
     arbuscular_mycorrhiza_n_supply: NDArray[np.floating]
-    """Supply rate of nitrogen to plants by arbuscular mycorrhiza [kg N m^-3 day^-1]."""
+    """Supply rate of nitrogen to plants by arbuscular mycorrhiza [kg{N} m^-3 day^-1]."""
 
     arbuscular_mycorrhiza_p_supply: NDArray[np.floating]
-    """Supply rate of phosphorus to plants by arbuscular mycorrhiza [kg P m^-3 day^-1].
+    """Supply rate of phosphorus to plants by arbuscular mycorrhiza [kg{P} m^-3 day^-1].
     """
 
     ectomycorrhiza_n_supply: NDArray[np.floating]
-    """Supply rate of nitrogen to plants by ectomycorrhiza [kg N m^-3 day^-1]."""
+    """Supply rate of nitrogen to plants by ectomycorrhiza [kg{N} m^-3 day^-1]."""
 
     ectomycorrhiza_p_supply: NDArray[np.floating]
-    """Supply rate of phosphorus to plants by ectomycorrhiza [kg P m^-3 day^-1].
+    """Supply rate of phosphorus to plants by ectomycorrhiza [kg{P} m^-3 day^-1].
     """
 
 
@@ -153,13 +153,13 @@ class EnzymeMediatedRates:
     pom_to_lmwc: NDArray[np.floating]
     """Rate of particulate organic matter decomposition to low molecular weight carbon.
     
-    Units of [kg C m^-3 day^-1].
+    Units of [kg{C} m^-3 day^-1].
     """
 
     maom_to_lmwc: NDArray[np.floating]
     """Rate of mineral associated organic matter decomposition to LMWC.
 
-    Units of [kg C m^-3 day^-1].
+    Units of [kg{C} m^-3 day^-1].
     """
 
 
@@ -170,49 +170,49 @@ class EnzymePoolChanges:
     net_change_pom_bacteria: NDArray[np.floating]
     """Net change in the bacterially produced enzyme pool that breaks down :term:`POM`.
     
-    Units of [kg C m^-3 day^-1]
+    Units of [kg{C} m^-3 day^-1]
     """
 
     net_change_maom_bacteria: NDArray[np.floating]
     """Net change in the bacterially produced enzyme pool that breaks down :term:`MAOM`.
     
-    Units of [kg C m^-3 day^-1]
+    Units of [kg{C} m^-3 day^-1]
     """
 
     net_change_pom_fungi: NDArray[np.floating]
     """Net change in the fungally produced enzyme pool that breaks down :term:`POM`.
     
-    Units of [kg C m^-3 day^-1]
+    Units of [kg{C} m^-3 day^-1]
     """
 
     net_change_maom_fungi: NDArray[np.floating]
     """Net change in the fungally produced enzyme pool that breaks down :term:`MAOM`.
     
-    Units of [kg C m^-3 day^-1]
+    Units of [kg{C} m^-3 day^-1]
     """
 
     denaturation_pom_bacteria: NDArray[np.floating]
     """Denaturation rate for the :term:`POM` degrading enzyme produced by bacteria.
     
-    Units of [kg C m^-3 day^-1]
+    Units of [kg{C} m^-3 day^-1]
     """
 
     denaturation_maom_bacteria: NDArray[np.floating]
     """Denaturation rate for the :term:`MAOM` degrading enzyme produced by bacteria.
     
-    Units of [kg C m^-3 day^-1]
+    Units of [kg{C} m^-3 day^-1]
     """
 
     denaturation_pom_fungi: NDArray[np.floating]
     """Denaturation rate for the :term:`POM` degrading enzyme produced by fungi.
     
-    Units of [kg C m^-3 day^-1]
+    Units of [kg{C} m^-3 day^-1]
     """
 
     denaturation_maom_fungi: NDArray[np.floating]
     """Denaturation rate for the :term:`MAOM` degrading enzyme produced by fungi.
     
-    Units of [kg C m^-3 day^-1]
+    Units of [kg{C} m^-3 day^-1]
     """
 
 
@@ -221,16 +221,16 @@ class BiomassLosses:
     """Losses of biomass from each microbial functional group due to turnover."""
 
     bacteria: NDArray[np.floating]
-    """Rate of loss of bacterial biomass [kg C m^-3 day^-1]."""
+    """Rate of loss of bacterial biomass [kg{C} m^-3 day^-1]."""
 
     saprotrophic_fungi: NDArray[np.floating]
-    """Rate of loss of saprotrophic fungal biomass [kg C m^-3 day^-1]."""
+    """Rate of loss of saprotrophic fungal biomass [kg{C} m^-3 day^-1]."""
 
     ectomycorrhiza: NDArray[np.floating]
-    """Rate of loss of ectomycorrhizal fungal biomass [kg C m^-3 day^-1]."""
+    """Rate of loss of ectomycorrhizal fungal biomass [kg{C} m^-3 day^-1]."""
 
     arbuscular_mycorrhiza: NDArray[np.floating]
-    """Rate of loss of arbuscular mycorrhizal fungal biomass [kg C m^-3 day^-1]."""
+    """Rate of loss of arbuscular mycorrhizal fungal biomass [kg{C} m^-3 day^-1]."""
 
 
 @dataclass
@@ -238,22 +238,22 @@ class WaterRemovalRates:
     """Rate at which each soluble nutrient pool is removed due to soil water flows."""
 
     lmwc: NDArray[np.floating]
-    """Removal rate for the low molecular weight carbon pool [kg C m^-3 day^-1]."""
+    """Removal rate for the low molecular weight carbon pool [kg{C} m^-3 day^-1]."""
 
     don: NDArray[np.floating]
-    """Loss of dissolved organic nitrogen due to LMWC removal [kg N m^-3 day^-1]."""
+    """Loss of dissolved organic nitrogen due to LMWC removal [kg{N} m^-3 day^-1]."""
 
     dop: NDArray[np.floating]
-    """Loss of dissolved organic phosphorus due to LMWC removal [kg P m^-3 day^-1]."""
+    """Loss of dissolved organic phosphorus due to LMWC removal [kg{P} m^-3 day^-1]."""
 
     ammonium: NDArray[np.floating]
-    """Removal rate for the soil ammonium pool [kg N m^-3 day^-1]."""
+    """Removal rate for the soil ammonium pool [kg{N} m^-3 day^-1]."""
 
     nitrate: NDArray[np.floating]
-    """Removal rate for the soil nitrate pool [kg N m^-3 day^-1]."""
+    """Removal rate for the soil nitrate pool [kg{N} m^-3 day^-1]."""
 
     labile_P: NDArray[np.floating]
-    """Removal rate for the labile inorganic phosphorus pool [kg P m^-3 day^-1]."""
+    """Removal rate for the labile inorganic phosphorus pool [kg{P} m^-3 day^-1]."""
 
 
 @dataclass
@@ -261,30 +261,30 @@ class LitterMineralisationFluxes:
     """Fluxes into each soil pool due to mineralisation from litter model."""
 
     lmwc: NDArray[np.floating]
-    """Mineralisation into the low molecular weight carbon pool [kg C m^-3 day^-1]."""
+    """Mineralisation into the low molecular weight carbon pool [kg{C} m^-3 day^-1]."""
 
     pom: NDArray[np.floating]
-    """Mineralisation into the particulate organic matter pool [kg C m^-3 day^-1]."""
+    """Mineralisation into the particulate organic matter pool [kg{C} m^-3 day^-1]."""
 
     don: NDArray[np.floating]
-    """Mineralisation into the dissolved organic nitrogen pool [kg N m^-3 day^-1]."""
+    """Mineralisation into the dissolved organic nitrogen pool [kg{N} m^-3 day^-1]."""
 
     ammonium: NDArray[np.floating]
-    """Mineralisation into the ammonium pool [kg N m^-3 day^-1]."""
+    """Mineralisation into the ammonium pool [kg{N} m^-3 day^-1]."""
 
     particulate_n: NDArray[np.floating]
-    """Mineralisation into the particulate organic nitrogen pool [kg N m^-3 day^-1]."""
+    """Mineralisation into the particulate organic nitrogen pool [kg{N} m^-3 day^-1]."""
 
     dop: NDArray[np.floating]
-    """Mineralisation into the dissolved organic phosphorus pool [kg P m^-3 day^-1]."""
+    """Mineralisation into the dissolved organic phosphorus pool [kg{P} m^-3 day^-1]."""
 
     labile_p: NDArray[np.floating]
-    """Mineralisation into the labile inorganic phosphorus pool [kg P m^-3 day^-1]."""
+    """Mineralisation into the labile inorganic phosphorus pool [kg{P} m^-3 day^-1]."""
 
     particulate_p: NDArray[np.floating]
     """Mineralisation into the particulate organic phosphorus pool.
     
-    Units of [kg P m^-3 day^-1].
+    Units of [kg{P} m^-3 day^-1].
     """
 
 
@@ -293,105 +293,105 @@ class PoolData:
     """Data class collecting the full set of soil pools updated by the soil model."""
 
     soil_cnp_pool_maom_carbon: NDArray[np.floating]
-    """Carbon content of the mineral associated organic matter pool [kg C m^-3]."""
+    """Carbon content of the mineral associated organic matter pool [kg{C} m^-3]."""
 
     soil_cnp_pool_maom_nitrogen: NDArray[np.floating]
-    """Nitrogen content of the :term:`MAOM` pool [kg N m^-3]."""
+    """Nitrogen content of the :term:`MAOM` pool [kg{N} m^-3]."""
 
     soil_cnp_pool_maom_phosphorus: NDArray[np.floating]
-    """Phosphorus content of the :term:`MAOM` pool [kg P m^-3]."""
+    """Phosphorus content of the :term:`MAOM` pool [kg{P} m^-3]."""
 
     soil_cnp_pool_lmwc_carbon: NDArray[np.floating]
-    """Carbon content of the low molecular weight carbon pool [kg C m^-3]."""
+    """Carbon content of the low molecular weight carbon pool [kg{C} m^-3]."""
 
     soil_cnp_pool_lmwc_nitrogen: NDArray[np.floating]
-    """Nitrogen content of the :term:`LMWC` pool [kg N m^-3]."""
+    """Nitrogen content of the :term:`LMWC` pool [kg{N} m^-3]."""
 
     soil_cnp_pool_lmwc_phosphorus: NDArray[np.floating]
-    """Phosphorus content of the :term:`LMWC` pool [kg P m^-3]."""
+    """Phosphorus content of the :term:`LMWC` pool [kg{P} m^-3]."""
 
     soil_c_pool_bacteria: NDArray[np.floating]
-    """Bacterial biomass pool [kg C m^-3]."""
+    """Bacterial biomass pool [kg{C} m^-3]."""
 
     soil_c_pool_saprotrophic_fungi: NDArray[np.floating]
-    """Saprotrophic fungi biomass pool [kg C m^-3]."""
+    """Saprotrophic fungi biomass pool [kg{C} m^-3]."""
 
     soil_c_pool_arbuscular_mycorrhiza: NDArray[np.floating]
-    """Arbuscular mycorrhizal fungi biomass pool [kg C m^-3]."""
+    """Arbuscular mycorrhizal fungi biomass pool [kg{C} m^-3]."""
 
     soil_c_pool_ectomycorrhiza: NDArray[np.floating]
-    """Ectomycorrhizal fungi biomass pool [kg C m^-3]."""
+    """Ectomycorrhizal fungi biomass pool [kg{C} m^-3]."""
 
     soil_cnp_pool_pom_carbon: NDArray[np.floating]
-    """Carbon content of the particulate organic matter pool [kg C m^-3]."""
+    """Carbon content of the particulate organic matter pool [kg{C} m^-3]."""
 
     soil_cnp_pool_pom_nitrogen: NDArray[np.floating]
-    """Nitrogen content of the :term:`POM` pool [kg N m^-3]."""
+    """Nitrogen content of the :term:`POM` pool [kg{N} m^-3]."""
 
     soil_cnp_pool_pom_phosphorus: NDArray[np.floating]
-    """Phosphorus content of the :term:`POM` pool [kg P m^-3]."""
+    """Phosphorus content of the :term:`POM` pool [kg{P} m^-3]."""
 
     soil_cnp_pool_necromass_carbon: NDArray[np.floating]
-    """Carbon content of the microbial necromass pool [kg C m^-3]."""
+    """Carbon content of the microbial necromass pool [kg{C} m^-3]."""
 
     soil_cnp_pool_necromass_nitrogen: NDArray[np.floating]
-    """Nitrogen content of the microbial necromass pool [kg N m^-3]."""
+    """Nitrogen content of the microbial necromass pool [kg{N} m^-3]."""
 
     soil_cnp_pool_necromass_phosphorus: NDArray[np.floating]
-    """Phosphorus content of the microbial necromass pool [kg P m^-3]."""
+    """Phosphorus content of the microbial necromass pool [kg{P} m^-3]."""
 
     soil_enzyme_pom_bacteria: NDArray[np.floating]
-    """Bacteria produced enzyme class which breaks down :term:`POM` [kg C m^-3]."""
+    """Bacteria produced enzyme class which breaks down :term:`POM` [kg{C} m^-3]."""
 
     soil_enzyme_maom_bacteria: NDArray[np.floating]
-    """Bacteria produced enzyme class which breaks down :term:`MAOM` [kg C m^-3]."""
+    """Bacteria produced enzyme class which breaks down :term:`MAOM` [kg{C} m^-3]."""
 
     soil_enzyme_pom_fungi: NDArray[np.floating]
-    """Fungi produced enzyme class which breaks down :term:`POM` [kg C m^-3]."""
+    """Fungi produced enzyme class which breaks down :term:`POM` [kg{C} m^-3]."""
 
     soil_enzyme_maom_fungi: NDArray[np.floating]
-    """Fungi produced enzyme class which breaks down :term:`MAOM` [kg C m^-3]."""
+    """Fungi produced enzyme class which breaks down :term:`MAOM` [kg{C} m^-3]."""
 
     soil_n_pool_ammonium: NDArray[np.floating]
-    r"""Soil ammonium (:math:`\ce{NH4+}`) pool [kg N m^-3]."""
+    r"""Soil ammonium (:math:`\ce{NH4+}`) pool [kg{N} m^-3]."""
 
     soil_n_pool_nitrate: NDArray[np.floating]
-    r"""Soil nitrate (:math:`\ce{NO3-}`) pool [kg N m^-3]."""
+    r"""Soil nitrate (:math:`\ce{NO3-}`) pool [kg{N} m^-3]."""
 
     soil_p_pool_primary: NDArray[np.floating]
-    """Primary mineral phosphorus pool [kg P m^-3]."""
+    """Primary mineral phosphorus pool [kg{P} m^-3]."""
 
     soil_p_pool_secondary: NDArray[np.floating]
-    """Secondary (inorganic) mineral phosphorus pool [kg P m^-3]."""
+    """Secondary (inorganic) mineral phosphorus pool [kg{P} m^-3]."""
 
     soil_p_pool_labile: NDArray[np.floating]
-    """Inorganic labile phosphorus pool [kg P m^-3]."""
+    """Inorganic labile phosphorus pool [kg{P} m^-3]."""
 
     new_fungal_fruiting_body_production: NDArray[np.floating]
-    """Fungal fruiting biomass produced during simulation time step [kg C m^-3]."""
+    """Fungal fruiting biomass produced during simulation time step [kg{C} m^-3]."""
 
     new_amf_n_supply: NDArray[np.floating]
     """Nitrogen supplied to plants by arbuscular mycorrhiza over integration time.
 
-    Units of [kg N m^-3].
+    Units of [kg{N} m^-3].
     """
 
     new_amf_p_supply: NDArray[np.floating]
     """Phosphorus supplied to plants by arbuscular mycorrhiza over integration time.
 
-    Units of [kg P m^-3].
+    Units of [kg{P} m^-3].
     """
 
     new_emf_n_supply: NDArray[np.floating]
     """Nitrogen supplied to plants by ectomycorrhiza over integration time.
 
-    Units of [kg N m^-3].
+    Units of [kg{N} m^-3].
     """
 
     new_emf_p_supply: NDArray[np.floating]
     """Phosphorus supplied to plants by ectomycorrhiza over integration time.
 
-    Units of [kg P m^-3].
+    Units of [kg{P} m^-3].
     """
 
 
@@ -878,13 +878,13 @@ def calculate_microbial_changes(
 
     Args:
         pools: Data class containing the various soil pools.
-        soil_temp: soil temperature for each soil grid cell [degrees C]
+        soil_temp: soil temperature for each soil grid cell [Celsius]
         env_factors: Data class containing the various factors through which the
             environment effects soil cycling rates.
         constants: Set of constants for the soil model.
         microbial_groups: Set of microbial functional groups used by the soil model.
         enzyme_classes: Details of the enzyme classes used by the soil model.
-        carbon_supply: The carbon supply to each symbiotic microbial partner [kg C m^-3
+        carbon_supply: The carbon supply to each symbiotic microbial partner [kg{C} m^-3
             day^-1]
 
     Returns:
@@ -1087,10 +1087,10 @@ def calculate_biomass_losses(
     Args:
         pools: Data class containing the various soil pools.
         microbial_groups: Set of microbial functional groups defined in the soil model.
-        soil_temp: temperature of the microbially active soil [degrees C]
+        soil_temp: temperature of the microbially active soil [Celsius]
 
     Returns:
-        The rate of biomass loss of each microbial functional group [kg C m^-3 day^-1]
+        The rate of biomass loss of each microbial functional group [kg{C} m^-3 day^-1]
     """
 
     return BiomassLosses(
@@ -1115,7 +1115,7 @@ def calculate_enzyme_mediated_rates(
 
     Args:
         pools: Data class containing the various soil pools.
-        soil_temp: soil temperature for each soil grid cell [degrees C]
+        soil_temp: soil temperature for each soil grid cell [Celsius]
         env_factors: Data class containing the various factors through which the
             environment effects soil cycling rates.
         enzyme_classes: Details of the enzyme classes used in the soil model.
@@ -1169,17 +1169,17 @@ def calculate_nutrient_removal_by_water(
     removal rate of the LMWC pool.
 
     Args:
-        soil_c_pool_lmwc: Low molecular weight carbon pool [kg C m^-3]
-        soil_n_pool_don: Dissolved organic nitrogen pool [kg N m^-3]
-        soil_p_pool_dop: Dissolved organic phosphorus pool [kg P m^-3]
-        soil_n_pool_ammonium: Soil ammonium pool [kg N m^-3]
-        soil_n_pool_nitrate: Soil nitrate pool [kg N m^-3]
-        soil_p_pool_labile: Labile inorganic phosphorus pool [kg P m^-3]
+        soil_c_pool_lmwc: Low molecular weight carbon pool [kg{C} m^-3]
+        soil_n_pool_don: Dissolved organic nitrogen pool [kg{N} m^-3]
+        soil_p_pool_dop: Dissolved organic phosphorus pool [kg{P} m^-3]
+        soil_n_pool_ammonium: Soil ammonium pool [kg{N} m^-3]
+        soil_n_pool_nitrate: Soil nitrate pool [kg{N} m^-3]
+        soil_p_pool_labile: Labile inorganic phosphorus pool [kg{P} m^-3]
         vertical_flow_rates: Rates of flow downwards between the different soil layers
             [mm day^-1]
         soil_moisture: Volume of water contained in topsoil layer [mm]
         layer_structure: The details of the layer structure used across the Virtual
-                Ecosystem.
+            Ecosystem.
         constants: Set of constants for the soil model.
 
     Returns:
@@ -1242,7 +1242,7 @@ def calculate_enzyme_changes(
 
     Args:
         pools: Data class containing the various soil pools.
-        enzyme_production: Production rates for each class of enzyme [kg C m^-3 day^-1]
+        enzyme_production: Production rates for each class of enzyme [kg{C} m^-3 day^-1]
         constants: Set of constants for the soil model.
         enzyme_classes: Details of the enzyme classes used in the soil model.
 
@@ -1300,8 +1300,9 @@ def calculate_net_enzyme_change(
     in the enzyme pool of interest.
 
     Args:
-        enzyme_pool_size: Amount of enzyme class of interest [kg C m^-3]
-        enzyme_production: Production rate for the enzyme in question [kg C m^-3 day^-1]
+        enzyme_pool_size: Amount of enzyme class of interest [kg{C} m^-3]
+        enzyme_production: Production rate for the enzyme in question
+            [kg{C} m^-3 day^-1]
         enzyme_turnover_rate: Rate at which the enzyme denatures [day^-1]
 
     Returns:
@@ -1330,12 +1331,12 @@ def calculate_enzyme_production(
 
     Args:
         microbial_groups: Set of microbial functional groups defined in the soil model
-        growth_rates: The (gross) growth rates of each microbial group [kg C m^-3
-            day^-1]
+        growth_rates: The (gross) growth rates of each microbial group
+        [kg{C} m^-3 day^-1]
 
     Returns:
-        A dictionary containing the total production rate of each enzyme class [kg C
-        m^-3 day^-1]
+        A dictionary containing the total production rate of each enzyme class
+        [kg{C} m^-3 day^-1]
     """
 
     production_rates: dict[str, NDArray[np.floating]] = {}
@@ -1368,12 +1369,12 @@ def calculate_fruiting_body_production(
 
     Args:
         microbial_groups: Set of microbial functional groups defined in the soil model
-        growth_rates: The (gross) growth rates of each microbial group [kg C m^-3
-            day^-1]
+        growth_rates: The (gross) growth rates of each microbial group
+        [kg{C} m^-3 day^-1]
 
     Returns:
-        The total production rate of fungal fruiting bodies by the soil microbes [kg C
-        m^-3 day^-1]
+        The total production rate of fungal fruiting bodies by the soil microbes
+        [kg{C} m^-3 day^-1]
     """
 
     fruiting_body_production = np.zeros_like(growth_rates["bacteria"])
@@ -1402,13 +1403,13 @@ def calculate_maintenance_biomass_synthesis(
     decay, but also include loses due to extracellular enzyme excretion.
 
     Args:
-        microbe_pool_size: Size of the microbial pool of interest [kg C m^-3]
-        soil_temp: soil temperature for each soil grid cell [degrees C]
+        microbe_pool_size: Size of the microbial pool of interest [kg{C} m^-3]
+        soil_temp: soil temperature for each soil grid cell [Celsius]
         microbial_group: Constants associated with the microbial group of interest
 
     Returns:
         The rate of microbial biomass loss that must be matched to maintain a steady
-        population [kg C m^-3 day^-1]
+        population [kg{C} m^-3 day^-1]
     """
 
     temp_factor = calculate_temperature_effect_on_microbes(
@@ -1430,11 +1431,11 @@ def calculate_enzyme_turnover(
     """Calculate the turnover rate of a specific enzyme class.
 
     Args:
-        enzyme_pool: The pool size for the enzyme class in question [kg C m^-3]
+        enzyme_pool: The pool size for the enzyme class in question [kg{C} m^-3]
         turnover_rate: The rate at which enzymes in the pool turnover [day^-1]
 
     Returns:
-        The rate at which enzymes are lost from the pool [kg C m^-3 day^-1]
+        The rate at which enzymes are lost from the pool [kg{C} m^-3 day^-1]
     """
 
     return np.where(enzyme_pool > 0, turnover_rate * enzyme_pool, 0)
@@ -1454,17 +1455,17 @@ def calculate_enzyme_mediated_decomposition(
     are then used to find the decomposition rate of the pool in question.
 
     Args:
-        soil_c_pool: Size of organic matter pool [kg C m^-3]
+        soil_c_pool: Size of organic matter pool [kg{C} m^-3]
         soil_enzyme: Amount of enzyme class which breaks down the organic matter pool in
-            question [kg C m^-3]
-        soil_temp: soil temperature for each soil grid cell [degrees C]
+            question [kg{C} m^-3]
+        soil_temp: soil temperature for each soil grid cell [Celsius]
         env_factors: Data class containing the various factors through which the
             environment effects soil cycling rates.
         enzyme_class: Constants associated with the enzyme class in question.
 
     Returns:
-        The rate of decomposition of the organic matter pool in question [kg C m^-3
-        day^-1]
+        The rate of decomposition of the organic matter pool in question
+        [kg{C} m^-3 day^-1]
     """
 
     # Calculate the factors which impact the rate and saturation constants
@@ -1510,11 +1511,12 @@ def calculate_maom_desorption(
     rates. This may be something we want to alter in future.
 
     Args:
-        soil_c_pool_maom: Size of the mineral associated organic matter pool [kg C m^-3]
-        desorption_rate_constant: Rate constant for MAOM desorption [day^-1]
+        soil_c_pool_maom: Size of the mineral associated organic matter pool
+        [kg{C} m^-3] desorption_rate_constant: Rate constant for MAOM desorption
+        [day^-1]
 
     Returns:
-        The rate of MAOM desorption to LMWC [kg C m^-3 day^-1]
+        The rate of MAOM desorption to LMWC [kg{C} m^-3 day^-1]
     """
 
     return np.where(
@@ -1536,11 +1538,11 @@ def calculate_sorption_to_maom(
     rates. This may be something we want to alter in future.
 
     Args:
-        soil_c_pool: Size of carbon pool [kg C m^-3]
+        soil_c_pool: Size of carbon pool [kg{C} m^-3]
         sorption_rate_constant: Rate constant for sorption to MAOM [day^-1]
 
     Returns:
-        The rate of sorption to MAOM [kg C m^-3 day^-1]
+        The rate of sorption to MAOM [kg{C} m^-3 day^-1]
     """
 
     return np.where(soil_c_pool >= 0, sorption_rate_constant * soil_c_pool, 0)
@@ -1558,11 +1560,11 @@ def calculate_necromass_breakdown(
     to bear in mind when planning future model improvements.
 
     Args:
-        soil_c_pool_necromass: Size of the microbial necromass pool [kg C m^-3]
+        soil_c_pool_necromass: Size of the microbial necromass pool [kg{C} m^-3]
         necromass_decay_rate: Rate at which necromass decays into LMWC [day^-1]
 
     Returns:
-        The amount of necromass that breakdown to LMWC [kg C m^-3 day^-1]
+        The amount of necromass that breakdown to LMWC [kg{C} m^-3 day^-1]
     """
 
     return np.where(
@@ -1640,14 +1642,14 @@ def calculate_litter_mineralisation_split(
 
     Args:
         mineralisation_rate: The rate at which the nutrient is being mineralised from
-            the litter [kg C m^-3 day^-1]
+            the litter [kg{C} m^-3 day^-1]
         litter_leaching_coefficient: Fraction of the litter mineralisation of the
             nutrient that occurs via leaching rather than as particulates [unitless]
 
     Returns:
         The rate at which the nutrient is added to the soil as particulates (first part
-        of tuple) and as dissolved matter (second part of tuple) [kg nutrient m^-3
-        day^-1].
+        of tuple) and as dissolved matter (second part of tuple)
+        [kg{nutrient} m^-3 day^-1].
     """
 
     return (
@@ -1669,15 +1671,15 @@ def calculate_soil_nutrient_mineralisation(
     (e.g. phosphatase enzymes).
 
     Args:
-        pool_carbon: The carbon content of the organic matter pool [kg C m^-3]
-        pool_nutrient: The nutrient content of the organic matter pool [kg nutrient
-            m^-3]
+        pool_carbon: The carbon content of the organic matter pool [kg{C} m^-3]
+        pool_nutrient: The nutrient content of the organic matter pool
+            [kg{nutrient} m^-3]
         breakdown_rate: The rate at which the pool is being broken down (expressed in
-            carbon terms) [kg C m^-3 day^-1]
+            carbon terms) [kg{C} m^-3 day^-1]
 
     Returns:
         The rate at which the nutrient in question is mineralised due to organic matter
-        breakdown [kg nutrient m^-3 day^-1]
+        breakdown [kg{nutrient} m^-3 day^-1]
     """
 
     # Mineralisation should not occur if carbon or nutrient component is negative
@@ -1702,14 +1704,14 @@ def calculate_nutrient_flows_to_necromass(
 
     Args:
         biomass_losses: Rate at which biomass of each microbial functional group becomes
-            necromass [kg C m^-3 day^-1]
+            necromass [kg{C} m^-3 day^-1]
         enzyme_changes: Details of the rate change for the soil enzyme pools.
         microbial_groups: Set of microbial functional groups defined in the soil model
         enzyme_classes: Details of the enzyme classes used by the soil model.
 
     Returns:
-        A tuple containing the rates at which nitrogen [kg N m^-3 day^-1] and phosphorus
-        [kg P m^-3 day^-1] are added to the soil necromass pool
+        A tuple containing the rates at which nitrogen [kg{N} m^-3 day^-1] and phosphorus
+        [kg{P} m^-3 day^-1] are added to the soil necromass pool
     """
 
     # Calculate nutrient flows due to cellular losses
@@ -1757,21 +1759,22 @@ def find_necromass_nutrient_outflows(
     split between pathways as the carbon does.
 
     Args:
-        necromass_carbon: The amount of carbon stored as microbial necromass [kg C m^-3]
-        necromass_nitrogen: The amount of nitrogen stored as microbial necromass [kg N
-            m^-3]
-        necromass_phosphorus: The amount of phosphorus stored as microbial necromass [kg
-            P m^-3]
-        necromass_decay: The rate at which necromass decays to form lmwc [kg C m^-3
-            day^-1]
+        necromass_carbon: The amount of carbon stored as microbial necromass
+            [kg{C} m^-3]
+        necromass_nitrogen: The amount of nitrogen stored as microbial necromass
+            [kg{N} m^-3]
+        necromass_phosphorus: The amount of phosphorus stored as microbial necromass
+            [kg{P} m^-3]
+        necromass_decay: The rate at which necromass decays to form lmwc
+            [kg{C} m^-3 day^-1]
         necromass_sorption: The rate at which necromass gets sorbed to soil minerals to
-            form mineral associated organic matter [kg C m^-3 day^-1]
+            form mineral associated organic matter [kg{C} m^-3 day^-1]
 
     Returns:
         A dictionary containing the rates at which nitrogen and phosphorus contained in
         necromass is released as dissolved organic nitrogen, and the rates at which they
-        gets sorbed to soil minerals to form soil associated organic matter [kg nutrient
-        m^-3 day^-1].
+        gets sorbed to soil minerals to form soil associated organic matter
+        [kg{nutrient} m^-3 day^-1].
     """
 
     # If either necromass carbon or the relevant nutrient is negative, this is treated
@@ -1818,29 +1821,29 @@ def calculate_net_nutrient_transfers_from_maom_to_lmwc(
     """Calculate the net rate of transfer of nutrients between MAOM and LMWC.
 
     Args:
-        lmwc_carbon: The amount of carbon stored as low molecular weight carbon [kg C
-            m^-3]
+        lmwc_carbon: The amount of carbon stored as low molecular weight carbon
+            [kg{C} m^-3]
         lmwc_nitrogen: The amount of nitrogen stored as low molecular weight
-            carbon/dissolved organic nitrogen [kg N m^-3]
+            carbon/dissolved organic nitrogen [kg{N} m^-3]
         lmwc_phosphorus: The amount of phosphorus stored as low molecular weight
-            carbon/dissolved organic phosphorus [kg P m^-3]
+            carbon/dissolved organic phosphorus [kg{P} m^-3]
         maom_carbon: The amount of carbon stored as mineral associated organic matter
-            [kg C m^-3]
+            [kg{C} m^-3]
         maom_nitrogen: The amount of nitrogen stored as mineral associated organic
-            matter [kg N m^-3]
+            matter [kg{N} m^-3]
         maom_phosphorus: The amount of phosphorus stored as mineral associated organic
-            matter [kg P m^-3]
+            matter [kg{P} m^-3]
         maom_breakdown: The rate at which the mineral associated organic matter pool is
-            being broken down by enzymes (expressed in carbon terms) [kg C m^-3 day^-1]
+            being broken down by enzymes (expressed in carbon terms) [kg{C} m^-3 day^-1]
         maom_desorption: The rate at which the mineral associated organic matter pool is
-            spontaneously desorbing [kg C m^-3 day^-1]
+            spontaneously desorbing [kg{C} m^-3 day^-1]
         lmwc_sorption: The rate at which the low molecular weight carbon pool is sorbing
-            to minerals to form mineral associated organic matter [kg C m^-3 day^-1]
+            to minerals to form mineral associated organic matter [kg{C} m^-3 day^-1]
 
     Returns:
         The net nutrient transfer rates of transfer from mineral associated organic
         matter into dissolved organic forms. This is currently includes nitrogen and
-        phosphorus [kg nutrient m^-3 day^-1]
+        phosphorus [kg{nutrient} m^-3 day^-1]
     """
 
     # Find gain and loss for MAOM separately (negatives have to be controlled for by
@@ -1888,13 +1891,13 @@ def calculate_rate_of_nitrification(
     :cite:t:`fatichi_mechanistic_2019`.
 
     Args:
-        soil_temp: Temperature of the relevant segment of soil [C]
+        soil_temp: Temperature of the relevant segment of soil [Celsius]
         effective_saturation: Effective saturation of the soil with water [unitless]
-        soil_n_pool_ammonium: Soil ammonium pool [kg N m^-3]
+        soil_n_pool_ammonium: Soil ammonium pool [kg{N} m^-3]
         constants: Set of constants for the soil model.
 
     Returns:
-        The rate at which ammonium nitrifies to form nitrate [kg N m^-3 day^-1].
+        The rate at which ammonium nitrifies to form nitrate [kg{N} m^-3 day^-1].
     """
 
     # Calculate moisture and temperature factors
@@ -1930,13 +1933,13 @@ def calculate_rate_of_denitrification(
     :cite:t:`fatichi_mechanistic_2019`.
 
     Args:
-        soil_temp: Temperature of the relevant segment of soil [C]
+        soil_temp: Temperature of the relevant segment of soil [Celsius]
         effective_saturation: Effective saturation of the soil with water [unitless]
-        soil_n_pool_nitrate: Soil nitrate pool [kg N m^-3]
+        soil_n_pool_nitrate: Soil nitrate pool [kg{N} m^-3]
         constants: Set of constants for the soil model.
 
     Returns:
-        The rate at which ammonium nitrifies to form nitrate [kg N m^-3 day^-1].
+        The rate at which ammonium nitrifies to form nitrate [kg{N} m^-3 day^-1].
     """
 
     # Calculate moisture and temperature factors
@@ -1969,8 +1972,8 @@ def calculate_symbiotic_nitrogen_fixation(
 
     Args:
         carbon_supply: The rate at which carbon is supplied to symbiotic partners by
-            plants for the purpose of nitrogen fixation [kg C m^-3 day^-1]
-        soil_temp: Temperature of the relevant soil zone [C]
+            plants for the purpose of nitrogen fixation [kg{C} m^-3 day^-1]
+        soil_temp: Temperature of the relevant soil zone [Celsius]
         constants: Set of constants for the soil model.
 
     Returns:
@@ -2007,10 +2010,10 @@ def calculate_free_living_nitrogen_fixation(
     review.
 
     Args:
-        soil_temp: Temperature of the relevant soil zone [C]
+        soil_temp: Temperature of the relevant soil zone [Celsius]
         fixation_at_reference: Rate of nitrogen fixation at the reference temperature
-            [kg N m^-2 day^-1]
-        reference_temperature: Reference temperature [K]
+            [kg{N} m^-2 day^-1]
+        reference_temperature: Reference temperature [Kelvin]
         q10_nitrogen_fixation: Q10 temperature coefficient for free-living nitrogen
             fixation [unitless]
         active_depth: The depth to which the soil is considered to be biologically
@@ -2018,7 +2021,7 @@ def calculate_free_living_nitrogen_fixation(
 
     Returns:
         The rate at which nitrogen is fixed by free living (i.e. non-symbiotic) microbes
-        [kg N m^-3 day^-1]
+        [kg{N} m^-3 day^-1]
     """
 
     soil_temp_in_kelvin = convert_temperature(
@@ -2046,8 +2049,8 @@ def calculate_net_formation_of_secondary_P(
     secondary mineral phosphorus breaking down.
 
     Args:
-        soil_p_pool_labile: Labile inorganic phosphorus pool [kg P m^-3]
-        soil_p_pool_secondary: Secondary mineral phosphorus pool [kg P m^-3]
+        soil_p_pool_labile: Labile inorganic phosphorus pool [kg{P} m^-3]
+        soil_p_pool_secondary: Secondary mineral phosphorus pool [kg{P} m^-3]
         secondary_p_breakdown_rate: Rate constant for breakdown of secondary mineral
             phosphorus to labile phosphorus [day^-1]
         labile_p_sorption_rate: Rate constant for sorption of labile inorganic
@@ -2055,7 +2058,7 @@ def calculate_net_formation_of_secondary_P(
 
     Returns:
         The net rate of labile inorganic phosphorus that has become secondary mineral
-        phosphorus (this can be negative) [kg P m^-3 day^-1]
+        phosphorus (this can be negative) [kg{P} m^-3 day^-1]
     """
 
     association_rate = np.where(
@@ -2079,8 +2082,8 @@ def calculate_fungal_fruiting_body_decay(
     ratios of the fungal fruiting bodies pool.
 
     Args:
-        decay_rate: The rate at which fungal fruiting bodies decay in carbon terms [kg C
-            m^-3 day^-1]
+        decay_rate: The rate at which fungal fruiting bodies decay in carbon terms
+            [kg{C} m^-3 day^-1]
         fungal_fruiting_body_c_n_ratio: The carbon to nitrogen ratio of fungal fruiting
             bodies pool [unitless]
         fungal_fruiting_body_c_p_ratio: The carbon to phosphorus ratio of fungal

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -132,7 +132,8 @@ class MicrobialChanges:
     """Rate at which fungal fruiting bodies are being produced [kg{C} m^-3 day^-1]."""
 
     arbuscular_mycorrhiza_n_supply: NDArray[np.floating]
-    """Supply rate of nitrogen to plants by arbuscular mycorrhiza [kg{N} m^-3 day^-1]."""
+    """Supply rate of nitrogen to plants by arbuscular mycorrhiza [kg{N} m^-3 day^-1].
+    """
 
     arbuscular_mycorrhiza_p_supply: NDArray[np.floating]
     """Supply rate of phosphorus to plants by arbuscular mycorrhiza [kg{P} m^-3 day^-1].
@@ -1512,8 +1513,8 @@ def calculate_maom_desorption(
 
     Args:
         soil_c_pool_maom: Size of the mineral associated organic matter pool
-        [kg{C} m^-3] desorption_rate_constant: Rate constant for MAOM desorption
-        [day^-1]
+            [kg{C} m^-3]
+        desorption_rate_constant: Rate constant for MAOM desorption [day^-1]
 
     Returns:
         The rate of MAOM desorption to LMWC [kg{C} m^-3 day^-1]
@@ -1710,8 +1711,8 @@ def calculate_nutrient_flows_to_necromass(
         enzyme_classes: Details of the enzyme classes used by the soil model.
 
     Returns:
-        A tuple containing the rates at which nitrogen [kg{N} m^-3 day^-1] and phosphorus
-        [kg{P} m^-3 day^-1] are added to the soil necromass pool
+        A tuple containing the rates at which nitrogen [kg{N} m^-3 day^-1] and
+        phosphorus [kg{P} m^-3 day^-1] are added to the soil necromass pool
     """
 
     # Calculate nutrient flows due to cellular losses

--- a/virtual_ecosystem/models/soil/pools.py
+++ b/virtual_ecosystem/models/soil/pools.py
@@ -885,8 +885,8 @@ def calculate_microbial_changes(
         constants: Set of constants for the soil model.
         microbial_groups: Set of microbial functional groups used by the soil model.
         enzyme_classes: Details of the enzyme classes used by the soil model.
-        carbon_supply: The carbon supply to each symbiotic microbial partner [kg{C} m^-3
-            day^-1]
+        carbon_supply: The carbon supply to each symbiotic microbial partner
+            [kg{C} m^-3 day^-1]
 
     Returns:
         A dataclass containing the rate at which microbes uptake LMWC, DON and DOP, and
@@ -1333,7 +1333,7 @@ def calculate_enzyme_production(
     Args:
         microbial_groups: Set of microbial functional groups defined in the soil model
         growth_rates: The (gross) growth rates of each microbial group
-        [kg{C} m^-3 day^-1]
+            [kg{C} m^-3 day^-1]
 
     Returns:
         A dictionary containing the total production rate of each enzyme class
@@ -1371,7 +1371,7 @@ def calculate_fruiting_body_production(
     Args:
         microbial_groups: Set of microbial functional groups defined in the soil model
         growth_rates: The (gross) growth rates of each microbial group
-        [kg{C} m^-3 day^-1]
+            [kg{C} m^-3 day^-1]
 
     Returns:
         The total production rate of fungal fruiting bodies by the soil microbes

--- a/virtual_ecosystem/models/soil/soil_model.py
+++ b/virtual_ecosystem/models/soil/soil_model.py
@@ -591,11 +591,11 @@ class SoilModel(
 
         Args:
             total_production: The total production of fungal fruiting bodies over the
-                integration time period, per volume of soil [kg C m^-3]
+                integration time period, per volume of soil [kg{C} m^-3]
 
         Returns:
             A data array containing the rate at which fungal fruiting bodies are
-            produced per unit area [kg C m^-2 day^-1].
+            produced per unit area [kg{C} m^-2 day^-1].
         """
 
         return {
@@ -614,8 +614,8 @@ class SoilModel(
         it is assumed dissolved nutrient concentrations are taken to be zero.
 
         Returns:
-            A data array containing the size of each dissolved nutrient pool [kg
-            nutrient m^-3].
+            A data array containing the size of each dissolved nutrient pool
+            [kg{nutrient} m^-3].
         """
 
         return {
@@ -810,16 +810,16 @@ def estimate_past_mycorrhizal_supply(
 
     Args:
         soil_c_pool_lmwc: The amount of carbon in the labile mineral associated organic
-            matter pool [kg C m^-3]
+            matter pool [kg{C} m^-3]
         soil_n_pool_don: The amount of nitrogen in the dissolved organic nitrogen pool
-            [kg N m^-3]
-        soil_n_pool_ammonium: Size of the soil ammonium pool [kg N m^-3]
-        soil_n_pool_nitrate: Size of the soil nitrate pool [kg N m^-3]
+            [kg{N} m^-3]
+        soil_n_pool_ammonium: Size of the soil ammonium pool [kg{N} m^-3]
+        soil_n_pool_nitrate: Size of the soil nitrate pool [kg{N} m^-3]
         soil_p_pool_dop: The amount of phosphorus in the dissolved organic phosphorus
-            pool [kg P m^-3]
-        soil_p_pool_labile: Size of the labile phosphorus pool [kg P m^-3]
-        microbe_pool_size: Size of the microbial pool of interest [kg C m^-3]
-        soil_temp: Soil temperature [degrees C]
+            pool [kg{P} m^-3]
+        soil_p_pool_labile: Size of the labile phosphorus pool [kg{P} m^-3]
+        microbe_pool_size: Size of the microbial pool of interest [kg{C} m^-3]
+        soil_temp: Soil temperature [Celsius]
         microbial_group: Constants associated with the microbial group of interest.
         env_factors: Data class containing the various factors through which the
             environment effects soil cycling rates.

--- a/virtual_ecosystem/models/soil/uptake.py
+++ b/virtual_ecosystem/models/soil/uptake.py
@@ -24,22 +24,22 @@ class NetNutrientConsumption:
     """
 
     carbon: NDArray[np.floating]
-    """Uptake of low molecular weight carbon [kg C m^-3 day^-1]."""
+    """Uptake of low molecular weight carbon [kg{C} m^-3 day^-1]."""
 
     organic_nitrogen: NDArray[np.floating]
-    """Uptake of dissolved organic nitrogen [kg N m^-3 day^-1]."""
+    """Uptake of dissolved organic nitrogen [kg{N} m^-3 day^-1]."""
 
     ammonium: NDArray[np.floating]
-    """Uptake of ammonium [kg N m^-3 day^-1]."""
+    """Uptake of ammonium [kg{N} m^-3 day^-1]."""
 
     nitrate: NDArray[np.floating]
-    """Uptake of nitrate [kg N m^-3 day^-1]."""
+    """Uptake of nitrate [kg{N} m^-3 day^-1]."""
 
     organic_phosphorus: NDArray[np.floating]
-    """Uptake of dissolved organic phosphorus [kg P m^-3 day^-1]."""
+    """Uptake of dissolved organic phosphorus [kg{P} m^-3 day^-1]."""
 
     inorganic_phosphorus: NDArray[np.floating]
-    """Uptake of labile inorganic phosphorus [kg P m^-3 day^-1]."""
+    """Uptake of labile inorganic phosphorus [kg{P} m^-3 day^-1]."""
 
 
 @dataclass
@@ -47,28 +47,28 @@ class MaxUptakeRates:
     """Maximum rate at which each nutrient can be taken up by the microbial group."""
 
     carbon: NDArray[np.floating]
-    """Maximum uptake of low molecular weight carbon [kg C m^-3 day^-1]."""
+    """Maximum uptake of low molecular weight carbon [kg{C} m^-3 day^-1]."""
 
     organic_nitrogen: NDArray[np.floating]
-    """Maximum uptake rate of organic nitrogen [kg N m^-3 day^-1].
+    """Maximum uptake rate of organic nitrogen [kg{N} m^-3 day^-1].
     
     This nitrogen is taken up along with the :term:`LMWC` uptake.
     """
 
     organic_phosphorus: NDArray[np.floating]
-    """Maximum uptake rate of organic phosphorus [kg P m^-3 day^-1].
+    """Maximum uptake rate of organic phosphorus [kg{P} m^-3 day^-1].
     
     This phosphorus is taken up along with the :term:`LMWC` uptake.
     """
 
     ammonium: NDArray[np.floating]
-    """Maximum uptake rate of ammonium [kg N m^-3 day^-1]."""
+    """Maximum uptake rate of ammonium [kg{N} m^-3 day^-1]."""
 
     nitrate: NDArray[np.floating]
-    """Maximum uptake rate of nitrate [kg N m^-3 day^-1]."""
+    """Maximum uptake rate of nitrate [kg{N} m^-3 day^-1]."""
 
     inorganic_phosphorus: NDArray[np.floating]
-    """Maximum uptake rate of labile inorganic phosphorus [kg P m^-3 day^-1]."""
+    """Maximum uptake rate of labile inorganic phosphorus [kg{P} m^-3 day^-1]."""
 
 
 def calculate_nutrient_uptake_rates(
@@ -125,20 +125,20 @@ def calculate_nutrient_uptake_rates(
     than the microbes can use the surplus is added to the soil as :term:`LMWC`.
 
     Args:
-        soil_c_pool_lmwc: Low molecular weight carbon pool [kg C m^-3]
-        soil_n_pool_don: Dissolved organic nitrogen pool [kg N m^-3]
-        soil_n_pool_ammonium: Soil ammonium pool [kg N m^-3]
-        soil_n_pool_nitrate: Soil nitrate pool [kg N m^-3]
-        soil_p_pool_dop: Dissolved organic phosphorus pool [kg P m^-3]
-        soil_p_pool_labile: Labile inorganic phosphorus pool [kg P m^-3]
-        microbial_pool_size: Amount of biomass for functional of interest [kg C m^-3]
+        soil_c_pool_lmwc: Low molecular weight carbon pool [kg{C} m^-3]
+        soil_n_pool_don: Dissolved organic nitrogen pool [kg{N} m^-3]
+        soil_n_pool_ammonium: Soil ammonium pool [kg{N} m^-3]
+        soil_n_pool_nitrate: Soil nitrate pool [kg{N} m^-3]
+        soil_p_pool_dop: Dissolved organic phosphorus pool [kg{P} m^-3]
+        soil_p_pool_labile: Labile inorganic phosphorus pool [kg{P} m^-3]
+        microbial_pool_size: Amount of biomass for functional of interest [kg{C} m^-3]
         external_carbon_supply: Additional supply of carbon to the microbial group from
-            external sources (i.e. partner plants) [kg C m^-3 day^-1]
+            external sources (i.e. partner plants) [kg{C} m^-3 day^-1]
         water_factor: A factor capturing the impact of soil water potential on microbial
             rates [unitless]
         pH_factor: A factor capturing the impact of soil pH on microbial rates
             [unitless]
-        soil_temp: soil temperature for each soil grid cell [degrees C]
+        soil_temp: soil temperature for each soil grid cell [Celsius]
         constants: Set of constants for the soil model.
         functional_group: A data class containing the parameters defining the microbial
             functional group
@@ -353,7 +353,7 @@ def find_net_nutrient_consumptions_symbiotic(
         actual_carbon_gain: The rate at which carbon is assimilated to biomass [kg C
             m^-3 day^-1]
         external_carbon_supply: Additional supply of carbon to the microbial group from
-            symbiotic partner plants [kg C m^-3 day^-1]
+            symbiotic partner plants [kg{C} m^-3 day^-1]
         carbon_use_efficiency: Carbon use efficiency of the microbial group (varies with
             temperature) [unitless]
         functional_group: A data class containing the parameters defining the microbial
@@ -441,7 +441,7 @@ def calculate_actual_carbon_gain(
     Args:
         max_uptake_rates: Maximum uptake rates for each nutrient class [kg m^-3 day^-1]
         external_carbon_supply: Additional supply of carbon to the microbial group from
-            external sources (i.e. partner plants) [kg C m^-3 day^-1]
+            external sources (i.e. partner plants) [kg{C} m^-3 day^-1]
         carbon_use_efficiency: Carbon use efficiency of the microbial group (varies with
             temperature) [unitless]
         functional_group: A data class containing the parameters defining the microbial
@@ -500,13 +500,13 @@ def calculate_maximum_uptake_rates(
     (ammonium and nitrate), and inorganic phosphorus.
 
     Args:
-        soil_c_pool_lmwc: Low molecular weight carbon pool [kg C m^-3]
-        soil_n_pool_don: Dissolved organic nitrogen pool [kg N m^-3]
-        soil_n_pool_ammonium: Soil ammonium pool [kg N m^-3]
-        soil_n_pool_nitrate: Soil nitrate pool [kg N m^-3]
-        soil_p_pool_dop: Dissolved organic phosphorus pool [kg P m^-3]
-        soil_p_pool_labile: Labile inorganic phosphorus pool [kg P m^-3]
-        microbial_pool_size: Amount of biomass for functional of interest [kg C m^-3]
+        soil_c_pool_lmwc: Low molecular weight carbon pool [kg{C} m^-3]
+        soil_n_pool_don: Dissolved organic nitrogen pool [kg{N} m^-3]
+        soil_n_pool_ammonium: Soil ammonium pool [kg{N} m^-3]
+        soil_n_pool_nitrate: Soil nitrate pool [kg{N} m^-3]
+        soil_p_pool_dop: Dissolved organic phosphorus pool [kg{P} m^-3]
+        soil_p_pool_labile: Labile inorganic phosphorus pool [kg{P} m^-3]
+        microbial_pool_size: Amount of biomass for functional of interest [kg{C} m^-3]
         lmwc_c_n_ratio: Carbon to nitrogen ratio of the low molecular weight carbon pool
             [unitless]
         lmwc_c_p_ratio: Carbon to phosphorus ratio of the low molecular weight carbon
@@ -515,7 +515,7 @@ def calculate_maximum_uptake_rates(
             rates [unitless]
         pH_factor: A factor capturing the impact of soil pH on microbial rates
             [unitless]
-        soil_temp: soil temperature for each soil grid cell [degrees C]
+        soil_temp: soil temperature for each soil grid cell [Celsius]
         constants: Set of constants for the soil model.
         functional_group: A data class containing the parameters defining the microbial
             functional group
@@ -623,23 +623,24 @@ def calculate_highest_achievable_nutrient_uptake(
 
     Args:
         labile_nutrient_pool: Mass of nutrient that is in a readily uptakeable (labile)
-            form [kg nut m^-3]
-        microbial_pool_size: Size of microbial biomass (carbon) pool of interest [kg C
-            m^-3]
+            form [kg{nutrient} m^-3]
+        microbial_pool_size: Size of microbial biomass (carbon) pool of interest
+            [kg{C} m^-3]
         water_factor: A factor capturing the impact of soil water potential on microbial
             rates [unitless]
         pH_factor: A factor capturing the impact of soil pH on microbial rates
             [unitless]
-        soil_temp: soil temperature for each soil grid cell [degrees C]
+        soil_temp: soil temperature for each soil grid cell [Celsius]
         max_uptake_rate: Maximum possible uptake rate of the nutrient (at reference
             temperature) [day^-1]
         activation_energy_uptake: Activation energy for nutrient uptake for the
-            microbial group in question [J K^-1].
+            microbial group in question [J Kelvin^-1].
         half_saturation_constant: Half saturation constant for nutrient uptake (at
-            reference temperature) [kg nut m^-3]
+            reference temperature) [kg{nutrient} m^-3]
         activation_energy_uptake_saturation: Activation energy for nutrient uptake
-            saturation for the microbial group in question [J K^-1].
-        reference_temperature: The reference temperature of the Arrhenius equation [C]
+            saturation for the microbial group in question [J Kelvin^-1].
+        reference_temperature: The reference temperature of the Arrhenius equation
+            [Celsius]
 
     Returns:
         The maximum uptake rate by the soil microbial biomass for the nutrient in


### PR DESCRIPTION
# Description

This PR changes the unit of measurements in the soil and litter modules to follow:
- Temperature units are spelled in full and consistently as Celsius or Kelvin; this follows `scipy.constants.convert_temperature()`'s argument options. Spelling them in full makes it easier to detect or parse the units in downstream analyses. I decided to forgo "degree" in Celsius for brevity.
- Explicit element in mass units now uses the curly bracket comment convention following [UCUM](https://ucum.org/ucum), e.g., kg{C}, kg{N}, kg{P} and kg{lignin C}. This also minimises parsing error. So generally, the idea is to use curly brackets for custom units like 1{apple}, 136{dinosaur} etc.

As I went through the scripts, I feel that it is better to not break a line of text about units into separate lines. Keeping them in the same line makes it easier to Ctrl + F to find them.

Fixes #1623

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
