### PR TITLE
Animal - Replaced ceiling mortality with stochastic rounding

### DIFF
--- a/tests/models/animals/test_animal_cohorts.py
+++ b/tests/models/animals/test_animal_cohorts.py
@@ -2488,204 +2488,63 @@ class TestAnimalCohort:
         )
 
     @pytest.mark.parametrize(
-        "is_mature, u_bg, lambda_se, t_to_maturity, t_since_maturity, lambda_max, J_st,"
-        "zeta_st, mass_current, mass_max, pop_size, dt, mock_random, expected_dead",
+        "is_mature, mock_dead, pop_size, expected_survivors",
         [
-            pytest.param(
-                True,
-                0.001,
-                0.003,
-                365,
-                30,
-                1.0,
-                0.6,
-                0.05,
-                600,
-                600,
-                100,
-                30,
-                0.99,  # 12.870 + 0.99 = 13.86 → int = 13 (with extra)
-                13,
-                id="mature_all_mortalities_with_extra",
-            ),
-            pytest.param(
-                True,
-                0.001,
-                0.003,
-                365,
-                30,
-                1.0,
-                0.6,
-                0.05,
-                600,
-                600,
-                100,
-                30,
-                0.0,  # 12.870 + 0.0 = 12.87 → int = 12 (no extra)
-                12,
-                id="mature_all_mortalities_no_extra",
-            ),
-            pytest.param(
-                False,
-                0.001,
-                0.003,
-                365,
-                30,
-                1.0,
-                0.6,
-                0.05,
-                600,
-                600,
-                100,
-                30,
-                0.99,  # 3.927 + 0.99 = 4.917 → int = 4 (with extra)
-                4,
-                id="immature_no_senescence_with_extra",
-            ),
-            pytest.param(
-                False,
-                0.001,
-                0.003,
-                365,
-                30,
-                1.0,
-                0.6,
-                0.05,
-                600,
-                600,
-                100,
-                30,
-                0.0,  # 3.927 + 0.0 = 3.927 → int = 3 (no extra)
-                3,
-                id="immature_no_senescence_no_extra",
-            ),
-            pytest.param(
-                False,
-                0.001,
-                0.0,
-                365,
-                0,
-                0.0,
-                0.6,
-                0.05,
-                600,
-                600,
-                1,
-                30,
-                0.99,  # 0.030 + 0.99 = 1.02 → int = 1 (one death)
-                1,
-                id="single_large_animal_one_death",
-            ),
-            pytest.param(
-                False,
-                0.001,
-                0.0,
-                365,
-                0,
-                0.0,
-                0.6,
-                0.05,
-                600,
-                600,
-                1,
-                30,
-                0.0,  # 0.030 + 0.0 = 0.030 → int = 0 (no death)
-                0,
-                id="single_large_animal_no_death",
-            ),
+            pytest.param(True, 12, 100, 88, id="mature_all_mortalities"),
+            pytest.param(False, 3, 100, 97, id="immature_no_senescence"),
+            pytest.param(False, 0, 1, 1, id="single_large_animal_no_death"),
+            pytest.param(False, 1, 1, 0, id="single_large_animal_one_death"),
         ],
     )
     def test_inflict_non_predation_mortality(
         self,
         mocker,
         is_mature,
-        u_bg,
-        lambda_se,
-        t_to_maturity,
-        t_since_maturity,
-        lambda_max,
-        J_st,
-        zeta_st,
-        mass_current,
-        mass_max,
+        mock_dead,
         pop_size,
-        dt,
-        mock_random,
-        expected_dead,
+        expected_survivors,
         predator_cohort_instance,
         carcass_pool_instance,
     ):
-        """Test stochastic rounding of non-predation mortality.
+        """Test that non-predation mortality removes the correct number of individuals.
 
-        ``random.random`` is mocked to give deterministic control over the
-        stochastic branch.  The compact rounding form ``int(expected + U)``
-        means a high ``U`` (e.g. 0.99) pushes the value over the next integer,
-        producing more deaths, while ``U=0.0`` truncates down.  The
-        ``single_large_animal`` cases are the primary regression: with ``ceil``
-        a cohort of 1 with expected_dead ≈ 0.03 would die every timestep; with
-        stochastic rounding it only dies when ``U < 0.03``.
+        ``binomial`` is mocked to return a fixed number of deaths, decoupling the
+        test from the stochastic draw and from the specific mortality rate values.
+        The ``single_large_animal`` cases are the primary regression: the old
+        ``ceil`` implementation would guarantee at least one death per timestep
+        regardless of how low the mortality rate was.
         """
-        from math import exp
-
         cohort = predator_cohort_instance
         cohort.individuals = pop_size
         cohort.is_mature = is_mature
-        cohort.time_to_maturity = t_to_maturity
-        cohort.time_since_maturity = t_since_maturity
-        cohort.functional_group.adult_mass = mass_max
 
         mocker.patch.object(
             type(cohort),
             "mass_current",
             new_callable=mocker.PropertyMock,
-            return_value=mass_current,
+            return_value=600,
         )
         mocker.patch(
             "virtual_ecosystem.models.animal.scaling_functions.background_mortality",
-            return_value=u_bg,
+            return_value=0.001,
         )
         mocker.patch(
             "virtual_ecosystem.models.animal.scaling_functions.senescence_mortality",
-            return_value=(
-                lambda_se * exp(t_since_maturity / t_to_maturity) if is_mature else 0.0
-            ),
+            return_value=0.003,
         )
         mocker.patch(
             "virtual_ecosystem.models.animal.scaling_functions.starvation_mortality",
-            return_value=(
-                lambda_max
-                / (1 + exp((mass_current - J_st * mass_max) / (zeta_st * mass_max)))
-                if lambda_max > 0.0
-                else 0.0
-            ),
+            return_value=0.001,
         )
         mocker.patch(
-            "virtual_ecosystem.models.animal.animal_cohorts.random.random",
-            return_value=mock_random,
+            "virtual_ecosystem.models.animal.animal_cohorts.binomial",
+            return_value=mock_dead,
         )
 
-        cohort.inflict_non_predation_mortality(dt, [carcass_pool_instance])
+        cohort.inflict_non_predation_mortality(30, [carcass_pool_instance])
 
-        # Recompute using the same values the mocks returned so the guard
-        # sees the same u_t as the implementation did.
-        u_bg_mocked = u_bg
-        u_se_mocked = (
-            lambda_se * exp(t_since_maturity / t_to_maturity) if is_mature else 0.0
-        )
-        u_st_mocked = (
-            lambda_max
-            / (1 + exp((mass_current - J_st * mass_max) / (zeta_st * mass_max)))
-            if lambda_max > 0.0
-            else 0.0
-        )
-        u_t = u_bg_mocked + u_se_mocked + u_st_mocked
-        expected_from_formula = int(pop_size * (1 - exp(-u_t * dt)) + mock_random)
-        assert expected_from_formula == expected_dead, (
-            f"Parametrize mismatch: formula gives {expected_from_formula}, "
-            f"expected_dead={expected_dead} (mock_random={mock_random})."
-        )
-        assert cohort.individuals == pop_size - expected_dead, (
-            f"Expected {pop_size - expected_dead} survivors, got {cohort.individuals}."
+        assert cohort.individuals == expected_survivors, (
+            f"Expected {expected_survivors} survivors, got {cohort.individuals}."
         )
 
     @pytest.mark.parametrize(

--- a/tests/models/animals/test_animal_cohorts.py
+++ b/tests/models/animals/test_animal_cohorts.py
@@ -2504,9 +2504,9 @@ class TestAnimalCohort:
                 600,
                 100,
                 30,
-                0.99,  # above remainder (0.870) → floor only
-                12,
-                id="mature_all_mortalities_no_extra",
+                0.99,  # 12.870 + 0.99 = 13.86 → int = 13 (with extra)
+                13,
+                id="mature_all_mortalities_with_extra",
             ),
             pytest.param(
                 True,
@@ -2521,9 +2521,9 @@ class TestAnimalCohort:
                 600,
                 100,
                 30,
-                0.0,  # below remainder (0.870) → floor + 1
-                13,
-                id="mature_all_mortalities_with_extra",
+                0.0,  # 12.870 + 0.0 = 12.87 → int = 12 (no extra)
+                12,
+                id="mature_all_mortalities_no_extra",
             ),
             pytest.param(
                 False,
@@ -2538,32 +2538,30 @@ class TestAnimalCohort:
                 600,
                 100,
                 30,
-                0.99,  # above remainder (0.927) → floor only
+                0.99,  # 3.927 + 0.99 = 4.917 → int = 4 (with extra)
+                4,
+                id="immature_no_senescence_with_extra",
+            ),
+            pytest.param(
+                False,
+                0.001,
+                0.003,
+                365,
+                30,
+                1.0,
+                0.6,
+                0.05,
+                600,
+                600,
+                100,
+                30,
+                0.0,  # 3.927 + 0.0 = 3.927 → int = 3 (no extra)
                 3,
                 id="immature_no_senescence_no_extra",
             ),
             pytest.param(
                 False,
                 0.001,
-                0.003,
-                365,
-                30,
-                1.0,
-                0.6,
-                0.05,
-                600,
-                600,
-                100,
-                30,
-                0.0,  # below remainder (0.927) → floor + 1
-                4,
-                id="immature_no_senescence_with_extra",
-            ),
-            pytest.param(
-                # Core regression: large-bodied cohort of 1 with low mortality.
-                # expected_dead ≈ 0.030 so ceil would always kill it; floor should not.
-                False,
-                0.001,
                 0.0,
                 365,
                 0,
@@ -2574,26 +2572,26 @@ class TestAnimalCohort:
                 600,
                 1,
                 30,
-                0.99,  # above remainder (0.030) → 0 deaths
-                0,
-                id="single_large_animal_no_death",
-            ),
-            pytest.param(
-                False,
-                0.001,
-                0.0,
-                365,
-                0,
-                0.0,
-                0.6,
-                0.05,
-                600,
-                600,
-                1,
-                30,
-                0.0,  # below remainder (0.030) → 1 death
+                0.99,  # 0.030 + 0.99 = 1.02 → int = 1 (one death)
                 1,
                 id="single_large_animal_one_death",
+            ),
+            pytest.param(
+                False,
+                0.001,
+                0.0,
+                365,
+                0,
+                0.0,
+                0.6,
+                0.05,
+                600,
+                600,
+                1,
+                30,
+                0.0,  # 0.030 + 0.0 = 0.030 → int = 0 (no death)
+                0,
+                id="single_large_animal_no_death",
             ),
         ],
     )
@@ -2620,16 +2618,14 @@ class TestAnimalCohort:
         """Test stochastic rounding of non-predation mortality.
 
         ``random.random`` is mocked to give deterministic control over the
-        stochastic branch.  Each logical scenario is split into a ``_no_extra``
-        case (mock value above the fractional remainder) and a ``_with_extra``
-        case (mock value of 0.0, always below the remainder).  The
+        stochastic branch.  The compact rounding form ``int(expected + U)``
+        means a high ``U`` (e.g. 0.99) pushes the value over the next integer,
+        producing more deaths, while ``U=0.0`` truncates down.  The
         ``single_large_animal`` cases are the primary regression: with ``ceil``
         a cohort of 1 with expected_dead ≈ 0.03 would die every timestep; with
-        stochastic rounding it dies with probability 0.03.
+        stochastic rounding it only dies when ``U < 0.03``.
         """
-        from math import exp, floor
-
-        import virtual_ecosystem.models.animal.scaling_functions as sf
+        from math import exp
 
         cohort = predator_cohort_instance
         cohort.individuals = pop_size
@@ -2670,26 +2666,24 @@ class TestAnimalCohort:
 
         cohort.inflict_non_predation_mortality(dt, [carcass_pool_instance])
 
-        # Recompute independently to guard against parametrize drift.
-        u_t = (
-            sf.background_mortality(u_bg)
-            + (
-                sf.senescence_mortality(lambda_se, t_to_maturity, t_since_maturity)
-                if is_mature
-                else 0.0
-            )
-            + sf.starvation_mortality(lambda_max, J_st, zeta_st, mass_current, mass_max)
+        # Recompute using the same values the mocks returned so the guard
+        # sees the same u_t as the implementation did.
+        u_bg_mocked = u_bg
+        u_se_mocked = (
+            lambda_se * exp(t_since_maturity / t_to_maturity) if is_mature else 0.0
         )
-        continuous_dead = pop_size * (1 - exp(-u_t * dt))
-        floor_dead = floor(continuous_dead)
-        remainder = continuous_dead - floor_dead
-        expected_from_formula = floor_dead + (1 if mock_random < remainder else 0)
+        u_st_mocked = (
+            lambda_max
+            / (1 + exp((mass_current - J_st * mass_max) / (zeta_st * mass_max)))
+            if lambda_max > 0.0
+            else 0.0
+        )
+        u_t = u_bg_mocked + u_se_mocked + u_st_mocked
+        expected_from_formula = int(pop_size * (1 - exp(-u_t * dt)) + mock_random)
         assert expected_from_formula == expected_dead, (
             f"Parametrize mismatch: formula gives {expected_from_formula}, "
-            f"expected_dead={expected_dead} (remainder={remainder:.6f}, "
-            f"mock_random={mock_random})."
+            f"expected_dead={expected_dead} (mock_random={mock_random})."
         )
-
         assert cohort.individuals == pop_size - expected_dead, (
             f"Expected {pop_size - expected_dead} survivors, got {cohort.individuals}."
         )

--- a/tests/models/animals/test_animal_cohorts.py
+++ b/tests/models/animals/test_animal_cohorts.py
@@ -2489,7 +2489,7 @@ class TestAnimalCohort:
 
     @pytest.mark.parametrize(
         "is_mature, u_bg, lambda_se, t_to_maturity, t_since_maturity, lambda_max, J_st,"
-        "zeta_st, mass_current, mass_max, dt, expected_dead",
+        "zeta_st, mass_current, mass_max, pop_size, dt, mock_random, expected_dead",
         [
             pytest.param(
                 True,
@@ -2502,9 +2502,28 @@ class TestAnimalCohort:
                 0.05,
                 600,
                 600,
+                100,
                 30,
+                0.99,  # above remainder (0.870) → floor only
+                12,
+                id="mature_all_mortalities_no_extra",
+            ),
+            pytest.param(
+                True,
+                0.001,
+                0.003,
+                365,
+                30,
+                1.0,
+                0.6,
+                0.05,
+                600,
+                600,
+                100,
+                30,
+                0.0,  # below remainder (0.870) → floor + 1
                 13,
-                id="mature_with_all_mortalities",
+                id="mature_all_mortalities_with_extra",
             ),
             pytest.param(
                 False,
@@ -2517,9 +2536,64 @@ class TestAnimalCohort:
                 0.05,
                 600,
                 600,
+                100,
                 30,
+                0.99,  # above remainder (0.927) → floor only
+                3,
+                id="immature_no_senescence_no_extra",
+            ),
+            pytest.param(
+                False,
+                0.001,
+                0.003,
+                365,
+                30,
+                1.0,
+                0.6,
+                0.05,
+                600,
+                600,
+                100,
+                30,
+                0.0,  # below remainder (0.927) → floor + 1
                 4,
-                id="immature_without_senescence",
+                id="immature_no_senescence_with_extra",
+            ),
+            pytest.param(
+                # Core regression: large-bodied cohort of 1 with low mortality.
+                # expected_dead ≈ 0.030 so ceil would always kill it; floor should not.
+                False,
+                0.001,
+                0.0,
+                365,
+                0,
+                0.0,
+                0.6,
+                0.05,
+                600,
+                600,
+                1,
+                30,
+                0.99,  # above remainder (0.030) → 0 deaths
+                0,
+                id="single_large_animal_no_death",
+            ),
+            pytest.param(
+                False,
+                0.001,
+                0.0,
+                365,
+                0,
+                0.0,
+                0.6,
+                0.05,
+                600,
+                600,
+                1,
+                30,
+                0.0,  # below remainder (0.030) → 1 death
+                1,
+                id="single_large_animal_one_death",
             ),
         ],
     )
@@ -2536,33 +2610,40 @@ class TestAnimalCohort:
         zeta_st,
         mass_current,
         mass_max,
+        pop_size,
         dt,
+        mock_random,
         expected_dead,
         predator_cohort_instance,
         carcass_pool_instance,
     ):
-        """Test the calculation of total non-predation mortality in a cohort."""
-        from math import ceil, exp
+        """Test stochastic rounding of non-predation mortality.
+
+        ``random.random`` is mocked to give deterministic control over the
+        stochastic branch.  Each logical scenario is split into a ``_no_extra``
+        case (mock value above the fractional remainder) and a ``_with_extra``
+        case (mock value of 0.0, always below the remainder).  The
+        ``single_large_animal`` cases are the primary regression: with ``ceil``
+        a cohort of 1 with expected_dead ≈ 0.03 would die every timestep; with
+        stochastic rounding it dies with probability 0.03.
+        """
+        from math import exp, floor
 
         import virtual_ecosystem.models.animal.scaling_functions as sf
 
-        # Use the predator cohort instance and set initial individuals to 100
         cohort = predator_cohort_instance
-        cohort.individuals = 100  # Set initial individuals count
+        cohort.individuals = pop_size
         cohort.is_mature = is_mature
         cohort.time_to_maturity = t_to_maturity
         cohort.time_since_maturity = t_since_maturity
         cohort.functional_group.adult_mass = mass_max
 
-        # Mock `mass_current` properly as a property on the class
         mocker.patch.object(
             type(cohort),
             "mass_current",
             new_callable=mocker.PropertyMock,
             return_value=mass_current,
         )
-
-        # Mocking the mortality functions to return predefined values
         mocker.patch(
             "virtual_ecosystem.models.animal.scaling_functions.background_mortality",
             return_value=u_bg,
@@ -2578,49 +2659,39 @@ class TestAnimalCohort:
             return_value=(
                 lambda_max
                 / (1 + exp((mass_current - J_st * mass_max) / (zeta_st * mass_max)))
+                if lambda_max > 0.0
+                else 0.0
             ),
         )
+        mocker.patch(
+            "virtual_ecosystem.models.animal.animal_cohorts.random.random",
+            return_value=mock_random,
+        )
 
-        # Diagnostics
-        print(f"Initial individuals: {cohort.individuals}")
-
-        # Run the method
         cohort.inflict_non_predation_mortality(dt, [carcass_pool_instance])
 
-        # Calculate expected number of deaths inside the test
-        u_bg_value = sf.background_mortality(u_bg)
-        u_se_value = (
-            sf.senescence_mortality(lambda_se, t_to_maturity, t_since_maturity)
-            if is_mature
-            else 0.0
+        # Recompute independently to guard against parametrize drift.
+        u_t = (
+            sf.background_mortality(u_bg)
+            + (
+                sf.senescence_mortality(lambda_se, t_to_maturity, t_since_maturity)
+                if is_mature
+                else 0.0
+            )
+            + sf.starvation_mortality(lambda_max, J_st, zeta_st, mass_current, mass_max)
         )
-        u_st_value = sf.starvation_mortality(
-            lambda_max, J_st, zeta_st, mass_current, mass_max
-        )
-        u_t = u_bg_value + u_se_value + u_st_value
-
-        number_dead = ceil(100 * (1 - exp(-u_t * dt)))
-
-        # Diagnostics
-        print(
-            f"background: {u_bg_value},"
-            f"senescence: {u_se_value},"
-            f"starvation: {u_st_value}"
-        )
-        print(f"Calculated total mortality rate: {u_t}")
-        print(
-            f"Calculated number dead: {number_dead},"
-            f"Expected number dead: {expected_dead}"
-        )
-        print(
-            f"Remaining individuals: {cohort.individuals},"
-            f"Expected remaining: {100 - expected_dead}"
+        continuous_dead = pop_size * (1 - exp(-u_t * dt))
+        floor_dead = floor(continuous_dead)
+        remainder = continuous_dead - floor_dead
+        expected_from_formula = floor_dead + (1 if mock_random < remainder else 0)
+        assert expected_from_formula == expected_dead, (
+            f"Parametrize mismatch: formula gives {expected_from_formula}, "
+            f"expected_dead={expected_dead} (remainder={remainder:.6f}, "
+            f"mock_random={mock_random})."
         )
 
-        # Verify
-        assert cohort.individuals == 100 - expected_dead, (
-            "The calculated number of dead individuals doesn't match the expected "
-            "value."
+        assert cohort.individuals == pop_size - expected_dead, (
+            f"Expected {pop_size - expected_dead} survivors, got {cohort.individuals}."
         )
 
     @pytest.mark.parametrize(

--- a/virtual_ecosystem/models/animal/animal_cohorts.py
+++ b/virtual_ecosystem/models/animal/animal_cohorts.py
@@ -1680,8 +1680,6 @@ class AnimalCohort:
     ) -> None:
         """Inflict combined background, senescence, and starvation mortalities.
 
-        TODO: Review the use of ceil in number_dead, it fails for large animals.
-
         Args:
             dt: The time passed in the timestep (days).
             carcass_pools: The local carcass pool to which dead individuals go.
@@ -1717,8 +1715,12 @@ class AnimalCohort:
         )  # starvation mortality
         u_t = u_bg + u_se + u_st
 
-        # Calculate the total number of dead individuals
-        number_dead = ceil(pop_size * (1 - exp(-u_t * dt)))
+        # Calculate the total number of dead individuals w/ stochastic rounding
+        expected_dead = pop_size * (1 - exp(-u_t * dt))
+        floor_dead = int(expected_dead)
+        remainder = expected_dead - floor_dead
+        stochastic_extra = 1 if random.random() < remainder else 0
+        number_dead = floor_dead + stochastic_extra
 
         # Remove the dead individuals from the cohort
         self.die_individual(number_dead, carcass_pools)

--- a/virtual_ecosystem/models/animal/animal_cohorts.py
+++ b/virtual_ecosystem/models/animal/animal_cohorts.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import random
 import uuid
 from _collections_abc import Callable, Mapping
-from math import ceil, exp, log, sqrt
+from math import ceil, exp, floor, log, sqrt
 from typing import Literal, TypeVar, cast
 
 from numpy import mean, timedelta64
@@ -1717,10 +1717,7 @@ class AnimalCohort:
 
         # Calculate the total number of dead individuals w/ stochastic rounding
         expected_dead = pop_size * (1 - exp(-u_t * dt))
-        floor_dead = int(expected_dead)
-        remainder = expected_dead - floor_dead
-        stochastic_extra = 1 if random.random() < remainder else 0
-        number_dead = floor_dead + stochastic_extra
+        number_dead = floor(expected_dead + random.random())
 
         # Remove the dead individuals from the cohort
         self.die_individual(number_dead, carcass_pools)

--- a/virtual_ecosystem/models/animal/animal_cohorts.py
+++ b/virtual_ecosystem/models/animal/animal_cohorts.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import random
 import uuid
 from _collections_abc import Callable, Mapping
-from math import ceil, exp, floor, log, sqrt
+from math import ceil, exp, log, sqrt
 from typing import Literal, TypeVar, cast
 
 from numpy import mean, timedelta64
+from numpy.random import binomial
 from numpy.typing import NDArray
 
 import virtual_ecosystem.models.animal.scaling_functions as sf
@@ -1680,6 +1681,10 @@ class AnimalCohort:
     ) -> None:
         """Inflict combined background, senescence, and starvation mortalities.
 
+        The number of deaths is drawn from a binomial distribution with trial size
+        ``pop_size`` and per-individual death probability ``1 - exp(-u_t * dt)`` where
+        ``u_t`` is the sum of background, senescence, and starvation mortality rates.
+
         Args:
             dt: The time passed in the timestep (days).
             carcass_pools: The local carcass pool to which dead individuals go.
@@ -1699,12 +1704,9 @@ class AnimalCohort:
 
         u_se = 0.0
         if self.is_mature:
-            # senescence mortality is only experienced by mature adults.
             u_se = sf.senescence_mortality(
                 self.constants.lambda_se, t_to_maturity, t_since_maturity
-            )  # senesence mortality
-        elif self.is_mature is False:
-            u_se = 0.0
+            )  # senescence mortality only experienced by mature adults
 
         u_st = sf.starvation_mortality(
             self.constants.lambda_max,
@@ -1715,9 +1717,8 @@ class AnimalCohort:
         )  # starvation mortality
         u_t = u_bg + u_se + u_st
 
-        # Calculate the total number of dead individuals w/ stochastic rounding
-        expected_dead = pop_size * (1 - exp(-u_t * dt))
-        number_dead = floor(expected_dead + random.random())
+        # Calculate the total number of dead individuals w/ binomial draw
+        number_dead = binomial(n=pop_size, p=1 - exp(-u_t * dt))
 
         # Remove the dead individuals from the cohort
         self.die_individual(number_dead, carcass_pools)


### PR DESCRIPTION
The non-predation mortality method was using a `ceil` function with non-integer mortality rates. This produced unreasonably high total mortality for large bodied animals. 

Changes:
- ceiling function has been replaced with a floor function + stochastic rounding
- tests for non_predation_mortality have been updated

Fixes #469 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
