### PR TITLE
Animal - Fixed bugs in metabolic parameter mapping and c2k conversion.

### DIFF
--- a/virtual_ecosystem/models/animal/scaling_functions.py
+++ b/virtual_ecosystem/models/animal/scaling_functions.py
@@ -214,13 +214,13 @@ def metabolic_rate(
     mass_g = mass * 1000  # convert kg to g
 
     if metabolic_type == MetabolicType.ENDOTHERMIC:
-        Ib, bf = terms["basal"]
-        If, bb = terms["field"]
+        Ib, bb = terms["basal"]
+        If, bf = terms["field"]
         Tk = 310.0  # fixed body temperature for endotherms [K]
     elif metabolic_type == MetabolicType.ECTOTHERMIC:
-        Ib, bf = terms["basal"]
-        If, bb = terms["field"]
-        Tk = temperature + 274.15  # body temperature equals ambient [K]
+        Ib, bb = terms["basal"]
+        If, bf = terms["field"]
+        Tk = temperature + 273.15  # body temperature equals ambient [K]
     else:
         raise ValueError(f"Invalid metabolic type: {metabolic_type}")
 


### PR DESCRIPTION
# Description

This fixes two small bugs.

1) The metabolic parameter mapping was mixed up. Basal/field exponent values were reversed.

2) The Celsius to Kelvin conversion was off by 1 degree. 

Fixes #1641 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
