### PR TITLE
Animal - Change initialization mass from adult_mass to birth_mass to squash mayfly extinctions

### DIFF
--- a/tests/models/animals/test_animal_model.py
+++ b/tests/models/animals/test_animal_model.py
@@ -776,7 +776,7 @@ class TestAnimalModel:
             assert isinstance(cohort, AnimalCohort)
             assert cohort.age == 0.0
             assert cohort.mass_current == pytest.approx(
-                cohort.functional_group.adult_mass
+                cohort.functional_group.birth_mass
             )
             assert cohort.individuals >= model.minimum_cohort_size
             assert cohort.centroid_key in model.data.grid.cell_id

--- a/virtual_ecosystem/models/animal/animal_model.py
+++ b/virtual_ecosystem/models/animal/animal_model.py
@@ -596,6 +596,9 @@ class AnimalModel(
     def _initialize_communities(self, functional_groups: list[FunctionalGroup]) -> None:
         """Initializes the animal communities.
 
+        TODO: Review relationship between birth mass initialization and adult mass in
+        heterotroph biomass normalization
+
         Args:
             functional_groups: The list of functional groups that will populate the
             model.
@@ -620,7 +623,7 @@ class AnimalModel(
             for size, cell_id in zip(cohort_sizes, cohort_locations):
                 self.create_new_cohort(
                     functional_group=fg,
-                    mass=fg.adult_mass,
+                    mass=fg.birth_mass,
                     age=0.0,
                     individuals=size,
                     centroid_key=cell_id,


### PR DESCRIPTION
# Description

Squashing the mayfly extinctions problem turned out to be a very simple change. This also brings me in alignment to the Madingley approach - initializing BABY WORLD and then using spinup to arrive at a sane demographic structure. This may need more fiddling in the future but, based on my casual observations, this solves our rapid extinction problem for now.

Changes:
- initialization mass is changed from `adult_mass` to `birth_mass` - thus preventing immediate senescence mortality

Fixes #1640 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
