### PR TITLE
Handle cells with unusual cohort configuration

### DIFF
--- a/tests/models/plants/conftest.py
+++ b/tests/models/plants/conftest.py
@@ -58,7 +58,12 @@ def fixture_exporter(tmpdir, fixture_configuration):
 
 @pytest.fixture
 def plants_cohort_data(tricky_plant_cohorts):
-    """Construct a simple initial cohort dataframe."""
+    """Construct a simple initial cohort dataframe.
+
+    The tricky plant cohorts switch can be passed down through tests to switch from
+    a normal set of cohorts and a set with edge cases (no cohorts at all, empty cohorts,
+    only one of 2 PFTs.)
+    """
 
     data = pd.DataFrame(
         {
@@ -207,26 +212,29 @@ def fixture_canopy_layer_data(
     from pyrealm.demography.canopy import Canopy
     from pyrealm.demography.community import Cohorts, Community
 
-    # Package the community data up into cell groups
-    cells = plants_cohort_data.groupby("plant_cohorts_cell_id")
-
     # Build the pyrealm community for each cell
-    communities = [
-        Community(
-            flora=flora,
-            cell_area=fixture_core_components.grid.cell_area,
-            cell_id=int(cell_id),
-            cohorts=Cohorts(
-                dbh_values=cell_data["plant_cohorts_dbh"].to_numpy(),
-                n_individuals=cell_data["plant_cohorts_n"].to_numpy(),
-                pft_names=cell_data["plant_cohorts_pft"].to_numpy(),
-            ),
+    communities = []
+    for cell_id in fixture_core_components.grid.cell_id:
+        chrts = plants_cohort_data[plants_cohort_data.plant_cohorts_cell_id == cell_id]
+        communities.append(
+            Community(
+                flora=flora,
+                cell_area=fixture_core_components.grid.cell_area,
+                cell_id=int(cell_id),
+                cohorts=Cohorts(
+                    dbh_values=chrts["plant_cohorts_dbh"].to_numpy(),
+                    n_individuals=chrts["plant_cohorts_n"].to_numpy(),
+                    pft_names=chrts["plant_cohorts_pft"].to_numpy(),
+                ),
+            )
         )
-        for cell_id, cell_data in cells
-    ]
 
     # Fit the PPA solution for each cell
-    canopies = [Canopy(cmnty, fit_ppa=True) for cmnty in communities]
+    # Handle communities with no cohorts
+    canopies = [
+        Canopy(cmnty, fit_ppa=True) if cmnty.n_cohorts else None
+        for cmnty in communities
+    ]
 
     # Extract direct pyrealm canopy data for different variable test cases.
     lyr_struct = fixture_core_components.layer_structure
@@ -248,15 +256,24 @@ def fixture_canopy_layer_data(
 
     # Fill in the plant canopy data
     for idx, (cmty, cnpy) in enumerate(zip(communities, canopies)):
-        # Heights - need to add top of canopy and reference height and remove the zero
-        #           that is always included in pyrealm list of heights.
-        heights = np.concat(
-            [
-                [cnpy.max_stem_height + lyr_struct.above_canopy_height_offset],
-                [cnpy.max_stem_height],
-                cnpy.heights[:-1, 0],
-            ]
-        )
+        if cnpy is None:
+            # Set canopy top at 2m up.
+            expected["layer_heights_full"][1][0, idx] = 2
+            expected["layer_heights_canopy"][1][0, idx] = 2
+            continue
+
+        if cnpy.heights.size:
+            # Heights - need to add top of canopy and reference height and remove the
+            #           zero that is always included in pyrealm list of heights.
+            heights = np.concat(
+                [
+                    [cnpy.max_stem_height + lyr_struct.above_canopy_height_offset],
+                    [cnpy.max_stem_height],
+                    cnpy.heights[:-1, 0],
+                ]
+            )
+        else:
+            heights = np.array([2])
 
         cnpy_height_idx = np.arange(0, heights.size)
         expected["layer_heights_full"][1][cnpy_height_idx, idx] = heights

--- a/tests/models/plants/conftest.py
+++ b/tests/models/plants/conftest.py
@@ -57,10 +57,10 @@ def fixture_exporter(tmpdir, fixture_configuration):
 
 
 @pytest.fixture
-def plants_cohort_data():
+def plants_cohort_data(tricky_plant_cohorts):
     """Construct a simple initial cohort dataframe."""
 
-    return pd.DataFrame(
+    data = pd.DataFrame(
         {
             "plant_cohorts_cell_id": [0, 0, 0, 1, 1, 2, 2, 3, 3, 3],
             "plant_cohorts_n": [400, 100, 100, 300, 100, 200, 100, 100, 100, 100],
@@ -79,6 +79,23 @@ def plants_cohort_data():
             "plant_cohorts_dbh": [1.0, 0.1, 0.01, 1.0, 0.1, 1.0, 0.01, 1.0, 0.1, 0.01],
         }
     )
+
+    if tricky_plant_cohorts:
+        data = pd.DataFrame(
+            {
+                "plant_cohorts_cell_id": [1, 2, 3, 3],
+                "plant_cohorts_n": [0, 1, 1, 1],
+                "plant_cohorts_pft": [
+                    "broadleaf",
+                    "broadleaf",
+                    "broadleaf",
+                    "broadleaf",
+                ],
+                "plant_cohorts_dbh": [1.0, 1.0, 1.0, 0.1],
+            }
+        )
+
+    return data
 
 
 @pytest.fixture

--- a/tests/models/plants/test_canopy.py
+++ b/tests/models/plants/test_canopy.py
@@ -62,12 +62,13 @@ def test_initialise_canopy_layers(plants_data, fixture_core_components):
     )
 
 
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
 @pytest.mark.parametrize(
     "max_canopy_layers, expected_exception, expected_log",
     [
-        (10, does_not_raise(), None),
-        (5, does_not_raise(), None),
-        (
+        pytest.param(10, does_not_raise(), None, id="10_layers"),
+        pytest.param(5, does_not_raise(), None, id="5_layers"),
+        pytest.param(
             1,
             pytest.raises(RuntimeError),
             (
@@ -77,6 +78,7 @@ def test_initialise_canopy_layers(plants_data, fixture_core_components):
                     "layers, configured maximum is 1",
                 ),
             ),
+            id="1_layer",
         ),
     ],
 )
@@ -88,8 +90,14 @@ def test_calculate_canopies(
     max_canopy_layers,
     expected_exception,
     expected_log,
+    tricky_plant_cohorts,
 ):
-    """Test the calculate_canopies function with different max_canopy_layers values."""
+    """Test the calculate_canopies function with different max_canopy_layers values.
+
+    This does not use the tricky cohorts because it is primarily aimed at checking the
+    layer clipping. The test_PlantsModel_update_canopy_layers test is aimed at
+    validating the expected arrays of layer heights etc.
+    """
     from pyrealm.demography.canopy import Canopy
 
     from virtual_ecosystem.models.plants.canopy import calculate_canopies

--- a/tests/models/plants/test_exporter.py
+++ b/tests/models/plants/test_exporter.py
@@ -286,6 +286,7 @@ def csv_row_check(path: Path | None, n_rows: int, attr: list[str] = []) -> None:
         assert set(content.columns) == set(attr)
 
 
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
 @pytest.mark.parametrize(
     argnames="required,attributes",
     argvalues=(
@@ -295,9 +296,16 @@ def csv_row_check(path: Path | None, n_rows: int, attr: list[str] = []) -> None:
     ),
 )
 def test_CommunityDataExporter_dump_cohort_data(
-    tmp_path, fixture_exporter_components, required, attributes
+    tmp_path,
+    fixture_exporter_components,
+    tricky_plant_cohorts,  # Set that the straightforward cohort data gets used
+    required,
+    attributes,
 ):
-    """Test CommunityDataExporter _dump_cohort_data method."""
+    """Test CommunityDataExporter _dump_cohort_data method.
+
+    tricky_plant_cohorts
+    """
 
     from virtual_ecosystem.models.plants.exporter import CommunityDataExporter
 
@@ -337,6 +345,7 @@ def test_CommunityDataExporter_dump_cohort_data(
         assert "biomass_foliage_n_actual_element_mass" in content.columns
 
 
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
 @pytest.mark.parametrize(
     argnames="required,attributes",
     argvalues=(
@@ -348,7 +357,11 @@ def test_CommunityDataExporter_dump_cohort_data(
     ),
 )
 def test_CommunityDataExporter_dump_community_canopy_data(
-    tmp_path, fixture_exporter_components, required, attributes
+    tmp_path,
+    fixture_exporter_components,
+    tricky_plant_cohorts,  # Set that the straightforward cohort data gets used
+    required,
+    attributes,
 ):
     """Test CommunityDataExporter _dump_community_canopy_data method."""
 
@@ -382,6 +395,7 @@ def test_CommunityDataExporter_dump_community_canopy_data(
     csv_row_check(path=out_path, n_rows=cell_n_layers.sum(), attr=attributes)
 
 
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
 @pytest.mark.parametrize(
     argnames="required,attributes",
     argvalues=(
@@ -391,7 +405,11 @@ def test_CommunityDataExporter_dump_community_canopy_data(
     ),
 )
 def test_CommunityDataExporter_dump_stem_canopy_data(
-    tmp_path, fixture_exporter_components, required, attributes
+    tmp_path,
+    fixture_exporter_components,
+    tricky_plant_cohorts,  # Set that the straightforward cohort data gets used
+    required,
+    attributes,
 ):
     """Test CommunityDataExporter _dump_stem_canopy_data method."""
 
@@ -428,6 +446,7 @@ def test_CommunityDataExporter_dump_stem_canopy_data(
     csv_row_check(path=out_path, n_rows=cell_n_stem_layers, attr=attributes)
 
 
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
 @pytest.mark.parametrize(
     argnames=("required"),
     argvalues=(

--- a/tests/models/plants/test_plants_model.py
+++ b/tests/models/plants/test_plants_model.py
@@ -205,7 +205,10 @@ def test_PlantsModel_from_config(
     )
 
 
-def test_PlantsModel_update_canopy_layers(fxt_plants_model, fixture_canopy_layer_data):
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False, True])
+def test_PlantsModel_update_canopy_layers(
+    fxt_plants_model, fixture_canopy_layer_data, tricky_plant_cohorts
+):
     """Simple test that update canopy layers restores overwritten data."""
 
     # Overwrite the existing canopy derived data in each layer - this also nukes the

--- a/tests/models/plants/test_plants_model.py
+++ b/tests/models/plants/test_plants_model.py
@@ -1,4 +1,14 @@
-"""Tests for the model.plants.plants_model submodule."""
+"""Tests for the model.plants.plants_model submodule.
+
+The cohort data fixture used to run the full model in these tests has two payloads - one
+with fairly sensible cohorts and the other with edge cases. These can be selected by
+passing the tricky_plant_cohorts argument to the test function, which pytest passes down
+to parameterise the `plants_cohort_data` fixture. Only one test in this module uses the
+tricky data but the other tests still need to be parameterised (there doesn't seem to be
+a way to set a default on the fixture).
+
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
+"""
 
 from contextlib import nullcontext as does_not_raise
 from copy import deepcopy
@@ -54,6 +64,7 @@ def wipe_canopy_layers(model):
         model.data[layer] = model.layer_structure.from_template()
 
 
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
 def test_PlantsModel__init__(
     plants_data,
     plants_cohort_data,
@@ -62,6 +73,7 @@ def test_PlantsModel__init__(
     fixture_core_components,
     fixture_canopy_layer_data,
     fixture_exporter,
+    tricky_plant_cohorts,
 ):
     """Test the PlantsModel.__init__ method."""
 
@@ -96,6 +108,7 @@ def test_PlantsModel__init__(
     )
 
 
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
 @pytest.mark.parametrize(
     argnames="new_data,context_manager,error_message",
     argvalues=(
@@ -137,7 +150,7 @@ def test_PlantsModel__init__errors(
     plants_cohort_data,
     extra_pft_traits,
     fixture_core_components,
-    fixture_canopy_layer_data,
+    tricky_plant_cohorts,
     fixture_exporter,
     new_data,
     context_manager,
@@ -169,11 +182,13 @@ def test_PlantsModel__init__errors(
     assert str(ctxt.value) == error_message
 
 
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
 def test_PlantsModel_from_config(
     plants_data,
     fixture_configuration,
     fixture_core_components,
     fixture_canopy_layer_data,
+    tricky_plant_cohorts,
 ):
     """Test the PlantsModel.from_config factory method."""
 
@@ -207,9 +222,16 @@ def test_PlantsModel_from_config(
 
 @pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False, True])
 def test_PlantsModel_update_canopy_layers(
-    fxt_plants_model, fixture_canopy_layer_data, tricky_plant_cohorts
+    fxt_plants_model,
+    fixture_canopy_layer_data,
+    tricky_plant_cohorts,  # Passed down to fixtures to set cohort inputs
 ):
-    """Simple test that update canopy layers restores overwritten data."""
+    """Simple test that update canopy layers restores overwritten data.
+
+    The tricky_plant_cohorts argument is passed down to fixtures to swap between a set
+    of cohorts that provide all PFTs in all cells and a set with odd edge cases (no
+    cohorts at all, cohorts with no individuals, only one PFT)
+    """
 
     # Overwrite the existing canopy derived data in each layer - this also nukes the
     # soil and surface depths _which_ are not correctly regenerated in this test, so the
@@ -238,8 +260,9 @@ def test_PlantsModel_update_canopy_layers(
     )
 
 
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
 def test_PlantsModel_set_shortwave_absorption(
-    fxt_plants_model, fixture_canopy_layer_data
+    fxt_plants_model, fixture_canopy_layer_data, tricky_plant_cohorts
 ):
     """Simple test that update canopy layers restores overwritten data."""
 
@@ -307,7 +330,8 @@ def fxt_plants_model_hbvry(fxt_plants_model):
     return fxt_plants_model
 
 
-def test_PlantsModel_apply_herbivory(fxt_plants_model_hbvry):
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
+def test_PlantsModel_apply_herbivory(fxt_plants_model_hbvry, tricky_plant_cohorts):
     """Check the sequencing and processes for applying herbivory."""
 
     from virtual_ecosystem.models.plants.canopy import calculate_canopies
@@ -380,7 +404,8 @@ def test_PlantsModel_apply_herbivory(fxt_plants_model_hbvry):
         )
 
 
-def test_PlantsModel_update_allometry(fxt_plants_model_hbvry):
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
+def test_PlantsModel_update_allometry(fxt_plants_model_hbvry, tricky_plant_cohorts):
     """Check update allometry correctly resets traits."""
     from pyrealm.demography.tmodel import StemAllometry
 
@@ -439,7 +464,8 @@ def test_PlantsModel_update_allometry(fxt_plants_model_hbvry):
         assert_allclose(pert, orig)
 
 
-def test_PlantsModel_estimate_gpp(fxt_plants_model):
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
+def test_PlantsModel_estimate_gpp(fxt_plants_model, tricky_plant_cohorts):
     """Test the estimate_gpp method."""
 
     # Set the canopy and absorbed irradiance
@@ -551,11 +577,8 @@ def test_PlantsModel_estimate_gpp(fxt_plants_model):
     )
 
 
-# @pytest.mark.skip(
-#     reason="The DBH increase check fails - we need to fix this but that is going "
-#     "to be tricky and we need to unblock the CI."
-# )
-def test_PlantsModel_allocate_gpp(fxt_plants_model):
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
+def test_PlantsModel_allocate_gpp(fxt_plants_model, tricky_plant_cohorts):
     """Test the allocate_gpp method."""
 
     # Populate the data variables required for update
@@ -625,7 +648,10 @@ def test_PlantsModel_allocate_gpp(fxt_plants_model):
         )
 
 
-def test_PlantsModel_update(fxt_plants_model, fixture_canopy_layer_data):
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
+def test_PlantsModel_update(
+    fxt_plants_model, fixture_canopy_layer_data, tricky_plant_cohorts
+):
     """Test the update method."""
 
     # The update method runs both update_canopy_layers and set_shortwave_absorption so
@@ -659,7 +685,8 @@ def test_PlantsModel_update(fxt_plants_model, fixture_canopy_layer_data):
     #         assert np.allclose(cohort.dbh, 0.13)
 
 
-def test_PlantsModel_calculate_turnover(fxt_plants_model):
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
+def test_PlantsModel_calculate_turnover(fxt_plants_model, tricky_plant_cohorts):
     """Test the calculate_turnover method of the plants model."""
 
     # Check reset
@@ -679,7 +706,8 @@ def test_PlantsModel_calculate_turnover(fxt_plants_model):
     assert np.allclose(fxt_plants_model.data["root_lignin"], consts.root_lignin)
 
 
-def test_PlantsModel_calculate_nutrient_uptake(fxt_plants_model):
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
+def test_PlantsModel_calculate_nutrient_uptake(fxt_plants_model, tricky_plant_cohorts):
     """Test the calculate_nutrient_uptake method of the plants model."""
 
     # Provide transpiration values
@@ -719,7 +747,8 @@ def test_PlantsModel_calculate_nutrient_uptake(fxt_plants_model):
     )
 
 
-def test_PlantsModel_apply_mortality(mocker, fxt_plants_model):
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
+def test_PlantsModel_apply_mortality(mocker, fxt_plants_model, tricky_plant_cohorts):
     """Test the apply_mortality method of the plants model."""
 
     # Patch the RNG in mortality to kill one of every cohort - easier calculation of
@@ -779,7 +808,8 @@ def test_PlantsModel_apply_mortality(mocker, fxt_plants_model):
                 )
 
 
-def test_PlantsModel_apply_recruitment(fxt_plants_model):
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
+def test_PlantsModel_apply_recruitment(fxt_plants_model, tricky_plant_cohorts):
     """Test the apply_recruitment method of the plants model."""
 
     original_n_cohorts = [
@@ -811,7 +841,8 @@ def test_PlantsModel_apply_recruitment(fxt_plants_model):
     assert np.all(np.less(original_n_cohorts, new_n_cohorts))
 
 
-def test_convert_to_litter_units(fxt_plants_model):
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
+def test_convert_to_litter_units(fxt_plants_model, tricky_plant_cohorts):
     """Tests the helper function that converts to litter model units."""
 
     input_mass = np.array([1e5, 3.4e2, 123.7, 0.007])
@@ -824,7 +855,8 @@ def test_convert_to_litter_units(fxt_plants_model):
     assert np.allclose(expected_input_density, actual_input_density)
 
 
-def test_convert_to_soil_units(fxt_plants_model):
+@pytest.mark.parametrize(argnames="tricky_plant_cohorts", argvalues=[False])
+def test_convert_to_soil_units(fxt_plants_model, tricky_plant_cohorts):
     """Tests the helper function that converts to soil model units."""
 
     print(fxt_plants_model.model_timing.update_interval_quantity)

--- a/virtual_ecosystem/models/plants/biomasses.py
+++ b/virtual_ecosystem/models/plants/biomasses.py
@@ -209,8 +209,10 @@ class BiomassTissueABC(ABC):
         # NOTE - this relies on the community being updated by reference when
         #        recruitment happens. If this changes then the match of the number of
         #        columns to the PFTs needs to be maintained some other way.
-        for pft in self.community.flora.name:
+        for pft in set(self.community.cohorts.pft_names):
+            # boolean index along carbon_mass array
             in_pft = self.community.cohorts.pft_names == pft
+            # aggregate masses across cohorts in the PFT and assign total.
             total_pft_carbon_biomass[in_pft] = self.carbon_mass[in_pft].sum()
 
         return self.carbon_mass / total_pft_carbon_biomass
@@ -326,7 +328,7 @@ class FoliageBiomass(BiomassTissueABC):
 
         # Need to use copy to avoid the biomass and allometry masses refer to the same
         # object!
-        carbon_mass = community.stem_allometry.foliage_mass.squeeze().copy()
+        carbon_mass = pyrealm_handling(community.stem_allometry.foliage_mass.copy())
         for elem in with_elements:
             ideal_ratio = np.array(
                 [
@@ -366,10 +368,12 @@ class FoliageBiomass(BiomassTissueABC):
             The increases in element quantities needed to support growth at the ideal
             ratio for the tissue.
         """
-        self.carbon_mass += allocation.delta_foliage_mass.squeeze()
+        carbon_mass = pyrealm_handling(allocation.delta_foliage_mass)
+
+        self.carbon_mass += carbon_mass
 
         nutrient_ideal_ratio_increase = {
-            ky: (allocation.delta_foliage_mass * (1 / elem.ideal_ratio)).squeeze()
+            ky: carbon_mass * (1 / elem.ideal_ratio)
             for ky, elem in self.element_masses.items()
         }
 
@@ -385,14 +389,13 @@ class FoliageBiomass(BiomassTissueABC):
         Returns:
             The element quantity lost to turnover for foliage tissue.
         """
+        carbon_mass = pyrealm_handling(allocation.foliage_turnover)
         elemental_turnovers = {
-            ky: (
-                (allocation.foliage_turnover * (1 / elem.turnover_ratio)).squeeze()
-            ).squeeze()
+            ky: (carbon_mass * (1 / elem.turnover_ratio))
             for ky, elem in self.element_masses.items()
         }
 
-        return {"C": allocation.foliage_turnover.squeeze(), **elemental_turnovers}
+        return {"C": carbon_mass, **elemental_turnovers}
 
 
 @dataclass
@@ -414,7 +417,9 @@ class ReproductiveBiomass(BiomassTissueABC):
         element_masses: dict[str, Element] = {}
 
         # Use copy to avoid maintaining a reference to the allometry
-        carbon_mass = community.stem_allometry.reproductive_tissue_mass.squeeze().copy()
+        carbon_mass = pyrealm_handling(
+            community.stem_allometry.reproductive_tissue_mass.copy()
+        )
 
         for elem in with_elements:
             ideal_ratio = np.array(
@@ -452,14 +457,14 @@ class ReproductiveBiomass(BiomassTissueABC):
             ratio for the tissue.
         """
 
-        carbon_increase = (
+        carbon_increase = pyrealm_handling(
             allocation.delta_foliage_mass
             * self.community.stem_traits.p_foliage_for_reproductive_tissue
         )
-        self.carbon_mass += carbon_increase.squeeze()
+        self.carbon_mass += carbon_increase
 
         nutrient_ideal_ratio_increase = {
-            ky: (carbon_increase * (1 / elem.ideal_ratio)).squeeze()
+            ky: (carbon_increase * (1 / elem.ideal_ratio))
             for ky, elem in self.element_masses.items()
         }
 
@@ -480,22 +485,13 @@ class ReproductiveBiomass(BiomassTissueABC):
         # element  - maybe this should a cached property?
 
         cx_ratios = self.Cx_ratio
-
+        carbon_mass = pyrealm_handling(allocation.reproductive_tissue_turnover)
         elemental_turnovers = {
-            ky: (
-                (
-                    allocation.reproductive_tissue_turnover * (1 / cx_ratios[ky])
-                ).squeeze()
-            ).squeeze()
+            ky: carbon_mass * (1 / cx_ratios[ky])
             for ky, elem in self.element_masses.items()
         }
 
-        LOGGER.debug(f"412: {cx_ratios!r}, {allocation.reproductive_tissue_turnover!r}")
-
-        return {
-            "C": allocation.reproductive_tissue_turnover.squeeze(),
-            **elemental_turnovers,
-        }
+        return {"C": carbon_mass, **elemental_turnovers}
 
 
 @dataclass
@@ -523,8 +519,8 @@ class FruitBiomass(BiomassTissueABC):
 
         # Multiplication here avoids the need to copy() the array to avoid the reference
         # back to the allometry
-        carbon_mass = (
-            community.stem_allometry.reproductive_tissue_mass.squeeze() * fruit_fraction
+        carbon_mass = pyrealm_handling(
+            community.stem_allometry.reproductive_tissue_mass * fruit_fraction
         )
 
         for elem in with_elements:
@@ -568,15 +564,15 @@ class FruitBiomass(BiomassTissueABC):
             for name in self.community.cohorts.pft_names
         ]
 
-        carbon_increase = (
+        carbon_increase = pyrealm_handling(
             allocation.delta_foliage_mass
             * self.community.stem_traits.p_foliage_for_reproductive_tissue
             * fruit_fraction
         )
-        self.carbon_mass += carbon_increase.squeeze()
+        self.carbon_mass += carbon_increase
 
         nutrient_ideal_ratio_increase = {
-            ky: (carbon_increase * (1 / elem.ideal_ratio)).squeeze()
+            ky: (carbon_increase * (1 / elem.ideal_ratio))
             for ky, elem in self.element_masses.items()
         }
 
@@ -605,11 +601,11 @@ class FruitBiomass(BiomassTissueABC):
         ]
 
         carbon_turnover = (
-            allocation.reproductive_tissue_turnover.squeeze() * fruit_fraction
+            pyrealm_handling(allocation.reproductive_tissue_turnover) * fruit_fraction
         )
 
         elemental_turnovers = {
-            ky: ((carbon_turnover * (1 / cx_ratios[ky])).squeeze()).squeeze()
+            ky: (carbon_turnover * (1 / cx_ratios[ky]))
             for ky, elem in self.element_masses.items()
         }
 
@@ -643,7 +639,8 @@ class SeedBiomass(BiomassTissueABC):
         # Multiplication here avoids the need to copy() the array to avoid the reference
         # back to the allometry
         carbon_mass = (
-            community.stem_allometry.reproductive_tissue_mass.squeeze() * seed_fraction
+            pyrealm_handling(community.stem_allometry.reproductive_tissue_mass)
+            * seed_fraction
         )
 
         for elem in with_elements:
@@ -688,15 +685,15 @@ class SeedBiomass(BiomassTissueABC):
             for name in self.community.cohorts.pft_names
         ]
 
-        carbon_increase = (
+        carbon_increase = pyrealm_handling(
             allocation.delta_foliage_mass
             * self.community.stem_traits.p_foliage_for_reproductive_tissue
             * seed_fraction
         )
-        self.carbon_mass += carbon_increase.squeeze()
+        self.carbon_mass += carbon_increase
 
         nutrient_ideal_ratio_increase = {
-            ky: (carbon_increase * (1 / elem.ideal_ratio)).squeeze()
+            ky: (carbon_increase * (1 / elem.ideal_ratio))
             for ky, elem in self.element_masses.items()
         }
 
@@ -725,11 +722,11 @@ class SeedBiomass(BiomassTissueABC):
         ]
 
         carbon_turnover = (
-            allocation.reproductive_tissue_turnover.squeeze() * seed_fraction
+            pyrealm_handling(allocation.reproductive_tissue_turnover) * seed_fraction
         )
 
         elemental_turnovers = {
-            ky: ((carbon_turnover * (1 / cx_ratios[ky])).squeeze()).squeeze()
+            ky: (carbon_turnover * (1 / cx_ratios[ky]))
             for ky, elem in self.element_masses.items()
         }
 
@@ -755,7 +752,7 @@ class StemBiomass(BiomassTissueABC):
         element_masses: dict[str, Element] = {}
 
         # Use copy to avoid maintaining a reference to the allometry
-        carbon_mass = community.stem_allometry.stem_mass.squeeze().copy()
+        carbon_mass = pyrealm_handling(community.stem_allometry.stem_mass.copy())
 
         for elem in with_elements:
             ideal_ratio = np.array(
@@ -789,10 +786,10 @@ class StemBiomass(BiomassTissueABC):
             The increases in element quantities needed to support growth at the ideal
             ratio for the tissue.
         """
-        self.carbon_mass += allocation.delta_stem_mass.squeeze()
+        self.carbon_mass += pyrealm_handling(allocation.delta_stem_mass)
 
         nutrient_ideal_ratio_increase = {
-            ky: (allocation.delta_stem_mass * (1 / elem.ideal_ratio)).squeeze()
+            ky: pyrealm_handling(allocation.delta_stem_mass) * (1 / elem.ideal_ratio)
             for ky, elem in self.element_masses.items()
         }
 
@@ -809,11 +806,11 @@ class StemBiomass(BiomassTissueABC):
             The element quantity lost to turnover for foliage tissue.
         """
         elemental_turnovers = {
-            ky: np.zeros_like(self.carbon_mass).squeeze()
+            ky: np.zeros_like(self.carbon_mass)
             for ky, elem in self.element_masses.items()
         }
 
-        return {"C": np.zeros_like(self.carbon_mass).squeeze(), **elemental_turnovers}
+        return {"C": np.zeros_like(self.carbon_mass), **elemental_turnovers}
 
 
 @dataclass
@@ -835,11 +832,11 @@ class RootBiomass(BiomassTissueABC):
         element_masses: dict[str, Element] = {}
 
         # until pyrealm 2.0.1
-        fine_root_mass = (
+        fine_root_mass = pyrealm_handling(
             community.stem_allometry.foliage_mass
             * community.stem_traits.zeta
             * community.stem_traits.sla
-        ).squeeze()
+        )
 
         for elem in with_elements:
             ideal_ratio = np.array(
@@ -879,16 +876,16 @@ class RootBiomass(BiomassTissueABC):
             ratio for the tissue.
         """
 
-        carbon_increase = (
+        carbon_increase = pyrealm_handling(
             allocation.delta_foliage_mass
             * self.community.stem_traits.zeta
             * self.community.stem_traits.sla
         )
 
-        self.carbon_mass += carbon_increase.squeeze()
+        self.carbon_mass += carbon_increase
 
         nutrient_ideal_ratio_increase = {
-            ky: (carbon_increase * (1 / elem.ideal_ratio)).squeeze()
+            ky: (carbon_increase * (1 / elem.ideal_ratio))
             for ky, elem in self.element_masses.items()
         }
 
@@ -906,15 +903,38 @@ class RootBiomass(BiomassTissueABC):
         """
 
         cx_ratios = self.Cx_ratio
+        carbon_mass = pyrealm_handling(allocation.fine_root_turnover)
 
         elemental_turnovers = {
-            ky: (
-                (allocation.fine_root_turnover * (1 / cx_ratios[ky])).squeeze()
-            ).squeeze()
+            ky: (carbon_mass * (1 / cx_ratios[ky]))
             for ky, elem in self.element_masses.items()
         }
 
-        return {"C": allocation.fine_root_turnover.squeeze(), **elemental_turnovers}
+        return {"C": carbon_mass, **elemental_turnovers}
+
+
+def pyrealm_handling(arr: NDArray):
+    """Handle pyrealm dimensions.
+
+    The pyrealm package in version 2.0 and 3.0 returns 2D arrays of cohort data that
+    have length 1 in the second dimension: np.array([[1.5, 1.6]]). Those can be
+    collapsed using squeeze() _but_ this breaks on communities with a single cohort
+    because squeeze is greedy and collapses np.array([[1.5]]) to the zero-dimension case
+    np.array(1.5).
+
+    You can specify _which_ axis to squeeze (e.g. squeeze(1)) but the test data uses 1D
+    arrays as inputs, and it seems likely that pyrealm should change to stop doing this
+    as a default. So for the moment this function is used to simplify 2D to 1D.
+
+    Args:
+        arr: A numpy array.
+    """
+
+    if arr.ndim > 1:
+        # Specifically suppress pyrealm arrays with length 1 in axis 1.
+        return arr.squeeze(0)
+
+    return arr
 
 
 @dataclass

--- a/virtual_ecosystem/models/plants/canopy.py
+++ b/virtual_ecosystem/models/plants/canopy.py
@@ -79,7 +79,7 @@ def initialise_canopy_layers(
 
 def calculate_canopies(
     communities: PlantCommunities, max_canopy_layers: int
-) -> dict[int, Canopy]:
+) -> dict[int, Canopy | None]:
     """Calculate the canopy structure of communities.
 
     This function takes a PlantCommunities object and calculates the canopy
@@ -99,24 +99,35 @@ def calculate_canopies(
     # TODO - this could be a method of PlantCommunities but creates circular import of
     #        PlantCohorts
 
+    # TODO - pyrealm does not currently support an empty Canopy object (no cohorts) so
+    #        this currently uses None as a placeholder for cells with no cohorts.
+
     # TODO - maybe return dict[str, NDArray] as the number of layers is only going to
     #        increase with the need for more resources and cohort data.
 
     # Loop over the communities in each cell
-    canopies: dict[int, Canopy] = {}
+    canopies: dict[int, Canopy | None] = {}
     for cell_id, community in communities.items():
-        # Calculate the PPA canopy model for the community in the cell
-        canopies[cell_id] = Canopy(community, fit_ppa=True)
+        # Represent canopy of empty communities as None, otherwise calculate the Canopy
+        # object for the community
+        if community.n_cohorts == 0:
+            canopy = None
+        else:
+            # Calculate the PPA canopy model for the community in the cell
+            canopy = Canopy(community, fit_ppa=True)
 
-        # Fail if canopy representation has more layers than the configuration.
-        n_canopy_layers = canopies[cell_id].heights.size
-        if max_canopy_layers < n_canopy_layers:
-            msg = (
-                f"Canopy representation for the plant community in cell "
-                f"{cell_id} has {n_canopy_layers} layers, "
-                f"configured maximum is {max_canopy_layers}"
-            )
-            LOGGER.critical(msg)
-            raise RuntimeError(msg)
+            # Fail if canopy representation has more layers than the configuration.
+            n_canopy_layers = canopy.heights.size
+            if max_canopy_layers < n_canopy_layers:
+                msg = (
+                    f"Canopy representation for the plant community in cell "
+                    f"{cell_id} has {n_canopy_layers} layers, "
+                    f"configured maximum is {max_canopy_layers}"
+                )
+                LOGGER.critical(msg)
+                raise RuntimeError(msg)
+
+        # Store canopy representation
+        canopies[cell_id] = canopy
 
     return canopies

--- a/virtual_ecosystem/models/plants/communities.py
+++ b/virtual_ecosystem/models/plants/communities.py
@@ -12,6 +12,7 @@ instances.
 
 from collections.abc import Mapping
 
+import numpy as np
 import pandas as pd
 from pyrealm.demography.community import Cohorts, Community
 from pyrealm.demography.flora import Flora
@@ -102,16 +103,30 @@ class PlantCommunities(dict, Mapping[int, Community]):
             raise ValueError(msg)
 
         # Now build the pyrealm community objects for each cell
-        for cell_id, cell_cohort_data in cohort_data_grouped:
+        communities = {k: v for k, v in cohort_data_grouped}
+
+        for cell_id in grid.cell_id:
+            if cell_id in communities:
+                # Build cohorts object with provided data
+                cell_cohort_data = communities[cell_id]
+                cohorts = Cohorts(
+                    n_individuals=cell_cohort_data["plant_cohorts_n"].to_numpy(),
+                    pft_names=cell_cohort_data["plant_cohorts_pft"].to_numpy(),
+                    dbh_values=cell_cohort_data["plant_cohorts_dbh"].to_numpy(),
+                )
+            else:
+                # Empty cohorts object
+                cohorts = Cohorts(
+                    dbh_values=np.array([]),
+                    n_individuals=np.array([]),
+                    pft_names=np.array([]),
+                )
+
             self[cell_id] = Community(
                 cell_id=cell_id,
                 cell_area=grid.cell_area,  # Note this is constant
                 flora=flora,
-                cohorts=Cohorts(
-                    n_individuals=cell_cohort_data["plant_cohorts_n"].to_numpy(),
-                    pft_names=cell_cohort_data["plant_cohorts_pft"].to_numpy(),
-                    dbh_values=cell_cohort_data["plant_cohorts_dbh"].to_numpy(),
-                ),
+                cohorts=cohorts,
             )
 
         LOGGER.info("Plant cohort data loaded")

--- a/virtual_ecosystem/models/plants/plants_model.py
+++ b/virtual_ecosystem/models/plants/plants_model.py
@@ -271,7 +271,7 @@ class PlantsModel(
         self._canopy_layer_indices: NDArray[np.bool_]
         """The indices of the canopy layers within wider vertical profile. This is 
         a shorter reference to self.layer_structure.index_canopy."""
-        self.canopies: dict[int, Canopy]
+        self.canopies: dict[int, Canopy | None]
         """A dictionary giving the canopy structure of each grid cell."""
         self.stem_allocations: dict[int, StemAllocation]
         """A dictionary giving the stem allocation of GPP for the community in each grid
@@ -783,15 +783,19 @@ class PlantsModel(
             self.canopies, self.canopies.values(), self.communities.values()
         ):
             # Handle empty canopies
-            # - currently this is being detected by the calculated canopy having no
-            #   layers. If pyrealm changes the handling of empty communities, then need
-            #   to track here. In particular, empty pyrealm canopies emerge from a
-            #   cohort with no individuals. The canopy max height is defined by the
-            #   hypothetical maximum size of the trees of which there no individuals -
-            #   which is misleading to say the least.
+            # - At the moment pyrealm does not handle canopies from no cohorts in the
+            #   cell (represented as None) and handles canopies from cohorts with no
+            #   individuals by reporting zero layer heights. These two pathways should
+            #   be synchronised in a future pyrealm release.
+            # - Of note, empty pyrealm canopies from cohorts with no
+            #   individuals. The canopy max height is defined by the hypothetical
+            #   maximum size of the trees of which there no individuals - which is
+            #   misleading to say the least.
 
-            if canopy.heights.size > 0:
-                # Otherwise get the indices of the array to be filled in
+            # If canopy height data is present then fill in the appropriate layers,
+            # otherwise leave the cell with NA data.
+            if canopy is not None and canopy.heights.size > 0:
+                # Array indices of filled layers in this cell
                 fill_idx = (slice(0, canopy.heights.size), (cell_id,))
 
                 # Insert canopy layer heights
@@ -833,8 +837,8 @@ class PlantsModel(
         self.data["layer_fapar"][self._canopy_layer_indices, :] = fapar
         self.data["layer_leaf_mass"][self._canopy_layer_indices, :] = mass
 
-        # Add the above canopy reference height, handling np.nan in first row where
-        # plants are absent
+        # Add the above canopy reference height, handling np.nan in first row when
+        # the canopy is empty.
         self.data["layer_heights"][self.layer_structure.index_above, :] = np.where(
             np.isnan(heights[0, :]),
             self.layer_structure.above_canopy_height_offset,
@@ -844,10 +848,12 @@ class PlantsModel(
         # Update the filled canopy layers
         self.layer_structure.set_filled_canopy(canopy_heights=heights)
 
-        # Update the below canopy light fraction
+        # Update the below canopy light fraction, handling cells with no canopy
+        # Note - dual path here: no cohorts = None, extinct cohorts have defined
+        # transmission of 1.
         self.below_canopy_light_fraction = np.array(
             [
-                cnpy.community_data.transmission_to_ground
+                1 if cnpy is None else cnpy.community_data.transmission_to_ground
                 for cnpy in self.canopies.values()
             ]
         )
@@ -1079,6 +1085,16 @@ class PlantsModel(
             # Get the canopy and community for the cell
             canopy = self.canopies[cell_id]
             community = self.communities[cell_id]
+
+            # Handle cells with no canopy. Using continue here leaves the transpiration
+            # values for the cell as np.nan
+            if canopy is None:
+                # The .per_stem_gpp and .per_stem_transpiration dictionaries for the
+                # cell is filled with an empty array. Once we have a better handle on
+                # empty community structure this needs to be resolved.
+                self.per_stem_gpp[cell_id] = np.array([])
+                self.per_stem_transpiration[cell_id] = np.array([])
+                continue
 
             # Get cohort data into vertical structure - the cohort canopy data only
             # contains occupied layers - so for example a block of 3 canopy layers by 4

--- a/virtual_ecosystem/models/plants/plants_model.py
+++ b/virtual_ecosystem/models/plants/plants_model.py
@@ -782,48 +782,50 @@ class PlantsModel(
         for cell_id, canopy, community in zip(
             self.canopies, self.canopies.values(), self.communities.values()
         ):
-            # Get the indices of the array to be filled in
-            fill_idx = (slice(0, canopy.heights.size), (cell_id,))
+            # Handle empty canopies
+            # - currently this is being detected by the calculated canopy having no
+            #   layers. If pyrealm changes the handling of empty communities, then need
+            #   to track here. In particular, empty pyrealm canopies emerge from a
+            #   cohort with no individuals. The canopy max height is defined by the
+            #   hypothetical maximum size of the trees of which there no individuals -
+            #   which is misleading to say the least.
 
-            # Insert canopy layer heights
-            # TODO - #695 At present, pyrealm returns a column array which _I think_
-            #        always has zero as the last entry. We don't want that value, so it
-            #        is being clipped out here but keep an eye on this definition and
-            #        update if pyrealm changes. In the meantime, keep this guard check
-            #        to raise if the issue arises.
+            if canopy.heights.size > 0:
+                # Otherwise get the indices of the array to be filled in
+                fill_idx = (slice(0, canopy.heights.size), (cell_id,))
 
-            if canopy.heights[-1, :].item() > 0:
-                raise ValueError("Last canopy.height is non-zero")
+                # Insert canopy layer heights
+                # TODO - #695 At present, pyrealm returns a column array which _I think_
+                #        always has zero as the last entry. We don't want that value, so
+                #        it is being clipped out here but keep an eye on this definition
+                #        and update if pyrealm changes. In the meantime, keep this guard
+                #        check to raise if the issue arises.
 
-            heights[fill_idx] = np.concatenate(
-                [[[canopy.max_stem_height]], canopy.heights[0:-1, :]]
-            )
+                if canopy.heights[-1, :].item() > 0:
+                    raise ValueError("Last canopy.height is non-zero")
 
-            # Insert canopy fapar:
-            # TODO - #695 currently 1D, not 2D - consistency in pyrealm? keepdims?
-            fapar[fill_idx] = canopy.community_data.average_layer_fapar[:, None]
+                heights[fill_idx] = np.concatenate(
+                    [[[canopy.max_stem_height]], canopy.heights[0:-1, :]]
+                )
 
-            # Calculate the per stem leaf mass  as (stem leaf area * (1/sigma) * L) and
-            # then scale up to the number of individuals and sum across cohorts to give
-            # a total mass per layer within the cell.
-            # TODO - need to expose the per cohort data to allow selective herbivory.
-            # BUG  - The calculation here needs to be robust to no plants being present
-            #        in a cell. At the moment, even with plants present, the scaling of
-            #        the model is resulting in cohort total LAI of zero, which gives
-            #        zero division and hence np.nan in the expected leaf mass per cohort
-            #        per layer, which then breaks the setting of the filled layer mask.
-            #        But with actually no plants present, the code still needs to work.
+                # Insert canopy fapar:
+                # TODO - #695 currently 1D, not 2D - consistency in pyrealm? keepdims?
+                fapar[fill_idx] = canopy.community_data.average_layer_fapar[:, None]
 
-            cohort_leaf_mass_per_layer = (
-                canopy.cohort_data.stem_leaf_area
-                * (1 / community.stem_traits.sla)
-                * community.stem_traits.lai
-            ) * community.cohorts.n_individuals
+                # Calculate the per stem leaf mass  as (stem leaf area * (1/sigma) * L)
+                # and then scale up to the number of individuals and sum across cohorts
+                # to give a total mass per layer within the cell.
 
-            mass[fill_idx] = cohort_leaf_mass_per_layer.sum(axis=1, keepdims=True)
+                cohort_leaf_mass_per_layer = (
+                    canopy.cohort_data.stem_leaf_area
+                    * (1 / community.stem_traits.sla)
+                    * community.stem_traits.lai
+                ) * community.cohorts.n_individuals
 
-            # LAI - insert community average LAI values from light capture model
-            lai[fill_idx] = canopy.community_data.average_layer_lai[:, None]
+                mass[fill_idx] = cohort_leaf_mass_per_layer.sum(axis=1, keepdims=True)
+
+                # LAI - insert community average LAI values from light capture model
+                lai[fill_idx] = canopy.community_data.average_layer_lai[:, None]
 
         # Insert the canopy layers into the data objects
         self.data["layer_heights"][self._canopy_layer_indices, :] = heights
@@ -831,9 +833,12 @@ class PlantsModel(
         self.data["layer_fapar"][self._canopy_layer_indices, :] = fapar
         self.data["layer_leaf_mass"][self._canopy_layer_indices, :] = mass
 
-        # Add the above canopy reference height
-        self.data["layer_heights"][self.layer_structure.index_above, :] = (
-            heights[0, :] + self.layer_structure.above_canopy_height_offset
+        # Add the above canopy reference height, handling np.nan in first row where
+        # plants are absent
+        self.data["layer_heights"][self.layer_structure.index_above, :] = np.where(
+            np.isnan(heights[0, :]),
+            self.layer_structure.above_canopy_height_offset,
+            heights[0, :] + self.layer_structure.above_canopy_height_offset,
         )
 
         # Update the filled canopy layers


### PR DESCRIPTION
# Description

This started with #1645 but blew up to provide a bunch of fixes to handle edge cases in cohort data. There are three issues:

* A cell with _no cohort_ data can get an empty Community, but you can't create a Canopy from no cohorts, so the changes make sure empty communities get created and changes PlantsModel.canopies to `dict[int, Canopy | None]` and then handles `None` in canopy code.
* A cell with an _empty cohort_ (that is a tree diameter but no individuals) can have both a community _and_ Canopy - but the max canopy height is bogus and above canopy should be 2m.
* A cell can not contain all of the PFTs, so needed to take more care when iterating over the flora.

The patched code isn't elegant - we're basically waiting on a better version of `pyrealm.demography` here.

To check what is happening, I've added parameterisation to the `plants_cohort_data` fixture to yield an  alternative set of cohort data with the above edge cases. It's finicky, because that means all tests that access the fixture (mostly indirectly) need to provide the parameterisation even though only one test (`test_PlantsModel_update_canopy_layers`) actually does detailed tests. The `fixture_canopy_layer_data` fixture has also been rewritten to generate the expectations for both standard and tricky cohort data.

Fixes #1645 


## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
