### PR TITLE
aero resistance canopy function reactivated

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1077,6 +1077,7 @@ def fixture_static_inputs(
     )
     zero_plane_displacement = np.ones(data.grid.n_cells) * 2.0
     ventilation_rate = np.ones(data.grid.n_cells) * 2.0
+    roughness_length = np.ones(data.grid.n_cells) * 1.0
     wind_speed = data["wind_speed"].to_numpy()
 
     return {
@@ -1092,7 +1093,8 @@ def fixture_static_inputs(
         "mixing_coefficient": mixing_coefficient.to_numpy(),
         "zero_plane_displacement": zero_plane_displacement,
         "wind_speed": wind_speed,
-        "ventialtion_rate": ventilation_rate,
+        "ventilation_rate": ventilation_rate,
+        "roughness_length": roughness_length,
     }
 
 

--- a/tests/models/abiotic/test_microclimate.py
+++ b/tests/models/abiotic/test_microclimate.py
@@ -431,7 +431,6 @@ def test_calculate_thermodynamics_day_and_night(
 
     assert isinstance(result_day, dict)
     assert result_day["aerodynamic_resistance_canopy"].shape == (n_cells,)
-    assert np.all(result_day["aerodynamic_resistance_canopy"] == 20.0)
     np.testing.assert_allclose(
         result_day["aerodynamic_resistance_soil"],
         data["aerodynamic_resistance_soil"],

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -460,8 +460,8 @@ def calculate_thermodynamics(
                 denominator_tolerance=abiotic_constants.denominator_tolerance,
             )
         )
+        aerodynamic_resistance_canopy = aerodynamic_resistance_canopy.squeeze()
         aerodynamic_resistance_soil = state["aerodynamic_resistance_soil"]
-
     else:
         aerodynamic_resistance_canopy = np.repeat(
             abiotic_constants.aerodynamic_resistance_canopy_night, n_cells

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -807,7 +807,7 @@ def update_atmospheric_humidity(
         / (static["atmospheric_pressure"] - saturated_vapour_pressure_air)
     )
     max_specific_humidity = mixing_ratio_saturation / (1 + mixing_ratio_saturation)
-
+    mean_max_specific_humidity = np.nanmean(max_specific_humidity[idx.atm], axis=0)
     # Vertical mixing
     specific_humidity_mixed = wind.mix_and_ventilate(
         input_variable=specific_humidity_with_added_water,
@@ -815,8 +815,8 @@ def update_atmospheric_humidity(
         ventilation_rate=state["ventilation_rate"],
         limits=(
             abiotic_constants.min_specific_humidity,
-            max_specific_humidity[0],
-        ),  # TODO layer specific?
+            mean_max_specific_humidity,
+        ),
         surface_index=idx.surface,
     )
 

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -807,7 +807,7 @@ def update_atmospheric_humidity(
         / (static["atmospheric_pressure"] - saturated_vapour_pressure_air)
     )
     max_specific_humidity = mixing_ratio_saturation / (1 + mixing_ratio_saturation)
-    mean_max_specific_humidity = np.nanmean(max_specific_humidity[idx.atm], axis=0)
+
     # Vertical mixing
     specific_humidity_mixed = wind.mix_and_ventilate(
         input_variable=specific_humidity_with_added_water,
@@ -815,8 +815,8 @@ def update_atmospheric_humidity(
         ventilation_rate=state["ventilation_rate"],
         limits=(
             abiotic_constants.min_specific_humidity,
-            mean_max_specific_humidity,
-        ),
+            max_specific_humidity[0],
+        ),  # TODO layer specific?
         surface_index=idx.surface,
     )
 

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -438,8 +438,27 @@ def calculate_thermodynamics(
 
     # Aerodynamic resistances for day and nighttime, [s m-1]
     if is_day:
-        aerodynamic_resistance_canopy = np.repeat(
-            abiotic_constants.aerodynamic_resistance_canopy_day, n_cells
+        # Fallback for no canopy
+        wind_height = np.nan_to_num(
+            static["geometry"]["heights"][1],
+            nan=abiotic_constants.wind_reference_height,
+        )
+        wind_speed = np.where(
+            np.isnan(static["wind_speed"][1]),
+            static["wind_speed"][idx.above],
+            static["wind_speed"][1],
+        )
+
+        aerodynamic_resistance_canopy = aerodynamic_resistance_canopy = (
+            wind.calculate_aerodynamic_resistance(
+                wind_heights=wind_height,
+                roughness_length=static["roughness_length"],
+                zero_plane_displacement=static["zero_plane_displacement"],
+                wind_speed=wind_speed,
+                von_karman_constant=core_constants.von_karmans_constant,
+                fallback_resistance=abiotic_constants.aerodynamic_resistance_canopy_day,
+                denominator_tolerance=abiotic_constants.denominator_tolerance,
+            )
         )
         aerodynamic_resistance_soil = state["aerodynamic_resistance_soil"]
 


### PR DESCRIPTION
This PR reintroduces the calculation of aerodynamic resistance. The function was replaced by a constant while we had bigger issues with the `abiotic` and `plant` model, now it is working well.

Fixes #967

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
