### PR TITLE
Animal - Pred-Prey Mix up in Functional Response

### DIFF
--- a/tests/models/animals/test_animal_cohorts.py
+++ b/tests/models/animals/test_animal_cohorts.py
@@ -1198,23 +1198,29 @@ class TestAnimalCohort:
         assert result == 0.8, "Expected predation search rate not returned."
 
     def test_calculate_potential_prey_consumed(self, mocker, herbivore_cohort_instance):
-        """Test calculation of potential number of prey consumed."""
+        """Test calculation of potential number of prey consumed.
+
+        The prey cohort's abundance ``n_prey`` (Madingley ``N_j,t``) is the value
+        forwarded to ``k_i_j``; it is deliberately set different from the predator
+        cohort's own ``individuals`` so a regression to the predator-count swap would
+        fail this test.
+        """
         alpha = 0.8
+        n_prey = 1234.0
         theta_i_j = 0.7
         intersection_area = 5000.0
-
         mock_k_i_j = mocker.patch(
             "virtual_ecosystem.models.animal.scaling_functions.k_i_j",
             return_value=15.0,
         )
 
         result = herbivore_cohort_instance.calculate_potential_prey_consumed(
-            alpha, theta_i_j, intersection_area
+            alpha, n_prey, theta_i_j, intersection_area
         )
 
         mock_k_i_j.assert_called_once_with(
             alpha,
-            herbivore_cohort_instance.individuals,
+            n_prey,
             intersection_area,
             theta_i_j,
         )

--- a/tests/models/animals/test_scaling_functions.py
+++ b/tests/models/animals/test_scaling_functions.py
@@ -574,7 +574,7 @@ def test_alpha_i_j(alpha_0_pred, mass, w_bar_i_j, expected_search_rate):
 
 
 @pytest.mark.parametrize(
-    "alpha_i_j, N_i_t, A_cell, theta_i_j, expected_output",
+    "alpha_i_j, N_j_t, A_cell, theta_i_j, expected_output",
     [
         pytest.param(0.1, 100, 1.0, 0.5, 5.0, id="basic_scenario"),
         pytest.param(0.2, 50, 2.0, 0.75, 3.75, id="varied_parameters"),
@@ -586,16 +586,16 @@ def test_alpha_i_j(alpha_0_pred, mass, w_bar_i_j, expected_search_rate):
         pytest.param(0.1, 100, 1.0, 0.0, 0.0, id="zero_theta_i_j"),
     ],
 )
-def test_k_i_j(alpha_i_j, N_i_t, A_cell, theta_i_j, expected_output):
+def test_k_i_j(alpha_i_j, N_j_t, A_cell, theta_i_j, expected_output):
     """Testing the calculation of potential prey items eaten."""
     from virtual_ecosystem.models.animal.scaling_functions import k_i_j
 
     # Handle special case where division by zero might occur
     if A_cell == 0:
         with pytest.raises(ZeroDivisionError):
-            k_i_j(alpha_i_j, N_i_t, A_cell, theta_i_j)
+            k_i_j(alpha_i_j, N_j_t, A_cell, theta_i_j)
     else:
-        calculated_output = k_i_j(alpha_i_j, N_i_t, A_cell, theta_i_j)
+        calculated_output = k_i_j(alpha_i_j, N_j_t, A_cell, theta_i_j)
         assert calculated_output == pytest.approx(expected_output, rel=1e-6)
 
 

--- a/virtual_ecosystem/models/animal/animal_cohorts.py
+++ b/virtual_ecosystem/models/animal/animal_cohorts.py
@@ -880,12 +880,13 @@ class AnimalCohort:
         return sf.alpha_i_j(self.constants.alpha_0_pred, self.mass_current, w_bar)
 
     def calculate_potential_prey_consumed(
-        self, alpha: float, theta_i_j: float, intersection_area: float
+        self, alpha: float, n_prey: float, theta_i_j: float, intersection_area: float
     ) -> float:
         """Calculate the potential number of prey consumed.
 
         Args:
             alpha: The predation search rate in m2/(day*g).
+            n_prey: The number of prey individuals.
             theta_i_j: The cumulative density of organisms with a mass lying within the
                 same predator specific mass bin.
             intersection_area: The overlapping area between predator and prey
@@ -894,7 +895,7 @@ class AnimalCohort:
         Returns:
             The potential number of prey items consumed.
         """
-        return sf.k_i_j(alpha, self.individuals, intersection_area, theta_i_j)
+        return sf.k_i_j(alpha, n_prey, intersection_area, theta_i_j)
 
     def calculate_total_handling_time_for_predation(
         self,
@@ -945,7 +946,7 @@ class AnimalCohort:
                         self.constants.sigma_opt_pred_prey,
                     ),
                 ),
-                self.individuals,
+                prey.individuals,
                 intersection_areas[id(prey)],
                 bin_densities.get(self._mass_bin(prey.mass_current, theta_opt), 0.0),
             )
@@ -995,7 +996,7 @@ class AnimalCohort:
         target_bin = self._mass_bin(target_cohort.mass_current, theta_opt)
         theta = bin_densities.get(target_bin, 0.0)
         k_target = self.calculate_potential_prey_consumed(
-            alpha, theta, intersection_area
+            alpha, N_target, theta, intersection_area
         )
         return (
             self.individuals * (k_target / (1 + total_handling_time)) * (1 / N_target)

--- a/virtual_ecosystem/models/animal/scaling_functions.py
+++ b/virtual_ecosystem/models/animal/scaling_functions.py
@@ -539,7 +539,7 @@ def alpha_i_j(alpha_0_pred: float, mass: float, w_bar_i_j: float) -> float:
 
 
 def k_i_j(
-    alpha_i_j: float, N_i_t: float, intersection_area: float, theta_i_j: float
+    alpha_i_j: float, N_j_t: float, intersection_area: float, theta_i_j: float
 ) -> float:
     """Potential number of prey items eaten off j by i.
 
@@ -550,7 +550,7 @@ def k_i_j(
     Args:
         alpha_i_j: Rate at which an individual predator searches its environment and
             kills prey in m2/(day*g).
-        N_i_t: Number of consumer individuals.
+        N_j_t: Number of prey individuals.
         intersection_area: The overlapping area between predator and prey territories
           in m2.
         theta_i_j: The cumulative density of organisms with a mass lying within the
@@ -559,7 +559,8 @@ def k_i_j(
     Returns:
         Potential number of prey items eaten off j by i [integer number of individuals]
     """
-    return alpha_i_j * (N_i_t / intersection_area) * theta_i_j
+    #      m2/(day*g) * (con_ind / m2) * prey_ind/m2
+    return alpha_i_j * (N_j_t / intersection_area) * theta_i_j
 
 
 def H_i_j(


### PR DESCRIPTION
# Description

There was a variable mix-up in defining the functional response. Something that used predator abundance should have been using prey abundance. 

Changes:
- variable swap in `scaling_functions.k_i_j`

I absolutely do need to update the Madingley names. Coming Soon!

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
