### PR TITLE
1728 remove exception when recording negative biomasses

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,52 @@
+name: Run integration
+
+# When does this run?
+# * when called by another workflow, such as the publishing actions, or
+# * when manually triggered to check the integration tests on a branch.
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  # Run the CI checks to check it all runs normally and to define the test matrix
+  ci_checks:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+  
+  # Then if the standard CI checks pass run the integration tests
+  integration_tests:
+    needs: ci_checks
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # All supported OSs, minimum and maximum python version
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: ["3.12", "3.14"]
+    
+    steps:
+    - uses: actions/checkout@v7
+
+    - uses: actions/setup-python@v7
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Poetry
+      run: |
+        pipx install poetry --python python${{ matrix.python-version }}
+        poetry --version
+
+    - name: Install dependencies
+      run: poetry install
+
+    - name: Run integration tests
+      run: poetry run pytest -m "integration"
+
+    - name: Archive log for error checking on failure
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: failed_tests_ve_run_cli_log
+        path: ${{ runner.temp }}/log_file.log
+        archive: false
+        retention-days: 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,41 +14,9 @@ jobs:
   
   # Then if the standard CI checks pass run the integration tests
   integration_tests:
+    uses: ./.github/workflows/integration_tests.yml
     needs: ci_checks
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # All supported OSs, minimum and maximum python version
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: ["3.12", "3.14"]
-    
-    steps:
-    - uses: actions/checkout@v7
-
-    - uses: actions/setup-python@v7
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Install Poetry
-      run: |
-        pipx install poetry --python python${{ matrix.python-version }}
-        poetry --version
-
-    - name: Install dependencies
-      run: poetry install
-
-    - name: Run integration tests
-      run: poetry run pytest -m "integration"
-
-    - name: Archive log for error checking on failure
-      if: failure()
-      uses: actions/upload-artifact@v7
-      with:
-        name: failed_tests_ve_run_cli_log
-        path: ${{ runner.temp }}/log_file.log
-        archive: false
-        retention-days: 1
+    secrets: inherit
 
   # Next, build the package wheel and source releases and add them to the release assets
   build-wheel:

--- a/virtual_ecosystem/models/animal/animal_cohorts.py
+++ b/virtual_ecosystem/models/animal/animal_cohorts.py
@@ -258,12 +258,16 @@ class AnimalCohort:
         if delta.total == 0.0:
             return
 
-        if delta.C < 0.0 or delta.N < 0.0 or delta.P < 0.0:
-            raise ValueError(
-                "Trophic transfer masses must be non-negative. "
-                f"Received carbon={delta.C}, N={delta.N}, "
-                f"P={delta.P}."
-            )
+        # TODO - commented out in #1728 to stop biomass issues crashing integration
+        #        tests. This should probably be simply removed, once we track down the
+        #        source of the errors, but leaving it for now as a reminder.
+
+        # if delta.C < 0.0 or delta.N < 0.0 or delta.P < 0.0:
+        #     raise ValueError(
+        #         "Trophic transfer masses must be non-negative. "
+        #         f"Received carbon={delta.C}, N={delta.N}, "
+        #         f"P={delta.P}."
+        #     )
 
         if resource_key not in self.trophic_record:
             self.trophic_record[resource_key] = {


### PR DESCRIPTION
# Description

This PR:

* Comments out the exception in `record_trophic_transfer`
* Attempts (fingers crossed) to separate out the integration tests workflow so that we can manually trigger integration tests on a branch to run  tests before a release...

@jacobcook1995 No way of knowing if I've got this right until it is merged unfortunately - can only run `workflow_dispatch` jobs from `develop`.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
