### PR TITLE
Converting raises to warnings

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -8,14 +8,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Run the CI checks to check it all runs normally and to define the test matrix
-  ci_checks:
-    uses: ./.github/workflows/ci.yml
-    secrets: inherit
-  
-  # Then if the standard CI checks pass run the integration tests
+
+  # Run the integration tests
   integration_tests:
-    needs: ci_checks
+
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/tests/models/animals/test_decay.py
+++ b/tests/models/animals/test_decay.py
@@ -57,7 +57,7 @@ class TestCarcassPool:
         [
             (5.0, 1.0, 0.5, 5.0, 1.0, 0.5, False),  # Normal case
             (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, False),  # Zero mass
-            (-1.0, 1.0, 0.5, None, None, None, True),  # Negative value
+            # (-1.0, 1.0, 0.5, None, None, None, True),  # Negative value
         ],
     )
     def test_add_carcass(
@@ -128,7 +128,7 @@ class TestExcrementPool:
         [
             (5.0, 1.0, 0.5, 5.0, 1.0, 0.5, False),  # Normal case
             (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, False),  # Zero mass
-            (-1.0, 1.0, 0.5, None, None, None, True),  # Negative value
+            # (-1.0, 1.0, 0.5, None, None, None, True),  # Negative value
         ],
     )
     def test_add_excrement(

--- a/virtual_ecosystem/models/animal/decay.py
+++ b/virtual_ecosystem/models/animal/decay.py
@@ -129,11 +129,13 @@ class CarcassPool(ScavengeableMixin):
             ValueError: If any input mass is negative.
         """
         if C < 0 or N < 0 or P < 0:
-            raise ValueError(
-                f"CNP values must be non-negative. Provided values: C={C}, N={N}, P={P}"
-            )
+            LOGGER.warning("Negative CNP values in add_carcass: C={C}, N={N}, P={P}")
 
-        self.scavengeable_cnp.update(C=C, N=N, P=P)
+        self.scavengeable_cnp.update(
+            C=C if C > 0 else 0,
+            N=N if N > 0 else 0,
+            P=P if P > 0 else 0,
+        )
 
     def reset(self) -> None:
         """Reset tracking of the nutrients associated with decomposed carcasses.
@@ -199,12 +201,15 @@ class ExcrementPool(ScavengeableMixin):
         Raises:
             ValueError: If any input mass is negative.
         """
-        if C < 0 or N < 0 or P < 0:
-            raise ValueError(
-                f"CNP values must be non-negative. Provided values: C={C}, N={N}, P={P}"
-            )
 
-        self.scavengeable_cnp.update(C=C, N=N, P=P)
+        if C < 0 or N < 0 or P < 0:
+            LOGGER.warning("Negative CNP values in add_excrement: C={C}, N={N}, P={P}")
+
+        self.scavengeable_cnp.update(
+            C=C if C > 0 else 0,
+            N=N if N > 0 else 0,
+            P=P if P > 0 else 0,
+        )
 
     def reset(self) -> None:
         """Reset tracking of the nutrients associated with decomposed excrement.
@@ -660,8 +665,7 @@ class HerbivoryWaste:
                 [kg{lignin C} kg{C}^-1]
 
         Raises:
-            ValueError: If the input dictionary is missing required elements or contains
-                negative values.
+            ValueError: If the input dictionary is missing required elements.
         """
         # Validate input structure and content
         required_keys = {"C", "N", "P"}
@@ -671,9 +675,8 @@ class HerbivoryWaste:
                 f"Provided keys: {input_mass_cnp.keys()}"
             )
         if any(value < 0 for value in input_mass_cnp.values()):
-            raise ValueError(
-                f"CNP values must be non-negative. Provided values: {input_mass_cnp}"
-            )
+            LOGGER.warning("Negative CNP values in add_waste: C={C}, N={N}, P={P}")
+            input_mass_cnp = {k: v if v > 0 else 0 for k, v in input_mass_cnp.items()}
 
         just_soil = VerticalOccupancy.SOIL
         all_strata = (


### PR DESCRIPTION
# Description

This PR:

* Converts raises in `animals.decay` into logger warnings and zeros any negative elements.
* Removes the requirement for the standard tests and QA before running integration tests. Not needed for manual use and  otherwise these would get run twice when publishing

I'm not sure this catches all of the raises, might be another PR.

Fixes #1731

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
