### PR TITLE
1531 integrate air temperature update

### DIFF
--- a/tests/models/abiotic/test_abiotic_model.py
+++ b/tests/models/abiotic/test_abiotic_model.py
@@ -314,7 +314,7 @@ def test_setup_and_update_abiotic_model(
     valid_values_rel_hum_clean = valid_values_rel_hum.dropna(dim="layers", how="any")
 
     # Now do the test
-    assert ((soil_temps >= 0.0) & (soil_temps <= 40.0)).all()
+    assert ((soil_temps >= 0.0) & (soil_temps <= 50.0)).all()
     assert (
         (valid_values_can_temp_clean >= 0.0) & (valid_values_can_temp_clean <= 40.0)
     ).all()

--- a/tests/models/abiotic/test_energy_balance.py
+++ b/tests/models/abiotic/test_energy_balance.py
@@ -14,9 +14,7 @@ from virtual_ecosystem.models.abiotic.energy_balance import (
 )
 
 
-def test_initialise_canopy_and_soil_fluxes(
-    dummy_climate_data_varying_canopy, fixture_core_components
-):
+def test_initialise_canopy_and_soil_fluxes(fixture_core_components):
     """Test that canopy and soil fluxes initialised correctly."""
 
     from virtual_ecosystem.models.abiotic.energy_balance import (
@@ -279,7 +277,7 @@ def test_energy_balance_residual_only(
     dummy_climate_data_varying_canopy,
     fixture_abiotic_constants,
     fixture_core_constants,
-    fixture_core_components,
+    fixture_abiotic_indices,
 ):
     """Test energy balance residual without flux return."""
     from virtual_ecosystem.models.abiotic.energy_balance import (
@@ -289,6 +287,7 @@ def test_energy_balance_residual_only(
     data = dummy_climate_data_varying_canopy
     evapotranspiration = data["canopy_evaporation"] + data["transpiration"]
     aerodynamic_resistance_2d = np.tile(data["aerodynamic_resistance_canopy"], (14, 1))
+    idx = fixture_abiotic_indices
 
     result = calculate_energy_balance_residual(
         canopy_temperature_initial=data["canopy_temperature"].to_numpy(),
@@ -299,16 +298,17 @@ def test_energy_balance_residual_only(
         .isel(time_index=0)
         .to_numpy()
         * fixture_abiotic_constants.leaf_emissivity,
+        longwave_emission_soil=data["longwave_emission"][idx.topsoil].to_numpy(),
         specific_heat_air=data["specific_heat_air"].to_numpy(),
         density_air=data["density_air"].to_numpy(),
         aerodynamic_resistance=aerodynamic_resistance_2d,
         latent_heat_vapourisation=data["latent_heat_vapourisation"].to_numpy() * 1000,
-        surface_index=fixture_core_components.layer_structure.index_surface_scalar,
         leaf_emissivity=fixture_abiotic_constants.leaf_emissivity,
         stefan_boltzmann_constant=fixture_core_constants.stefan_boltzmann_constant,
         zero_Celsius=fixture_core_constants.zero_Celsius,
         seconds_to_hour=fixture_core_constants.seconds_to_hour,
         return_fluxes=False,
+        idx=idx,
     )
 
     assert isinstance(result, np.ndarray)
@@ -321,7 +321,7 @@ def test_energy_balance_return_fluxes(
     dummy_climate_data_varying_canopy,
     fixture_abiotic_constants,
     fixture_core_constants,
-    fixture_core_components,
+    fixture_abiotic_indices,
 ):
     """Test energy balance residual with flux return."""
     from virtual_ecosystem.models.abiotic.energy_balance import (
@@ -329,6 +329,7 @@ def test_energy_balance_return_fluxes(
     )
 
     data = dummy_climate_data_varying_canopy
+    idx = fixture_abiotic_indices
     evapotranspiration = data["canopy_evaporation"] + data["transpiration"]
     aerodynamic_resistance_2d = np.tile(data["aerodynamic_resistance_canopy"], (14, 1))
 
@@ -338,16 +339,17 @@ def test_energy_balance_return_fluxes(
         evapotranspiration=evapotranspiration.to_numpy(),
         absorbed_shortwave_radiation=data["shortwave_absorption"].to_numpy(),
         absorbed_longwave_radiation=data["shortwave_absorption"].to_numpy() * 0.5,
+        longwave_emission_soil=data["longwave_emission"][idx.topsoil].to_numpy(),
         specific_heat_air=data["specific_heat_air"].to_numpy(),
         density_air=data["density_air"].to_numpy(),
         aerodynamic_resistance=aerodynamic_resistance_2d,
         latent_heat_vapourisation=data["latent_heat_vapourisation"].to_numpy() * 1000,
-        surface_index=fixture_core_components.layer_structure.index_surface_scalar,
         leaf_emissivity=fixture_abiotic_constants.leaf_emissivity,
         stefan_boltzmann_constant=fixture_core_constants.stefan_boltzmann_constant,
         zero_Celsius=fixture_core_constants.zero_Celsius,
         seconds_to_hour=fixture_core_constants.seconds_to_hour,
         return_fluxes=True,
+        idx=idx,
     )
 
     assert isinstance(result, dict)
@@ -672,30 +674,22 @@ def test_secant_nan_handling():
 def test_make_canopy_residual_changes_with_temperature(
     fixture_abiotic_constants,
     fixture_core_constants,
+    fixture_abiotic_indices,
+    fixture_state_inputs,
+    fixture_static_inputs,
 ):
     """Test that canopy residual changes with temperature."""
 
     from virtual_ecosystem.models.abiotic.energy_balance import make_canopy_residual
 
-    shape = (2, 2)
+    state = fixture_state_inputs
+    static = fixture_static_inputs
 
-    state = {
-        "air_temperature": np.ones(shape) * 290,
-        "evapotranspiration": np.ones(shape),
-        "shortwave_absorption": np.ones(shape) * 200,
-        "specific_heat_air": np.ones(shape) * 1005,
-        "density_air": np.ones(shape) * 1.2,
-        "latent_heat_vapourisation": np.ones(shape) * 2.45e6,
-    }
-
-    static = {
-        "absorbed_longwave_radiation": np.ones(shape) * 300,
-    }
-
-    aerodynamic_resistance = np.ones(shape) * 50
+    aerodynamic_resistance = np.full_like(state["air_temperature"], 50)
 
     abiotic_constants = fixture_abiotic_constants
     core_constants = fixture_core_constants
+    idx = fixture_abiotic_indices
 
     residual = make_canopy_residual(
         state=state,
@@ -703,11 +697,11 @@ def test_make_canopy_residual_changes_with_temperature(
         aerodynamic_resistance=aerodynamic_resistance,
         abiotic_constants=abiotic_constants,
         core_constants=core_constants,
-        surface_index=0,
+        idx=idx,
     )
 
-    temperature1 = np.ones(shape) * 28
-    temperature2 = np.ones(shape) * 30
+    temperature1 = state["air_temperature"]
+    temperature2 = state["air_temperature"] + 2.0
 
     residual1 = residual(temperature1)
     residual2 = residual(temperature2)
@@ -716,31 +710,24 @@ def test_make_canopy_residual_changes_with_temperature(
 
 
 def test_make_canopy_residual_uses_state(
-    fixture_abiotic_constants, fixture_core_constants
+    fixture_abiotic_constants,
+    fixture_core_constants,
+    fixture_abiotic_indices,
+    fixture_state_inputs,
+    fixture_static_inputs,
 ):
     """Test that canopy residual reflects changes in state variables."""
 
     from virtual_ecosystem.models.abiotic.energy_balance import make_canopy_residual
 
-    shape = (2, 2)
+    state = fixture_state_inputs
+    static = fixture_static_inputs
 
-    state = {
-        "air_temperature": np.ones(shape) * 29,
-        "evapotranspiration": np.zeros(shape),
-        "shortwave_absorption": np.zeros(shape),
-        "specific_heat_air": np.ones(shape) * 1005,
-        "density_air": np.ones(shape) * 1.2,
-        "latent_heat_vapourisation": np.ones(shape) * 2.45e6,
-    }
-
-    static = {
-        "absorbed_longwave_radiation": np.zeros(shape),
-    }
-
-    aerodynamic_resistance = np.ones(shape) * 50
+    aerodynamic_resistance = np.full_like(state["air_temperature"], 50)
 
     abiotic_constants = fixture_abiotic_constants
     core_constants = fixture_core_constants
+    idx = fixture_abiotic_indices
 
     residual = make_canopy_residual(
         state=state,
@@ -748,67 +735,73 @@ def test_make_canopy_residual_uses_state(
         aerodynamic_resistance=aerodynamic_resistance,
         abiotic_constants=abiotic_constants,
         core_constants=core_constants,
-        surface_index=0,
+        idx=idx,
     )
 
-    temperature1 = np.ones(shape) * 29
+    temperature1 = np.full_like(state["air_temperature"], 29)
 
     residual1 = residual(temperature1)
 
     # change state AFTER creating closure
     state["air_temperature"] += 10
 
-    temperature2 = np.ones(shape) * 39
+    temperature2 = np.full_like(state["air_temperature"], 39)
     residual2 = residual(temperature2)
 
     # closure should reflect updated state
     assert not np.allclose(residual1, residual2)
 
 
-def test_make_canopy_residual_with_nans(
-    fixture_abiotic_constants, fixture_core_constants
+def test_solve_canopy_temperature_with_air_coupling(
+    fixture_state_inputs,
+    fixture_static_inputs,
+    fixture_abiotic_constants,
+    fixture_abiotic_indices,
+    fixture_core_constants,
 ):
-    """Test that canopy residual handles NaNs in state variables."""
+    """Test coupled canopy-air temperature solve returns consistent outputs."""
+    from virtual_ecosystem.models.abiotic.energy_balance import (
+        solve_canopy_temperature_with_air_coupling,
+    )
 
-    from virtual_ecosystem.models.abiotic.energy_balance import make_canopy_residual
-
-    shape = (2, 3)
-
-    state = {
-        "air_temperature": np.ones(shape) * 290,
-        "evapotranspiration": np.ones(shape),
-        "shortwave_absorption": np.ones(shape) * 200,
-        "specific_heat_air": np.ones(shape) * 1005,
-        "density_air": np.ones(shape) * 1.2,
-        "latent_heat_vapourisation": np.ones(shape) * 2.45e6,
-    }
-
-    static = {
-        "absorbed_longwave_radiation": np.ones(shape) * 300,
-    }
-
-    aerodynamic_resistance = np.ones(shape) * 50
-
+    state = fixture_state_inputs
+    static = fixture_static_inputs
     abiotic_constants = fixture_abiotic_constants
     core_constants = fixture_core_constants
+    idx = fixture_abiotic_indices
 
-    residual = make_canopy_residual(
-        state=state,
-        static=static,
-        aerodynamic_resistance=aerodynamic_resistance,
-        abiotic_constants=abiotic_constants,
-        core_constants=core_constants,
-        surface_index=0,
+    canopy_temperature, air_temperature, fluxes = (
+        solve_canopy_temperature_with_air_coupling(
+            state=state,
+            static=static,
+            abiotic_constants=abiotic_constants,
+            core_constants=core_constants,
+            maxiter_air=20,
+            air_temperature_tolerance=1e-4,
+            maxiter_secant=50,
+            convergence_tolerance=1e-6,
+            small_perturbation_second_guess=0.01,
+            denominator_tolerance=1e-12,
+            idx=idx,
+        )
     )
 
-    temperature = np.array(
-        [
-            [29, 29, 29],
-            [29, np.nan, np.nan],
-        ]
+    # Shape checks
+    assert canopy_temperature.shape == state["air_temperature"].shape
+    assert air_temperature.shape == state["air_temperature"].shape
+
+    for key in (
+        "longwave_emission",
+        "sensible_heat_flux",
+        "latent_heat_flux",
+        "energy_balance_residual",
+        "net_radiation",
+    ):
+        assert key in fluxes
+        assert fluxes[key].shape == state["air_temperature"].shape
+
+    # Air temperature should change if sensible heat flux is non-zero
+    assert not np.allclose(
+        air_temperature,
+        state["air_temperature"],
     )
-
-    result = residual(temperature)
-
-    assert np.isnan(result[1, 1])
-    assert np.isnan(result[1, 2])

--- a/tests/models/abiotic/test_microclimate.py
+++ b/tests/models/abiotic/test_microclimate.py
@@ -282,6 +282,7 @@ def test_initialize_state_shapes(dummy_climate_data_varying_canopy):
         "soil_temperature",
         "relative_humidity",
         "aerodynamic_resistance_soil",
+        "longwave_emission",
     ]
     assert set(state.keys()) == set(expected_keys)
 

--- a/virtual_ecosystem/models/abiotic/energy_balance.py
+++ b/virtual_ecosystem/models/abiotic/energy_balance.py
@@ -934,13 +934,11 @@ def solve_canopy_temperature_with_air_coupling(
         tuple of canopy temperature, air temperature, and final fluxes
     """
 
-    canopy_temperature = state["canopy_temperature"].copy()
-    air_temperature = state["air_temperature"].copy()
+    state_local = state.copy()
+    air_temperature = state_local["air_temperature"]
+    canopy_temperature = state_local["canopy_temperature"]
 
     for _ in range(maxiter_air):
-        state_local = state.copy()
-        state_local["air_temperature"] = air_temperature
-
         residual_function = make_canopy_residual(
             state=state_local,
             static=static,
@@ -962,14 +960,14 @@ def solve_canopy_temperature_with_air_coupling(
         fluxes = calculate_energy_balance_residual(
             canopy_temperature_initial=new_canopy_temperature,
             air_temperature=air_temperature,
-            evapotranspiration=state["evapotranspiration"],
-            absorbed_shortwave_radiation=state["shortwave_absorption"],
+            evapotranspiration=state_local["evapotranspiration"],
+            absorbed_shortwave_radiation=state_local["shortwave_absorption"],
             absorbed_longwave_radiation=static["absorbed_longwave_radiation"],
-            longwave_emission_soil=state["longwave_emission"][idx.topsoil],
-            specific_heat_air=state["specific_heat_air"],
-            density_air=state["density_air"],
-            aerodynamic_resistance=state["aerodynamic_resistance_canopy"],
-            latent_heat_vapourisation=state["latent_heat_vapourisation"],
+            longwave_emission_soil=state_local["longwave_emission"][idx.topsoil],
+            specific_heat_air=state_local["specific_heat_air"],
+            density_air=state_local["density_air"],
+            aerodynamic_resistance=state_local["aerodynamic_resistance_canopy"],
+            latent_heat_vapourisation=state_local["latent_heat_vapourisation"],
             leaf_emissivity=abiotic_constants.leaf_emissivity,
             stefan_boltzmann_constant=core_constants.stefan_boltzmann_constant,
             zero_Celsius=core_constants.zero_Celsius,
@@ -981,8 +979,8 @@ def solve_canopy_temperature_with_air_coupling(
         new_air_temperature = update_canopy_air_temperature(
             air_temperature=air_temperature,
             sensible_heat_flux=fluxes["sensible_heat_flux"],  # type: ignore
-            specific_heat_air=state["specific_heat_air"],
-            density_air=state["density_air"],
+            specific_heat_air=state_local["specific_heat_air"],
+            density_air=state_local["density_air"],
             mixing_layer_thickness=static["geometry"]["thickness"],
         )
 
@@ -995,22 +993,19 @@ def solve_canopy_temperature_with_air_coupling(
         if max(canopy_change, air_change) < air_temperature_tolerance:
             break
 
-    final_state = state.copy()
-    final_state["air_temperature"] = air_temperature
-
     final_fluxes = cast(
         dict[str, NDArray[np.floating]],
         calculate_energy_balance_residual(
             canopy_temperature_initial=canopy_temperature,
             air_temperature=air_temperature,
-            evapotranspiration=state["evapotranspiration"],
-            absorbed_shortwave_radiation=state["shortwave_absorption"],
+            evapotranspiration=state_local["evapotranspiration"],
+            absorbed_shortwave_radiation=state_local["shortwave_absorption"],
             absorbed_longwave_radiation=static["absorbed_longwave_radiation"],
-            longwave_emission_soil=state["longwave_emission"][idx.topsoil],
-            specific_heat_air=state["specific_heat_air"],
-            density_air=state["density_air"],
-            aerodynamic_resistance=state["aerodynamic_resistance_canopy"],
-            latent_heat_vapourisation=state["latent_heat_vapourisation"],
+            longwave_emission_soil=state_local["longwave_emission"][idx.topsoil],
+            specific_heat_air=state_local["specific_heat_air"],
+            density_air=state_local["density_air"],
+            aerodynamic_resistance=state_local["aerodynamic_resistance_canopy"],
+            latent_heat_vapourisation=state_local["latent_heat_vapourisation"],
             leaf_emissivity=abiotic_constants.leaf_emissivity,
             stefan_boltzmann_constant=core_constants.stefan_boltzmann_constant,
             zero_Celsius=core_constants.zero_Celsius,

--- a/virtual_ecosystem/models/abiotic/energy_balance.py
+++ b/virtual_ecosystem/models/abiotic/energy_balance.py
@@ -910,39 +910,52 @@ def solve_canopy_temperature_with_air_coupling(
     denominator_tolerance: float,
     idx: SimpleNamespace,
 ) -> tuple[
-    NDArray[np.floating], NDArray[np.floating], Any | dict[str, NDArray[np.floating]]
+    NDArray[np.floating],
+    NDArray[np.floating],
+    dict[str, NDArray[np.floating]],
 ]:
-    """Solve canopy temperature with air temperature coupling.
+    """Solve canopy temperature with iterative air temperature coupling.
+
+    The canopy temperature is solved with a secant method for fixed air temperature.
+    Air temperature is then updated from sensible heat flux, and the process is
+    repeated until both canopy and air temperatures converge.
 
     Args:
         state: Dictionary containing state variables needed for the energy balance
             residual.
         static: Dictionary containing static variables needed for the energy balance
-                residual.
+            residual.
         abiotic_constants: Constants related to abiotic processes.
         core_constants: Core constants.
-        maxiter_air: max number of iterations for air temperature update
-        air_temperature_tolerance: maximum allowed change in air temperature per
-            iteration, [C]
+        maxiter_air: Maximum number of outer iterations for air temperature coupling.
+        air_temperature_tolerance: Convergence tolerance on max absolute canopy/air
+            temperature change, [C].
         maxiter_secant: Maximum secant iterations.
-        convergence_tolerance: Convergence tolerance on max absolute update.
+        convergence_tolerance: Convergence tolerance on max absolute secant update.
         small_perturbation_second_guess: Small perturbation for second initial guess.
-        denominator_tolerance: Small value to prevent division by zero in secant update.
+        denominator_tolerance: Small value to prevent division by zero.
         idx: Namespace containing indices for different layers.
 
     Returns:
-        tuple of canopy temperature, air temperature, and final fluxes
+        Tuple of canopy temperature, air temperature, and final fluxes.
     """
 
+    # Local working state container
     state_local = state.copy()
-    air_temperature = state_local["air_temperature"]
-    canopy_temperature = state_local["canopy_temperature"]
+
+    # Solver-owned working arrays
+    air_temperature = state["air_temperature"].copy()
+    canopy_temperature = state["canopy_temperature"].copy()
 
     for _ in range(maxiter_air):
+        # Update local state seen by the canopy residual for this outer iteration
+        # state_local["air_temperature"] = air_temperature
+        # state_local["canopy_temperature"] = canopy_temperature
+
         residual_function = make_canopy_residual(
             state=state_local,
             static=static,
-            aerodynamic_resistance=state["aerodynamic_resistance_canopy"],
+            aerodynamic_resistance=state_local["aerodynamic_resistance_canopy"],
             abiotic_constants=abiotic_constants,
             core_constants=core_constants,
             idx=idx,
@@ -957,23 +970,26 @@ def solve_canopy_temperature_with_air_coupling(
             denominator_tolerance=denominator_tolerance,
         )
 
-        fluxes = calculate_energy_balance_residual(
-            canopy_temperature_initial=new_canopy_temperature,
-            air_temperature=air_temperature,
-            evapotranspiration=state_local["evapotranspiration"],
-            absorbed_shortwave_radiation=state_local["shortwave_absorption"],
-            absorbed_longwave_radiation=static["absorbed_longwave_radiation"],
-            longwave_emission_soil=state_local["longwave_emission"][idx.topsoil],
-            specific_heat_air=state_local["specific_heat_air"],
-            density_air=state_local["density_air"],
-            aerodynamic_resistance=state_local["aerodynamic_resistance_canopy"],
-            latent_heat_vapourisation=state_local["latent_heat_vapourisation"],
-            leaf_emissivity=abiotic_constants.leaf_emissivity,
-            stefan_boltzmann_constant=core_constants.stefan_boltzmann_constant,
-            zero_Celsius=core_constants.zero_Celsius,
-            seconds_to_hour=core_constants.seconds_to_hour,
-            return_fluxes=True,
-            idx=idx,
+        fluxes = cast(
+            dict[str, NDArray[np.floating]],
+            calculate_energy_balance_residual(
+                canopy_temperature_initial=new_canopy_temperature,
+                air_temperature=air_temperature,
+                evapotranspiration=state_local["evapotranspiration"],
+                absorbed_shortwave_radiation=state_local["shortwave_absorption"],
+                absorbed_longwave_radiation=static["absorbed_longwave_radiation"],
+                longwave_emission_soil=state_local["longwave_emission"][idx.topsoil],
+                specific_heat_air=state_local["specific_heat_air"],
+                density_air=state_local["density_air"],
+                aerodynamic_resistance=state_local["aerodynamic_resistance_canopy"],
+                latent_heat_vapourisation=state_local["latent_heat_vapourisation"],
+                leaf_emissivity=abiotic_constants.leaf_emissivity,
+                stefan_boltzmann_constant=core_constants.stefan_boltzmann_constant,
+                zero_Celsius=core_constants.zero_Celsius,
+                seconds_to_hour=core_constants.seconds_to_hour,
+                return_fluxes=True,
+                idx=idx,
+            ),
         )
 
         new_air_temperature = update_canopy_air_temperature(
@@ -993,6 +1009,7 @@ def solve_canopy_temperature_with_air_coupling(
         if max(canopy_change, air_change) < air_temperature_tolerance:
             break
 
+    # Final flux calculation at converged temperatures
     final_fluxes = cast(
         dict[str, NDArray[np.floating]],
         calculate_energy_balance_residual(

--- a/virtual_ecosystem/models/abiotic/energy_balance.py
+++ b/virtual_ecosystem/models/abiotic/energy_balance.py
@@ -45,7 +45,7 @@ unrealistic.
 
 from collections.abc import Callable
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 from numpy.typing import NDArray
@@ -330,16 +330,17 @@ def calculate_energy_balance_residual(
     evapotranspiration: NDArray[np.floating],
     absorbed_shortwave_radiation: NDArray[np.floating],
     absorbed_longwave_radiation: NDArray[np.floating],
+    longwave_emission_soil: NDArray[np.floating],
     specific_heat_air: NDArray[np.floating],
     density_air: NDArray[np.floating],
     aerodynamic_resistance: NDArray[np.floating],
     latent_heat_vapourisation: NDArray[np.floating],
-    surface_index: int,
     leaf_emissivity: float,
     stefan_boltzmann_constant: float,
     zero_Celsius: float,
     seconds_to_hour: float,
     return_fluxes: bool,
+    idx: SimpleNamespace,
 ) -> NDArray[np.floating] | dict[str, NDArray[np.floating]]:
     r"""Calculate energy balance residual for canopy.
 
@@ -362,11 +363,11 @@ def calculate_energy_balance_residual(
             layers, [W m-2]
         absorbed_longwave_radiation: Absorbed longwave radiation for all canopy layers,
             [W m-2]
+        longwave_emission_soil: Longwave emission from topsoil, [W m-2]
         specific_heat_air: Specific heat capacity of air, [J kg-1 K-1]
         density_air: Density of air, [kg m-3]
         aerodynamic_resistance: Aerodynamic resistance of canopy, [s m-1]
         latent_heat_vapourisation: Latent heat of vapourisation, [J kg-1]
-        surface_index: Row index of surface layer
         leaf_emissivity: Leaf emissivity, dimensionless
         stefan_boltzmann_constant: Stefan Boltzmann constant, [W m-2 K-4]
         zero_Celsius: Factor to convert between Celsius and Kelvin
@@ -374,6 +375,7 @@ def calculate_energy_balance_residual(
         return_fluxes: Flag to indicate if all components of the energy balance should
             be returned. This is false for the newton approach to solve for canopy
             temperature, but true to create the outputs in a second call afterwards.
+        idx: Namespace containing indices for different layers.
 
     Returns:
         full energy balance or energy balance residual, [W m-2]
@@ -419,7 +421,8 @@ def calculate_energy_balance_residual(
         - latent_heat_flux_canopy
     )
     # Add longwave_emission from surface to net radiation and energy balance residual
-    energy_balance_residual[1] += 0.5 * longwave_emission_canopy[surface_index]
+    net_radiation[idx.surface] += 0.5 * longwave_emission_soil
+    energy_balance_residual[idx.surface] += 0.5 * longwave_emission_soil
 
     if return_fluxes:
         energy_balance = {
@@ -852,7 +855,7 @@ def make_canopy_residual(
     aerodynamic_resistance: NDArray[np.floating],
     abiotic_constants: AbioticConstants,
     core_constants: CoreConstants,
-    surface_index: int,
+    idx: SimpleNamespace,
 ) -> Callable[[NDArray[np.floating]], NDArray[np.floating]]:
     """Creates a residual function for canopy temperature to be used in root finding.
 
@@ -864,7 +867,7 @@ def make_canopy_residual(
         aerodynamic_resistance: Aerodynamic resistance of canopy, [s m-1]
         abiotic_constants: Constants related to abiotic processes.
         core_constants: Core constants.
-        surface_index: Row index of surface layer.
+        idx: Namespace containing indices for different layers.
 
     Returns:
         A function that takes canopy_temperature as input and returns the energy balance
@@ -878,16 +881,143 @@ def make_canopy_residual(
             evapotranspiration=state["evapotranspiration"],
             absorbed_shortwave_radiation=state["shortwave_absorption"],
             absorbed_longwave_radiation=static["absorbed_longwave_radiation"],
+            longwave_emission_soil=state["longwave_emission"][idx.topsoil],
             specific_heat_air=state["specific_heat_air"],
             density_air=state["density_air"],
             aerodynamic_resistance=aerodynamic_resistance,
             latent_heat_vapourisation=state["latent_heat_vapourisation"],
-            surface_index=surface_index,
             leaf_emissivity=abiotic_constants.leaf_emissivity,
             stefan_boltzmann_constant=core_constants.stefan_boltzmann_constant,
             zero_Celsius=core_constants.zero_Celsius,
             seconds_to_hour=core_constants.seconds_to_hour,
             return_fluxes=False,
+            idx=idx,
         )
 
     return residual
+
+
+def solve_canopy_temperature_with_air_coupling(
+    state: dict[str, Any],
+    static: dict[str, Any],
+    abiotic_constants: AbioticConstants,
+    core_constants: CoreConstants,
+    maxiter_air: int,
+    air_temperature_tolerance: float,
+    maxiter_secant: int,
+    convergence_tolerance: float,
+    small_perturbation_second_guess: float,
+    denominator_tolerance: float,
+    idx: SimpleNamespace,
+) -> tuple[
+    NDArray[np.floating], NDArray[np.floating], Any | dict[str, NDArray[np.floating]]
+]:
+    """Solve canopy temperature with air temperature coupling.
+
+    Args:
+        state: Dictionary containing state variables needed for the energy balance
+            residual.
+        static: Dictionary containing static variables needed for the energy balance
+                residual.
+        abiotic_constants: Constants related to abiotic processes.
+        core_constants: Core constants.
+        maxiter_air: max number of iterations for air temperature update
+        air_temperature_tolerance: maximum allowed change in air temperature per
+            iteration, [C]
+        maxiter_secant: Maximum secant iterations.
+        convergence_tolerance: Convergence tolerance on max absolute update.
+        small_perturbation_second_guess: Small perturbation for second initial guess.
+        denominator_tolerance: Small value to prevent division by zero in secant update.
+        idx: Namespace containing indices for different layers.
+
+    Returns:
+        tuple of canopy temperature, air temperature, and final fluxes
+    """
+
+    canopy_temperature = state["canopy_temperature"].copy()
+    air_temperature = state["air_temperature"].copy()
+
+    for _ in range(maxiter_air):
+        state_local = state.copy()
+        state_local["air_temperature"] = air_temperature
+
+        residual_function = make_canopy_residual(
+            state=state_local,
+            static=static,
+            aerodynamic_resistance=state["aerodynamic_resistance_canopy"],
+            abiotic_constants=abiotic_constants,
+            core_constants=core_constants,
+            idx=idx,
+        )
+
+        new_canopy_temperature = secant_solve_cells_layers(
+            residual_function=residual_function,
+            initial_guess=canopy_temperature,
+            maxiter_secant=maxiter_secant,
+            convergence_tolerance=convergence_tolerance,
+            small_perturbation_second_guess=small_perturbation_second_guess,
+            denominator_tolerance=denominator_tolerance,
+        )
+
+        fluxes = calculate_energy_balance_residual(
+            canopy_temperature_initial=new_canopy_temperature,
+            air_temperature=air_temperature,
+            evapotranspiration=state["evapotranspiration"],
+            absorbed_shortwave_radiation=state["shortwave_absorption"],
+            absorbed_longwave_radiation=static["absorbed_longwave_radiation"],
+            longwave_emission_soil=state["longwave_emission"][idx.topsoil],
+            specific_heat_air=state["specific_heat_air"],
+            density_air=state["density_air"],
+            aerodynamic_resistance=state["aerodynamic_resistance_canopy"],
+            latent_heat_vapourisation=state["latent_heat_vapourisation"],
+            leaf_emissivity=abiotic_constants.leaf_emissivity,
+            stefan_boltzmann_constant=core_constants.stefan_boltzmann_constant,
+            zero_Celsius=core_constants.zero_Celsius,
+            seconds_to_hour=core_constants.seconds_to_hour,
+            return_fluxes=True,
+            idx=idx,
+        )
+
+        new_air_temperature = update_canopy_air_temperature(
+            air_temperature=air_temperature,
+            sensible_heat_flux=fluxes["sensible_heat_flux"],  # type: ignore
+            specific_heat_air=state["specific_heat_air"],
+            density_air=state["density_air"],
+            mixing_layer_thickness=static["geometry"]["thickness"],
+        )
+
+        canopy_change = np.nanmax(np.abs(new_canopy_temperature - canopy_temperature))
+        air_change = np.nanmax(np.abs(new_air_temperature - air_temperature))
+
+        canopy_temperature = new_canopy_temperature
+        air_temperature = new_air_temperature
+
+        if max(canopy_change, air_change) < air_temperature_tolerance:
+            break
+
+    final_state = state.copy()
+    final_state["air_temperature"] = air_temperature
+
+    final_fluxes = cast(
+        dict[str, NDArray[np.floating]],
+        calculate_energy_balance_residual(
+            canopy_temperature_initial=canopy_temperature,
+            air_temperature=air_temperature,
+            evapotranspiration=state["evapotranspiration"],
+            absorbed_shortwave_radiation=state["shortwave_absorption"],
+            absorbed_longwave_radiation=static["absorbed_longwave_radiation"],
+            longwave_emission_soil=state["longwave_emission"][idx.topsoil],
+            specific_heat_air=state["specific_heat_air"],
+            density_air=state["density_air"],
+            aerodynamic_resistance=state["aerodynamic_resistance_canopy"],
+            latent_heat_vapourisation=state["latent_heat_vapourisation"],
+            leaf_emissivity=abiotic_constants.leaf_emissivity,
+            stefan_boltzmann_constant=core_constants.stefan_boltzmann_constant,
+            zero_Celsius=core_constants.zero_Celsius,
+            seconds_to_hour=core_constants.seconds_to_hour,
+            return_fluxes=True,
+            idx=idx,
+        ),
+    )
+
+    return canopy_temperature, air_temperature, final_fluxes

--- a/virtual_ecosystem/models/abiotic/energy_balance.py
+++ b/virtual_ecosystem/models/abiotic/energy_balance.py
@@ -948,10 +948,6 @@ def solve_canopy_temperature_with_air_coupling(
     canopy_temperature = state["canopy_temperature"].copy()
 
     for _ in range(maxiter_air):
-        # Update local state seen by the canopy residual for this outer iteration
-        # state_local["air_temperature"] = air_temperature
-        # state_local["canopy_temperature"] = canopy_temperature
-
         residual_function = make_canopy_residual(
             state=state_local,
             static=static,

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -310,6 +310,7 @@ def initialize_state(
         "soil_temperature": data["soil_temperature"].to_numpy(),
         "relative_humidity": data["relative_humidity"].to_numpy(),
         "aerodynamic_resistance_soil": data["aerodynamic_resistance_soil"].to_numpy(),
+        "longwave_emission": data["longwave_emission"].to_numpy(),
     }
 
 
@@ -532,7 +533,7 @@ def calculate_vegetation_temperature(
         aerodynamic_resistance=aerodynamic_resistance_2d,
         abiotic_constants=abiotic_constants,
         core_constants=core_constants,
-        surface_index=idx.surface,
+        idx=idx,
     )
 
     # Result contains new canopy and understorey temperature
@@ -592,16 +593,17 @@ def calculate_vegetation_fluxes(
         evapotranspiration=state["evapotranspiration"],
         absorbed_shortwave_radiation=state["shortwave_absorption"],
         absorbed_longwave_radiation=static["absorbed_longwave_radiation"],
+        longwave_emission_soil=state["longwave_emission"][idx.topsoil],
         leaf_emissivity=abiotic_constants.leaf_emissivity,
         specific_heat_air=state["specific_heat_air"],
         density_air=state["density_air"],
         aerodynamic_resistance=aerodynamic_resistance_2d,
         latent_heat_vapourisation=state["latent_heat_vapourisation"],
-        surface_index=idx.surface,
         stefan_boltzmann_constant=core_constants.stefan_boltzmann_constant,
         zero_Celsius=core_constants.zero_Celsius,
         seconds_to_hour=core_constants.seconds_to_hour,
         return_fluxes=True,
+        idx=idx,
     )
 
     return fluxes  # type: ignore
@@ -902,24 +904,27 @@ def run_hour_step(
     )
     state.update(thermo)
 
-    # Update vegetation temperature
-    canopy_temperature = calculate_vegetation_temperature(
-        state=state,
-        static=static,
-        abiotic_constants=abiotic_constants,
-        core_constants=core_constants,
-        idx=idx,
+    # Update air temperature, canopy temperature, and fluxes
+    canopy_temperature, air_temperature, canopy_fluxes = (
+        energy_balance.solve_canopy_temperature_with_air_coupling(
+            state=state,
+            static=static,
+            abiotic_constants=abiotic_constants,
+            core_constants=core_constants,
+            maxiter_air=abiotic_constants.maxiter_secant_solver,
+            air_temperature_tolerance=5,
+            maxiter_secant=abiotic_constants.maxiter_secant_solver,
+            convergence_tolerance=abiotic_constants.convergence_tolerance_secant_solver,
+            small_perturbation_second_guess=(
+                abiotic_constants.small_perturbation_second_guess_secant_solver
+            ),
+            denominator_tolerance=abiotic_constants.denominator_tolerance,
+            idx=idx,
+        )
     )
-    state["canopy_temperature"] = canopy_temperature
 
-    # Calculate vegetation fluxes
-    canopy_fluxes = calculate_vegetation_fluxes(
-        state=state,
-        static=static,
-        abiotic_constants=abiotic_constants,
-        core_constants=core_constants,
-        idx=idx,
-    )
+    state["canopy_temperature"] = canopy_temperature
+    state["air_temperature"] = air_temperature
     state.update(canopy_fluxes)
 
     # Calculate soil fluxes
@@ -948,17 +953,6 @@ def run_hour_step(
         time_interval=core_constants.seconds_to_hour,
     )
     state["soil_temperature"][idx.soil] = soil_temperature
-
-    # Update air temperature
-    air_temperature = update_air_temperature(
-        state=state,
-        static=static,
-        abiotic_bounds=abiotic_bounds,
-        idx=idx,
-        denominator_tolerance=abiotic_constants.denominator_tolerance,
-        min_leaf_area_index_for_mixing=abiotic_constants.min_leaf_area_index_for_mixing,
-    )
-    state["air_temperature"] = air_temperature
 
     # Update atmospheric humidity
     air_humidity = update_atmospheric_humidity(


### PR DESCRIPTION
This PR integrates the update of air temperature in the secant method for canopy temperature which is running until both canopy and air temperatures converge.

I also replaced some random tests with existing fixtures.

Fixes #1531 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] TODO Relevant documentation reviewed and updated (separate issue #1742)
