### PR TITLE
Fix warnings in `BiomassTissueABC.Cx_ratio`

### DIFF
--- a/virtual_ecosystem/models/plants/biomasses.py
+++ b/virtual_ecosystem/models/plants/biomasses.py
@@ -229,9 +229,8 @@ class BiomassTissueABC(ABC):
     def Cx_ratio(self) -> dict[str, NDArray[np.floating]]:
         """Get the carbon to element ratio for the tissue type.
 
-        This has to handle cases where a tissue has no biomass at all or no actual
-        elemental mass, which would otherwise generate NaN ratios (C/0). It explicitly
-        sets these cases to infinity.
+        If there is no elemental mass (and possible also no carbon mass) for any
+        cohorts in the tissue then the function return ``np.inf`` for those values.
 
         Returns:
             The carbon to element ratio for the specified tissue.
@@ -239,10 +238,12 @@ class BiomassTissueABC(ABC):
         ratios = {}
 
         for ky, elem in self.element_masses.items():
-            ratios[ky] = np.where(
-                elem.actual_element_mass == 0,
-                np.inf,
-                self.carbon_mass / elem.actual_element_mass,
+            # Use np.divide and where here to avoid triggering warnings on zero divides
+            ratios[ky] = np.divide(
+                self.carbon_mass,
+                elem.actual_element_mass,
+                where=elem.actual_element_mass > 0,
+                out=np.full_like(self.carbon_mass, np.inf),
             )
 
         return ratios


### PR DESCRIPTION
# Description

This swaps out the numpy handling of calculating Cx ratios to a form that doesn't generate warnings when handling zero divides. The previous code handled the case but was gobby about it, because it had to evaluate the zero divides even though they were not passed on

Fixes #1753

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
