### PR TITLE
Fixes zero nutrient edge case

### DIFF
--- a/virtual_ecosystem/models/plants/biomasses.py
+++ b/virtual_ecosystem/models/plants/biomasses.py
@@ -710,6 +710,7 @@ class StemBiomass(BiomassTissueABC):
                 actual_element_mass=carbon_mass / ideal_ratio,
                 turnover_ratio=turnover_ratio,
             )
+            pass
 
         return cls(
             carbon_mass=carbon_mass,
@@ -1083,8 +1084,18 @@ class Biomasses(ToDataFrameMixin):
 
         # Calculate the redistribution of pool deficits (negative values) to tissues
         # weighted by the relative elemental mass for each tissue.
-        pool_deficits_to_tissues = stem_pools * (
-            tissue_element_masses / tissue_element_masses.sum(axis=0)
+        #
+        # This needs to guard against the pathological case where there is _none_ of the
+        # element in any of the tissues for a cohort (which leads to divide by zero and
+        # hence np.nan/np.inf). Values in this case are forced as zero - they can't have
+        # more of that element removed since they have none.
+
+        tissue_total_element_masses = tissue_element_masses.sum(axis=0)
+        pool_deficits_to_tissues = stem_pools * np.divide(
+            tissue_element_masses,
+            tissue_total_element_masses,
+            out=np.zeros_like(tissue_element_masses),
+            where=tissue_total_element_masses > 0,
         )
 
         # Calculate the redistribution of pool surpluses (positive values) to tissues

--- a/virtual_ecosystem/models/plants/biomasses.py
+++ b/virtual_ecosystem/models/plants/biomasses.py
@@ -710,7 +710,6 @@ class StemBiomass(BiomassTissueABC):
                 actual_element_mass=carbon_mass / ideal_ratio,
                 turnover_ratio=turnover_ratio,
             )
-            pass
 
         return cls(
             carbon_mass=carbon_mass,


### PR DESCRIPTION
# Description

This PR just replaces a np.array division with safer version using `np.divide` to catch divide by zero when trying to estimate the relative masses of an array of zero values. The change stops `np.nan` values appearing in plant biomass elemental masses and the zero value assignment prevents tissues with no elemental mass being further depleted (to negative masses!) to balance nutrient deficits.

Fixes #1757

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
