### PR TITLE
Squash warnings

### DIFF
--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -2,6 +2,7 @@
 balance in the Virtual Ecosystem.
 """  # noqa: D205
 
+import warnings
 from types import SimpleNamespace
 from typing import Any
 
@@ -1019,12 +1020,18 @@ def build_output_from_record(
                 soil = data_record["soil_temperature"]
 
                 combined = np.stack([air, soil], axis=0)
-                min_value = np.nanmin(combined, axis=(0, 1))
-                max_value = np.nanmax(combined, axis=(0, 1))
+
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", "All-NaN slice encountered")
+                    min_value = np.nanmin(combined, axis=(0, 1))
+                    max_value = np.nanmax(combined, axis=(0, 1))
+
                 values_out = max_value - min_value
 
             else:
-                values_out = np.nanmean(values_arr, axis=0)
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", "Mean of empty slice")
+                    values_out = np.nanmean(values_arr, axis=0)
 
         # assign dims
         if values_out.ndim == 1:

--- a/virtual_ecosystem/models/plants/plants_model.py
+++ b/virtual_ecosystem/models/plants/plants_model.py
@@ -1392,14 +1392,14 @@ class PlantsModel(
                 # calculating the cohort share (using cohort_fractions) and then
                 # dividing by the number of individuals per cohort. Handle case where
                 # there are no individuals in the cohort, by assigning them zero.
-                cohort_fractions = cohorts["n_individuals"].to_numpy() / sum(
-                    cohorts["n_individuals"].to_numpy()
-                )
+                n_individuals = cohorts["n_individuals"].to_numpy()
+                cohort_fractions = n_individuals / sum(n_individuals)
+
                 symbiote_nutrients[element] = np.divide(
                     total_supply * cohort_fractions,
-                    cohorts["n_individuals"].to_numpy(),
+                    n_individuals,
                     out=np.zeros_like(cohort_fractions),
-                    where=cohorts["n_individuals"] != 0,
+                    where=n_individuals > 0,
                 )
 
             biomasses._adjust_surpluses(symbiote_nutrients)


### PR DESCRIPTION
# Description

This PR squashes warnings from two sources:

* Unintended use of a `pd.Series` within `np.divide` in plants model lead to a division warning from `pandas`. Proper conversion to `numpy` removes the warning.
* The `abiotic` model exports some `nanmean` outputs that generate warnings. These are expected (empty rows in layers) so explicitly muting them with `warnings.filterwarnings` is appropriate.

With these changes, `maliau_2` runs cleanly without screen garbage (for the moment 😄 )

Fixes #1767

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
